### PR TITLE
add other SIP Characters into charset_filter

### DIFF
--- a/src/gear/charset_filter.cc
+++ b/src/gear/charset_filter.cc
@@ -21,7 +21,8 @@ bool is_extended_cjk(uint32_t ch)
       (ch >= 0x20000 && ch <= 0x2A6DF) ||  // CJK Unified Ideographs Extension B
       (ch >= 0x2A700 && ch <= 0x2B73F) ||  // CJK Unified Ideographs Extension C
       (ch >= 0x2B740 && ch <= 0x2B81F) ||  // CJK Unified Ideographs Extension D
-      (ch >= 0x2B820 && ch <= 0x2CEAF))    // CJK Unified Ideographs Extension E
+      (ch >= 0x2B820 && ch <= 0x2CEAF) ||  // CJK Unified Ideographs Extension E
+      (ch >= 0x2F800 && ch <= 0x2FA1F))    // CJK Compatibility Ideographs Supplement
     return true;
 
   return false;


### PR DESCRIPTION
according to http://unicode.org/roadmaps/sip/, CJK Compatibility Ideographs Supplement(0002F800-0002FA1F) was also included in Plane 2.