### PR TITLE
Fixed a boost-related crash

### DIFF
--- a/src/deployer.cc
+++ b/src/deployer.cc
@@ -106,6 +106,8 @@ bool Deployer::IsMaintenancing() {
 }
 
 void Deployer::JoinMaintenanceThread() {
+  if (!maintenance_thread_.joinable())
+    return;
   maintenance_thread_.join();
 }
 


### PR DESCRIPTION
# Fixed a boost-related crash

In _rime::Deployer::JoinMaintenanceThread()_, the call to _boost::thread::join()_ may cause application to crash if the thread is not joinable (i.e. not-a-thread, or thread terminated).

However, it seems that this situtaion only occur with the recent version of boost (without C++11, with multithread, with _BOOST_THREAD_TRROW_IF_PRECONDITION_NOT_SATISFIED_ macro defined by default).
# Demonstration

Compiling the following codes with _clang++ -lboost_system-mt -lboost_thread-mt_, and the latest _boost 1.52.0_ installed with Homebrew (all default configurations). Then run the executable. The second call to _boost::thread::join()_ with throw an uncaught exception and therefore lead to crash, since the thread is already terminated at that time.

It seems that neither librime nor Squirrel has done any exception handling. In my own experience, Squirrel compiled by myself always crashes at _RimeFinalize()_ due to this reason.

``` c++
#include <iostream>
#include <boost/thread.hpp>

static void test()
{
    std::cout << "test" << std::endl;
}

int main(int argc, char const *argv[])
{
    boost::thread thread(test);
    thread.join();
    thread.join();
    return 0;
}
```
