### PR TITLE
Need to build thirdparty libs before build librime

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Runtime dependencies
 Build and install librime on Linux
 ---
 ```
+make -f Makefile.thirdparty
 make
 sudo make install
 ```
@@ -106,4 +107,3 @@ Contributors
   - [Zhiwei Liu](https://github.com/liuzhiwei)
   - [BYVoid](http://www.byvoid.com)
   - [雪齋](https://github.com/LEOYoon-Tsaw)
-


### PR DESCRIPTION
Just to let you know, in my machine, I need to first build the third party libs and then try to build librime. Seems it can't compile with the system libs (Ubuntu) especially OpenCC. 
