### PR TITLE
Shorthand

### DIFF
--- a/include/rime/algo/algebra.h
+++ b/include/rime/algo/algebra.h
@@ -28,7 +28,7 @@ class Script : public map<string, vector<Spelling>> {
 
 class Projection {
  public:
-  bool Load(a<ConfigList> settings);
+  bool Load(an<ConfigList> settings);
   // "spelling" -> "gnilleps"
   bool Apply(string* value);
   // {z, y, x} -> {a, b, c, d}

--- a/include/rime/algo/algebra.h
+++ b/include/rime/algo/algebra.h
@@ -8,9 +8,6 @@
 #ifndef RIME_ALGEBRA_H_
 #define RIME_ALGEBRA_H_
 
-#include <map>
-#include <string>
-#include <vector>
 #include <rime/common.h>
 #include <rime/config.h>
 #include "spelling.h"
@@ -20,24 +17,24 @@ namespace rime {
 class Calculation;
 class Schema;
 
-class Script : public std::map<std::string, std::vector<Spelling>> {
+class Script : public map<string, vector<Spelling>> {
  public:
-  bool AddSyllable(const std::string& syllable);
-  void Merge(const std::string& s,
+  bool AddSyllable(const string& syllable);
+  void Merge(const string& s,
              const SpellingProperties& sp,
-             const std::vector<Spelling>& v);
-  void Dump(const std::string& file_name) const;
+             const vector<Spelling>& v);
+  void Dump(const string& file_name) const;
 };
 
 class Projection {
  public:
   bool Load(ConfigListPtr settings);
   // "spelling" -> "gnilleps"
-  bool Apply(std::string* value);
+  bool Apply(string* value);
   // {z, y, x} -> {a, b, c, d}
   bool Apply(Script* value);
  protected:
-  std::vector<shared_ptr<Calculation>> calculation_;
+  vector<a<Calculation>> calculation_;
 };
 
 }  // namespace rime

--- a/include/rime/algo/algebra.h
+++ b/include/rime/algo/algebra.h
@@ -28,7 +28,7 @@ class Script : public map<string, vector<Spelling>> {
 
 class Projection {
  public:
-  bool Load(ConfigListPtr settings);
+  bool Load(a<ConfigList> settings);
   // "spelling" -> "gnilleps"
   bool Apply(string* value);
   // {z, y, x} -> {a, b, c, d}

--- a/include/rime/algo/algebra.h
+++ b/include/rime/algo/algebra.h
@@ -34,7 +34,7 @@ class Projection {
   // {z, y, x} -> {a, b, c, d}
   bool Apply(Script* value);
  protected:
-  vector<a<Calculation>> calculation_;
+  vector<of<Calculation>> calculation_;
 };
 
 }  // namespace rime

--- a/include/rime/algo/calculus.h
+++ b/include/rime/algo/calculus.h
@@ -8,18 +8,16 @@
 #ifndef RIME_CALCULUS_H_
 #define RIME_CALCULUS_H_
 
-#include <map>
-#include <string>
-#include <vector>
 #include <stdint.h>
 #include <boost/regex.hpp>
+#include <rime/common.h>
 #include "spelling.h"
 
 namespace rime {
 
 class Calculation {
  public:
-  using Factory = Calculation* (const std::vector<std::string>& args);
+  using Factory = Calculation* (const vector<string>& args);
 
   Calculation() = default;
   virtual ~Calculation() = default;
@@ -31,11 +29,11 @@ class Calculation {
 class Calculus {
  public:
   Calculus();
-  void Register(const std::string& token, Calculation::Factory* factory);
-  Calculation* Parse(const std::string& defintion);
+  void Register(const string& token, Calculation::Factory* factory);
+  Calculation* Parse(const string& defintion);
 
  private:
-  std::map<std::string, Calculation::Factory*> factories_;
+  map<string, Calculation::Factory*> factories_;
 };
 
 // xlit/zyx/abc/
@@ -45,7 +43,7 @@ class Transliteration : public Calculation {
   bool Apply(Spelling* spelling);
 
  protected:
-  std::map<uint32_t, uint32_t> char_map_;
+  map<uint32_t, uint32_t> char_map_;
 };
 
 // xform/x/y/
@@ -56,7 +54,7 @@ class Transformation : public Calculation {
 
  protected:
   boost::regex pattern_;
-  std::string replacement_;
+  string replacement_;
 };
 
 // erase/x/

--- a/include/rime/algo/encoder.h
+++ b/include/rime/algo/encoder.h
@@ -8,17 +8,14 @@
 #ifndef RIME_ENCODER_H_
 #define RIME_ENCODER_H_
 
-#include <set>
-#include <string>
-#include <vector>
 #include <boost/regex.hpp>
 
 namespace rime {
 
-class RawCode : public std::vector<std::string> {
+class RawCode : public vector<string> {
  public:
-  std::string ToString() const;
-  void FromString(const std::string &code_str);
+  string ToString() const;
+  void FromString(const string &code_str);
 };
 
 class PhraseCollector {
@@ -26,12 +23,12 @@ class PhraseCollector {
   PhraseCollector() = default;
   virtual ~PhraseCollector() = default;
 
-  virtual void CreateEntry(const std::string& phrase,
-                           const std::string& code_str,
-                           const std::string& value) = 0;
+  virtual void CreateEntry(const string& phrase,
+                           const string& code_str,
+                           const string& value) = 0;
   // return a list of alternative code for the given word
-  virtual bool TranslateWord(const std::string& word,
-                             std::vector<std::string>* code) = 0;
+  virtual bool TranslateWord(const string& word,
+                             vector<string>* code) = 0;
 };
 
 class Config;
@@ -45,8 +42,8 @@ class Encoder {
     return false;
   }
 
-  virtual bool EncodePhrase(const std::string& phrase,
-                            const std::string& value) = 0;
+  virtual bool EncodePhrase(const string& phrase,
+                            const string& value) = 0;
 
   void set_collector(PhraseCollector* collector) { collector_ = collector; }
 
@@ -65,7 +62,7 @@ struct CodeCoords {
 struct TableEncodingRule {
   int min_word_length;
   int max_word_length;
-  std::vector<CodeCoords> coords;
+  vector<CodeCoords> coords;
 };
 
 // for rule-based phrase encoding
@@ -75,28 +72,28 @@ class TableEncoder : public Encoder {
 
   bool LoadSettings(Config* config);
 
-  bool Encode(const RawCode& code, std::string* result);
-  bool EncodePhrase(const std::string& phrase, const std::string& value);
+  bool Encode(const RawCode& code, string* result);
+  bool EncodePhrase(const string& phrase, const string& value);
 
-  bool IsCodeExcluded(const std::string& code);
+  bool IsCodeExcluded(const string& code);
 
   bool loaded() const { return loaded_; }
-  const std::vector<TableEncodingRule>& encoding_rules() const {
+  const vector<TableEncodingRule>& encoding_rules() const {
     return encoding_rules_;
   }
-  const std::string& tail_anchor() const { return tail_anchor_; }
+  const string& tail_anchor() const { return tail_anchor_; }
 
  protected:
-  bool ParseFormula(const std::string& formula, TableEncodingRule* rule);
-  int CalculateCodeIndex(const std::string& code, int index, int start);
-  bool DfsEncode(const std::string& phrase, const std::string& value,
+  bool ParseFormula(const string& formula, TableEncodingRule* rule);
+  int CalculateCodeIndex(const string& code, int index, int start);
+  bool DfsEncode(const string& phrase, const string& value,
                  size_t start_pos, RawCode* code, int* limit);
 
   bool loaded_;
   // settings
-  std::vector<TableEncodingRule> encoding_rules_;
-  std::vector<boost::regex> exclude_patterns_;
-  std::string tail_anchor_;
+  vector<TableEncodingRule> encoding_rules_;
+  vector<boost::regex> exclude_patterns_;
+  string tail_anchor_;
   // for optimization
   int max_phrase_length_;
 };
@@ -106,10 +103,10 @@ class ScriptEncoder : public Encoder {
  public:
   ScriptEncoder(PhraseCollector* collector);
 
-  bool EncodePhrase(const std::string& phrase, const std::string& value);
+  bool EncodePhrase(const string& phrase, const string& value);
 
  private:
-  bool DfsEncode(const std::string& phrase, const std::string& value,
+  bool DfsEncode(const string& phrase, const string& value,
                  size_t start_pos, RawCode* code, int* limit);
 };
 

--- a/include/rime/algo/spelling.h
+++ b/include/rime/algo/spelling.h
@@ -8,7 +8,7 @@
 #ifndef RIME_SPELLING_H_
 #define RIME_SPELLING_H_
 
-#include <string>
+#include <rime/common.h>
 
 namespace rime {
 
@@ -20,15 +20,15 @@ struct SpellingProperties {
   SpellingType type = kNormalSpelling;
   size_t end_pos = 0;
   double credibility = 1.0;
-  std::string tips;
+  string tips;
 };
 
 struct Spelling {
-  std::string str;
+  string str;
   SpellingProperties properties;
 
   Spelling() = default;
-  Spelling(const std::string& _str) : str(_str) {}
+  Spelling(const string& _str) : str(_str) {}
 
   bool operator== (const Spelling& other) { return str == other.str; }
   bool operator< (const Spelling& other) { return str < other.str; }

--- a/include/rime/algo/syllabifier.h
+++ b/include/rime/algo/syllabifier.h
@@ -9,9 +9,6 @@
 #define RIME_SYLLABIFIER_H_
 
 #include <stdint.h>
-#include <map>
-#include <string>
-#include <vector>
 #include "spelling.h"
 
 namespace rime {
@@ -20,14 +17,14 @@ class Prism;
 
 using SyllableId = int32_t;
 
-using SpellingMap = std::map<SyllableId, SpellingProperties>;
-using VertexMap = std::map<size_t, SpellingType>;
-using EndVertexMap = std::map<size_t, SpellingMap>;
-using EdgeMap = std::map<size_t, EndVertexMap>;
+using SpellingMap = map<SyllableId, SpellingProperties>;
+using VertexMap = map<size_t, SpellingType>;
+using EndVertexMap = map<size_t, SpellingMap>;
+using EdgeMap = map<size_t, EndVertexMap>;
 
-using SpellingPropertiesList = std::vector<const SpellingProperties*>;
-using SpellingIndex = std::map<SyllableId, SpellingPropertiesList>;
-using SpellingIndices = std::map<size_t, SpellingIndex>;
+using SpellingPropertiesList = vector<const SpellingProperties*>;
+using SpellingIndex = map<SyllableId, SpellingPropertiesList>;
+using SpellingIndices = map<size_t, SpellingIndex>;
 
 struct SyllableGraph {
   size_t input_length = 0;
@@ -40,7 +37,7 @@ struct SyllableGraph {
 class Syllabifier {
  public:
   Syllabifier() = default;
-  explicit Syllabifier(const std::string &delimiters,
+  explicit Syllabifier(const string &delimiters,
                        bool enable_completion = false,
                        bool strict_spelling = false)
       : delimiters_(delimiters),
@@ -48,7 +45,7 @@ class Syllabifier {
         strict_spelling_(strict_spelling) {
   }
 
-  int BuildSyllableGraph(const std::string &input,
+  int BuildSyllableGraph(const string &input,
                          Prism &prism,
                          SyllableGraph *graph);
 
@@ -57,7 +54,7 @@ class Syllabifier {
                                 size_t start, size_t end);
   void Transpose(SyllableGraph* graph);
 
-  std::string delimiters_;
+  string delimiters_;
   bool enable_completion_ = false;
   bool strict_spelling_ = false;
 };

--- a/include/rime/algo/utilities.h
+++ b/include/rime/algo/utilities.h
@@ -8,24 +8,24 @@
 #define RIME_UTILITIES_H_
 
 #include <stdint.h>
-#include <string>
 #include <boost/crc.hpp>
+#include <rime/common.h>
 
 namespace rime {
 
-int CompareVersionString(const std::string& x,
-                         const std::string& y);
+int CompareVersionString(const string& x,
+                         const string& y);
 
 class ChecksumComputer {
  public:
-  void ProcessFile(const std::string& file_name);
+  void ProcessFile(const string& file_name);
   uint32_t Checksum();
 
  private:
   boost::crc_32_type crc_;
 };
 
-inline uint32_t Checksum(const std::string& file_name) {
+inline uint32_t Checksum(const string& file_name) {
   ChecksumComputer c;
   c.ProcessFile(file_name);
   return c.Checksum();

--- a/include/rime/candidate.h
+++ b/include/rime/candidate.h
@@ -21,10 +21,10 @@ class Candidate {
       : type_(type), start_(start), end_(end), quality_(quality) {}
   virtual ~Candidate() = default;
 
-  static a<Candidate>
-  GetGenuineCandidate(const a<Candidate>& cand);
+  static an<Candidate>
+  GetGenuineCandidate(const an<Candidate>& cand);
   static vector<of<Candidate>>
-  GetGenuineCandidates(const a<Candidate>& cand);
+  GetGenuineCandidates(const an<Candidate>& cand);
 
   // recognized by translators in learning phase
   const string& type() const { return type_; }
@@ -85,7 +85,7 @@ class SimpleCandidate : public Candidate {
 
 class ShadowCandidate : public Candidate {
  public:
-  ShadowCandidate(const a<Candidate>& item,
+  ShadowCandidate(const an<Candidate>& item,
                   const string& type,
                   const string& text = string(),
                   const string& comment = string())
@@ -103,17 +103,17 @@ class ShadowCandidate : public Candidate {
     return item_->preedit();
   }
 
-  const a<Candidate>& item() const { return item_; }
+  const an<Candidate>& item() const { return item_; }
 
  protected:
   string text_;
   string comment_;
-  a<Candidate> item_;
+  an<Candidate> item_;
 };
 
 class UniquifiedCandidate : public Candidate {
  public:
-  UniquifiedCandidate(const a<Candidate>& item,
+  UniquifiedCandidate(const an<Candidate>& item,
                       const string& type,
                       const string& text = string(),
                       const string& comment = string())
@@ -134,7 +134,7 @@ class UniquifiedCandidate : public Candidate {
     return !items_.empty() ? items_.front()->preedit() : string();
   }
 
-  void Append(a<Candidate> item) {
+  void Append(an<Candidate> item) {
     items_.push_back(item);
     if (quality() < item->quality())
       set_quality(item->quality());

--- a/include/rime/candidate.h
+++ b/include/rime/candidate.h
@@ -23,7 +23,7 @@ class Candidate {
 
   static a<Candidate>
   GetGenuineCandidate(const a<Candidate>& cand);
-  static vector<a<Candidate>>
+  static vector<of<Candidate>>
   GetGenuineCandidates(const a<Candidate>& cand);
 
   // recognized by translators in learning phase
@@ -52,8 +52,8 @@ class Candidate {
   double quality_ = 0.;
 };
 
-using CandidateQueue = list<a<Candidate>>;
-using CandidateList = vector<a<Candidate>>;
+using CandidateQueue = list<of<Candidate>>;
+using CandidateList = vector<of<Candidate>>;
 
 // useful implimentations
 

--- a/include/rime/candidate.h
+++ b/include/rime/candidate.h
@@ -7,9 +7,6 @@
 #ifndef RIME_CANDIDATE_H_
 #define RIME_CANDIDATE_H_
 
-#include <list>
-#include <string>
-#include <vector>
 #include <rime/common.h>
 
 namespace rime {
@@ -17,127 +14,127 @@ namespace rime {
 class Candidate {
  public:
   Candidate() = default;
-  Candidate(const std::string type,
+  Candidate(const string type,
             size_t start,
             size_t end,
             double quality = 0.)
       : type_(type), start_(start), end_(end), quality_(quality) {}
   virtual ~Candidate() = default;
 
-  static shared_ptr<Candidate>
-  GetGenuineCandidate(const shared_ptr<Candidate>& cand);
-  static std::vector<shared_ptr<Candidate>>
-  GetGenuineCandidates(const shared_ptr<Candidate>& cand);
+  static a<Candidate>
+  GetGenuineCandidate(const a<Candidate>& cand);
+  static vector<a<Candidate>>
+  GetGenuineCandidates(const a<Candidate>& cand);
 
   // recognized by translators in learning phase
-  const std::string& type() const { return type_; }
+  const string& type() const { return type_; }
   // [start, end) mark a range in the input that the candidate corresponds to
   size_t start() const { return start_; }
   size_t end() const { return end_; }
   double quality() const { return quality_; }
 
   // candidate text to commit
-  virtual const std::string& text() const = 0;
+  virtual const string& text() const = 0;
   // (optional)
-  virtual std::string comment() const { return std::string(); }
+  virtual string comment() const { return string(); }
   // text shown in the preedit area, replacing input string (optional)
-  virtual std::string preedit() const { return std::string(); }
+  virtual string preedit() const { return string(); }
 
-  void set_type(const std::string& type) { type_ = type; }
+  void set_type(const string& type) { type_ = type; }
   void set_start(size_t start) { start_ = start; }
   void set_end(size_t end) { end_ = end; }
   void set_quality(double quality) { quality_ = quality; }
 
  private:
-  std::string type_;
+  string type_;
   size_t start_ = 0;
   size_t end_ = 0;
   double quality_ = 0.;
 };
 
-using CandidateQueue = std::list<shared_ptr<Candidate>>;
-using CandidateList = std::vector<shared_ptr<Candidate>>;
+using CandidateQueue = list<a<Candidate>>;
+using CandidateList = vector<a<Candidate>>;
 
 // useful implimentations
 
 class SimpleCandidate : public Candidate {
  public:
   SimpleCandidate() = default;
-  SimpleCandidate(const std::string type,
+  SimpleCandidate(const string type,
                   size_t start,
                   size_t end,
-                  const std::string& text,
-                  const std::string& comment = std::string(),
-                  const std::string& preedit = std::string())
+                  const string& text,
+                  const string& comment = string(),
+                  const string& preedit = string())
       : Candidate(type, start, end),
       text_(text), comment_(comment), preedit_(preedit) {}
 
-  const std::string& text() const { return text_; }
-  std::string comment() const { return comment_; }
-  std::string preedit() const { return preedit_; }
+  const string& text() const { return text_; }
+  string comment() const { return comment_; }
+  string preedit() const { return preedit_; }
 
-  void set_text(const std::string& text) { text_ = text; }
-  void set_comment(const std::string& comment) { comment_ = comment; }
-  void set_preedit(const std::string& preedit) { preedit_ = preedit; }
+  void set_text(const string& text) { text_ = text; }
+  void set_comment(const string& comment) { comment_ = comment; }
+  void set_preedit(const string& preedit) { preedit_ = preedit; }
 
  protected:
-  std::string text_;
-  std::string comment_;
-  std::string preedit_;
+  string text_;
+  string comment_;
+  string preedit_;
 };
 
 class ShadowCandidate : public Candidate {
  public:
-  ShadowCandidate(const shared_ptr<Candidate>& item,
-                  const std::string& type,
-                  const std::string& text = std::string(),
-                  const std::string& comment = std::string())
+  ShadowCandidate(const a<Candidate>& item,
+                  const string& type,
+                  const string& text = string(),
+                  const string& comment = string())
       : Candidate(type, item->start(), item->end(), item->quality()),
         text_(text), comment_(comment),
         item_(item) {}
 
-  const std::string& text() const {
+  const string& text() const {
     return text_.empty() ? item_->text() : text_;
   }
-  std::string comment() const {
+  string comment() const {
     return comment_.empty() ? item_->comment() : comment_;
   }
-  std::string preedit() const {
+  string preedit() const {
     return item_->preedit();
   }
 
-  const shared_ptr<Candidate>& item() const { return item_; }
+  const a<Candidate>& item() const { return item_; }
 
  protected:
-  std::string text_;
-  std::string comment_;
-  shared_ptr<Candidate> item_;
+  string text_;
+  string comment_;
+  a<Candidate> item_;
 };
 
 class UniquifiedCandidate : public Candidate {
  public:
-  UniquifiedCandidate(const shared_ptr<Candidate>& item,
-                      const std::string& type,
-                      const std::string& text = std::string(),
-                      const std::string& comment = std::string())
+  UniquifiedCandidate(const a<Candidate>& item,
+                      const string& type,
+                      const string& text = string(),
+                      const string& comment = string())
       : Candidate(type, item->start(), item->end(), item->quality()),
         text_(text), comment_(comment) {
     Append(item);
   }
 
-  const std::string& text() const {
+  const string& text() const {
     return text_.empty() && !items_.empty() ?
         items_.front()->text() : text_;
   }
-  std::string comment() const {
+  string comment() const {
     return comment_.empty() && !items_.empty() ?
         items_.front()->comment() : comment_;
   }
-  std::string preedit() const {
-    return !items_.empty() ? items_.front()->preedit() : std::string();
+  string preedit() const {
+    return !items_.empty() ? items_.front()->preedit() : string();
   }
 
-  void Append(shared_ptr<Candidate> item) {
+  void Append(a<Candidate> item) {
     items_.push_back(item);
     if (quality() < item->quality())
       set_quality(item->quality());
@@ -145,8 +142,8 @@ class UniquifiedCandidate : public Candidate {
   const CandidateList& items() const { return items_; }
 
  protected:
-  std::string text_;
-  std::string comment_;
+  string text_;
+  string comment_;
   CandidateList items_;
 };
 

--- a/include/rime/commit_history.h
+++ b/include/rime/commit_history.h
@@ -7,15 +7,14 @@
 #ifndef RIME_COMMIT_HISTORY_H_
 #define RIME_COMMIT_HISTORY_H_
 
-#include <list>
-#include <string>
+#include <rime/common.h>
 
 namespace rime {
 
 struct CommitRecord {
-  std::string type;
-  std::string text;
-  CommitRecord(const std::string& a_type, const std::string& a_text)
+  string type;
+  string text;
+  CommitRecord(const string& a_type, const string& a_text)
       : type(a_type), text(a_text) {}
   CommitRecord(int keycode) : type("thru"), text(1, keycode) {}
 };
@@ -23,13 +22,13 @@ struct CommitRecord {
 class KeyEvent;
 class Composition;
 
-class CommitHistory : public std::list<CommitRecord> {
+class CommitHistory : public list<CommitRecord> {
  public:
   static const size_t kMaxRecords = 20;
   void Push(const CommitRecord& record);
   void Push(const KeyEvent& key_event);
-  void Push(const Composition& composition, const std::string& input);
-  std::string repr() const;
+  void Push(const Composition& composition, const string& input);
+  string repr() const;
 };
 
 }  // Namespace rime

--- a/include/rime/common.h
+++ b/include/rime/common.h
@@ -49,6 +49,8 @@ using the = std::unique_ptr<T>;
 template <class T>
 using a = std::shared_ptr<T>;
 template <class T>
+using of = a<T>;
+template <class T>
 using weak = std::weak_ptr<T>;
 
 template <class X, class Y>

--- a/include/rime/common.h
+++ b/include/rime/common.h
@@ -7,8 +7,11 @@
 #ifndef RIME_COMMON_H_
 #define RIME_COMMON_H_
 
-#include <forward_list>
+#include <functional>
+#include <list>
+#include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 #include <unordered_map>
@@ -29,15 +32,17 @@
 
 namespace rime {
 
+using std::function;
+using std::list;
+using std::map;
+using std::set;
 using std::string;
 using std::vector;
 
-template <class T>
-using list = std::forward_list<T>;
 template <class Key, class T>
-using map = std::unordered_map<Key, T>;
+using hash_map = std::unordered_map<Key, T>;
 template <class T>
-using set = std::unordered_set<T>;
+using hash_set = std::unordered_set<T>;
 
 template <class T>
 using the = std::unique_ptr<T>;

--- a/include/rime/common.h
+++ b/include/rime/common.h
@@ -54,24 +54,24 @@ using hash_set = std::unordered_set<T>;
 template <class T>
 using the = std::unique_ptr<T>;
 template <class T>
-using a = std::shared_ptr<T>;
+using an = std::shared_ptr<T>;
 template <class T>
-using of = a<T>;
+using of = an<T>;
 template <class T>
 using weak = std::weak_ptr<T>;
 
 template <class X, class Y>
-inline a<X> As(const a<Y>& ptr) {
+inline an<X> As(const an<Y>& ptr) {
   return std::dynamic_pointer_cast<X>(ptr);
 }
 
 template <class X, class Y>
-inline bool Is(const a<Y>& ptr) {
+inline bool Is(const an<Y>& ptr) {
   return bool(As<X, Y>(ptr));
 }
 
 template <class T, class... Args>
-inline a<T> New(Args&&... args) {
+inline an<T> New(Args&&... args) {
   return std::make_shared<T>(std::forward<Args>(args)...);
 }
 

--- a/include/rime/common.h
+++ b/include/rime/common.h
@@ -7,8 +7,13 @@
 #ifndef RIME_COMMON_H_
 #define RIME_COMMON_H_
 
+#include <forward_list>
 #include <memory>
+#include <string>
 #include <utility>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 #define BOOST_BIND_NO_PLACEHOLDERS
 #include <boost/signals2/connection.hpp>
 #include <boost/signals2/signal.hpp>
@@ -24,27 +29,40 @@
 
 namespace rime {
 
-using boost::signals2::connection;
-using boost::signals2::signal;
+using std::string;
+using std::vector;
 
-using std::unique_ptr;
-using std::shared_ptr;
-using std::weak_ptr;
+template <class T>
+using list = std::forward_list<T>;
+template <class Key, class T>
+using map = std::unordered_map<Key, T>;
+template <class T>
+using set = std::unordered_set<T>;
 
-template <class A, class B>
-shared_ptr<A> As(const B& ptr) {
-  return std::dynamic_pointer_cast<A>(ptr);
+template <class T>
+using the = std::unique_ptr<T>;
+template <class T>
+using a = std::shared_ptr<T>;
+template <class T>
+using weak = std::weak_ptr<T>;
+
+template <class X, class Y>
+inline a<X> As(const a<Y>& ptr) {
+  return std::dynamic_pointer_cast<X>(ptr);
 }
 
-template <class A, class B>
-bool Is(const B& ptr) {
-  return bool(As<A, B>(ptr));
+template <class X, class Y>
+inline bool Is(const a<Y>& ptr) {
+  return bool(As<X, Y>(ptr));
 }
 
 template <class T, class... Args>
-inline shared_ptr<T> New(Args&&... args) {
+inline a<T> New(Args&&... args) {
   return std::make_shared<T>(std::forward<Args>(args)...);
 }
+
+using boost::signals2::connection;
+using boost::signals2::signal;
 
 }  // namespace rime
 

--- a/include/rime/common.h
+++ b/include/rime/common.h
@@ -16,6 +16,7 @@
 #include <utility>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 #define BOOST_BIND_NO_PLACEHOLDERS
 #ifdef BOOST_SIGNALS2
@@ -38,7 +39,9 @@ namespace rime {
 
 using std::function;
 using std::list;
+using std::make_pair;
 using std::map;
+using std::pair;
 using std::set;
 using std::string;
 using std::vector;

--- a/include/rime/component.h
+++ b/include/rime/component.h
@@ -7,8 +7,6 @@
 #ifndef RIME_COMPONENT_H_
 #define RIME_COMPONENT_H_
 
-#include <map>
-#include <string>
 #include <rime/registry.h>
 
 namespace rime {
@@ -28,7 +26,7 @@ struct Class {
     virtual T* Create(Initializer arg) = 0;
   };
 
-  static Component* Require(const std::string& name) {
+  static Component* Require(const string& name) {
     return dynamic_cast<Component*>(Registry::instance().Find(name));
   }
 };

--- a/include/rime/composition.h
+++ b/include/rime/composition.h
@@ -7,13 +7,12 @@
 #ifndef RIME_COMPOSITION_H_
 #define RIME_COMPOSITION_H_
 
-#include <string>
 #include <rime/segmentation.h>
 
 namespace rime {
 
 struct Preedit {
-  std::string text;
+  string text;
   size_t caret_pos = 0;
   size_t sel_start = 0;
   size_t sel_end = 0;
@@ -25,10 +24,10 @@ class Composition : public Segmentation {
 
   bool HasFinishedComposition() const;
   Preedit GetPreedit() const;
-  std::string GetPrompt() const;
-  std::string GetCommitText() const;
-  std::string GetScriptText() const;
-  std::string GetDebugText() const;
+  string GetPrompt() const;
+  string GetCommitText() const;
+  string GetScriptText() const;
+  string GetDebugText() const;
 };
 
 }  // namespace rime

--- a/include/rime/config.h
+++ b/include/rime/config.h
@@ -30,8 +30,6 @@ class ConfigItem {
   ValueType type_ = kNull;
 };
 
-using ConfigItemPtr = a<ConfigItem>;
-
 class ConfigValue : public ConfigItem {
  public:
   ConfigValue() : ConfigItem(kScalar) {}
@@ -58,19 +56,17 @@ class ConfigValue : public ConfigItem {
   string value_;
 };
 
-using ConfigValuePtr = a<ConfigValue>;
-
 class ConfigList : public ConfigItem {
  public:
-  using Sequence = vector<ConfigItemPtr>;
+  using Sequence = vector<a<ConfigItem>>;
   using Iterator = Sequence::iterator;
 
   ConfigList() : ConfigItem(kList) {}
-  ConfigItemPtr GetAt(size_t i) const;
-  ConfigValuePtr GetValueAt(size_t i) const;
-  bool SetAt(size_t i, ConfigItemPtr element);
-  bool Insert(size_t i, ConfigItemPtr element);
-  bool Append(ConfigItemPtr element);
+  a<ConfigItem> GetAt(size_t i) const;
+  a<ConfigValue> GetValueAt(size_t i) const;
+  bool SetAt(size_t i, a<ConfigItem> element);
+  bool Insert(size_t i, a<ConfigItem> element);
+  bool Append(a<ConfigItem> element);
   bool Resize(size_t size);
   bool Clear();
   size_t size() const;
@@ -82,19 +78,17 @@ class ConfigList : public ConfigItem {
   Sequence seq_;
 };
 
-using ConfigListPtr = a<ConfigList>;
-
 // limitation: map keys have to be strings, preferably alphanumeric
 class ConfigMap : public ConfigItem {
  public:
-  using Map = map<string, ConfigItemPtr>;
+  using Map = map<string, a<ConfigItem>>;
   using Iterator = Map::iterator;
 
   ConfigMap() : ConfigItem(kMap) {}
   bool HasKey(const string& key) const;
-  ConfigItemPtr Get(const string& key) const;
-  ConfigValuePtr GetValue(const string& key) const;
-  bool Set(const string& key, ConfigItemPtr element);
+  a<ConfigItem> Get(const string& key) const;
+  a<ConfigValue> GetValue(const string& key) const;
+  bool Set(const string& key, a<ConfigItem> element);
   bool Clear();
 
   Iterator begin();
@@ -104,8 +98,6 @@ class ConfigMap : public ConfigItem {
   Map map_;
 };
 
-using ConfigMapPtr = a<ConfigMap>;
-
 class ConfigData;
 class ConfigListEntryRef;
 class ConfigMapEntryRef;
@@ -114,7 +106,7 @@ class ConfigItemRef {
  public:
   ConfigItemRef(const a<ConfigData>& data) : data_(data) {
   }
-  operator ConfigItemPtr () const {
+  operator a<ConfigItem> () const {
     return GetItem();
   }
   ConfigListEntryRef operator[] (size_t index);
@@ -130,12 +122,12 @@ class ConfigItemRef {
   double ToDouble() const;
   string ToString() const;
 
-  ConfigListPtr AsList();
-  ConfigMapPtr AsMap();
+  a<ConfigList> AsList();
+  a<ConfigMap> AsMap();
   void Clear();
 
   // list
-  bool Append(ConfigItemPtr item);
+  bool Append(a<ConfigItem> item);
   size_t size() const;
   // map
   bool HasKey(const string& key) const;
@@ -144,8 +136,8 @@ class ConfigItemRef {
   void set_modified();
 
  protected:
-  virtual ConfigItemPtr GetItem() const = 0;
-  virtual void SetItem(ConfigItemPtr item) = 0;
+  virtual a<ConfigItem> GetItem() const = 0;
+  virtual void SetItem(a<ConfigItem> item) = 0;
 
   a<ConfigData> data_;
 };
@@ -153,13 +145,13 @@ class ConfigItemRef {
 namespace {
 
 template <class T>
-ConfigItemPtr AsConfigItem(const T& a, const std::false_type&) {
-  return New<ConfigValue>(a);
+a<ConfigItem> AsConfigItem(const T& x, const std::false_type&) {
+  return New<ConfigValue>(x);
 };
 
 template <class T>
-ConfigItemPtr AsConfigItem(const T& a, const std::true_type&) {
-  return a;
+a<ConfigItem> AsConfigItem(const T& x, const std::true_type&) {
+  return x;
 };
 
 }  // namespace
@@ -167,48 +159,48 @@ ConfigItemPtr AsConfigItem(const T& a, const std::true_type&) {
 class ConfigListEntryRef : public ConfigItemRef {
  public:
   ConfigListEntryRef(a<ConfigData> data,
-                     ConfigListPtr list, size_t index)
+                     a<ConfigList> list, size_t index)
       : ConfigItemRef(data), list_(list), index_(index) {
   }
   template <class T>
-  ConfigListEntryRef& operator= (const T& a) {
-    SetItem(AsConfigItem(a, std::is_convertible<T, ConfigItemPtr>()));
+  ConfigListEntryRef& operator= (const T& x) {
+    SetItem(AsConfigItem(x, std::is_convertible<T, a<ConfigItem>>()));
     return *this;
   }
  protected:
-  ConfigItemPtr GetItem() const {
+  a<ConfigItem> GetItem() const {
     return list_->GetAt(index_);
   }
-  void SetItem(ConfigItemPtr item) {
+  void SetItem(a<ConfigItem> item) {
     list_->SetAt(index_, item);
     set_modified();
   }
  private:
-  ConfigListPtr list_;
+  a<ConfigList> list_;
   size_t index_;
 };
 
 class ConfigMapEntryRef : public ConfigItemRef {
  public:
   ConfigMapEntryRef(a<ConfigData> data,
-                    ConfigMapPtr map, const string& key)
+                    a<ConfigMap> map, const string& key)
       : ConfigItemRef(data), map_(map), key_(key) {
   }
   template <class T>
-  ConfigMapEntryRef& operator= (const T& a) {
-    SetItem(AsConfigItem(a, std::is_convertible<T, ConfigItemPtr>()));
+  ConfigMapEntryRef& operator= (const T& x) {
+    SetItem(AsConfigItem(x, std::is_convertible<T, a<ConfigItem>>()));
     return *this;
   }
  protected:
-  ConfigItemPtr GetItem() const {
+  a<ConfigItem> GetItem() const {
     return map_->Get(key_);
   }
-  void SetItem(ConfigItemPtr item) {
+  void SetItem(a<ConfigItem> item) {
     map_->Set(key_, item);
     set_modified();
   }
  private:
-  ConfigMapPtr map_;
+  a<ConfigMap> map_;
   string key_;
 };
 
@@ -247,10 +239,10 @@ class Config : public Class<Config, const string&>, public ConfigItemRef {
   bool GetDouble(const string& key, double* value);
   bool GetString(const string& key, string* value);
 
-  ConfigItemPtr GetItem(const string& key);
-  ConfigValuePtr GetValue(const string& key);
-  ConfigListPtr GetList(const string& key);
-  ConfigMapPtr GetMap(const string& key);
+  a<ConfigItem> GetItem(const string& key);
+  a<ConfigValue> GetValue(const string& key);
+  a<ConfigList> GetList(const string& key);
+  a<ConfigMap> GetMap(const string& key);
 
   // setters
   bool SetBool(const string& key, bool value);
@@ -259,17 +251,17 @@ class Config : public Class<Config, const string&>, public ConfigItemRef {
   bool SetString(const string& key, const char* value);
   bool SetString(const string& key, const string& value);
   // setter for adding / replacing items to the tree
-  bool SetItem(const string& key, ConfigItemPtr item);
+  bool SetItem(const string& key, a<ConfigItem> item);
 
   template <class T>
-  Config& operator= (const T& a) {
-    SetItem(AsConfigItem(a, std::is_convertible<T, ConfigItemPtr>()));
+  Config& operator= (const T& x) {
+    SetItem(AsConfigItem(x, std::is_convertible<T, a<ConfigItem>>()));
     return *this;
   }
 
  protected:
-  ConfigItemPtr GetItem() const;
-  void SetItem(ConfigItemPtr item);
+  a<ConfigItem> GetItem() const;
+  void SetItem(a<ConfigItem> item);
  };
 
 // ConfigComponent class

--- a/include/rime/config.h
+++ b/include/rime/config.h
@@ -58,15 +58,15 @@ class ConfigValue : public ConfigItem {
 
 class ConfigList : public ConfigItem {
  public:
-  using Sequence = vector<a<ConfigItem>>;
+  using Sequence = vector<an<ConfigItem>>;
   using Iterator = Sequence::iterator;
 
   ConfigList() : ConfigItem(kList) {}
-  a<ConfigItem> GetAt(size_t i) const;
-  a<ConfigValue> GetValueAt(size_t i) const;
-  bool SetAt(size_t i, a<ConfigItem> element);
-  bool Insert(size_t i, a<ConfigItem> element);
-  bool Append(a<ConfigItem> element);
+  an<ConfigItem> GetAt(size_t i) const;
+  an<ConfigValue> GetValueAt(size_t i) const;
+  bool SetAt(size_t i, an<ConfigItem> element);
+  bool Insert(size_t i, an<ConfigItem> element);
+  bool Append(an<ConfigItem> element);
   bool Resize(size_t size);
   bool Clear();
   size_t size() const;
@@ -81,14 +81,14 @@ class ConfigList : public ConfigItem {
 // limitation: map keys have to be strings, preferably alphanumeric
 class ConfigMap : public ConfigItem {
  public:
-  using Map = map<string, a<ConfigItem>>;
+  using Map = map<string, an<ConfigItem>>;
   using Iterator = Map::iterator;
 
   ConfigMap() : ConfigItem(kMap) {}
   bool HasKey(const string& key) const;
-  a<ConfigItem> Get(const string& key) const;
-  a<ConfigValue> GetValue(const string& key) const;
-  bool Set(const string& key, a<ConfigItem> element);
+  an<ConfigItem> Get(const string& key) const;
+  an<ConfigValue> GetValue(const string& key) const;
+  bool Set(const string& key, an<ConfigItem> element);
   bool Clear();
 
   Iterator begin();
@@ -104,9 +104,9 @@ class ConfigMapEntryRef;
 
 class ConfigItemRef {
  public:
-  ConfigItemRef(const a<ConfigData>& data) : data_(data) {
+  ConfigItemRef(const an<ConfigData>& data) : data_(data) {
   }
-  operator a<ConfigItem> () const {
+  operator an<ConfigItem> () const {
     return GetItem();
   }
   ConfigListEntryRef operator[] (size_t index);
@@ -122,12 +122,12 @@ class ConfigItemRef {
   double ToDouble() const;
   string ToString() const;
 
-  a<ConfigList> AsList();
-  a<ConfigMap> AsMap();
+  an<ConfigList> AsList();
+  an<ConfigMap> AsMap();
   void Clear();
 
   // list
-  bool Append(a<ConfigItem> item);
+  bool Append(an<ConfigItem> item);
   size_t size() const;
   // map
   bool HasKey(const string& key) const;
@@ -136,21 +136,21 @@ class ConfigItemRef {
   void set_modified();
 
  protected:
-  virtual a<ConfigItem> GetItem() const = 0;
-  virtual void SetItem(a<ConfigItem> item) = 0;
+  virtual an<ConfigItem> GetItem() const = 0;
+  virtual void SetItem(an<ConfigItem> item) = 0;
 
-  a<ConfigData> data_;
+  an<ConfigData> data_;
 };
 
 namespace {
 
 template <class T>
-a<ConfigItem> AsConfigItem(const T& x, const std::false_type&) {
+an<ConfigItem> AsConfigItem(const T& x, const std::false_type&) {
   return New<ConfigValue>(x);
 };
 
 template <class T>
-a<ConfigItem> AsConfigItem(const T& x, const std::true_type&) {
+an<ConfigItem> AsConfigItem(const T& x, const std::true_type&) {
   return x;
 };
 
@@ -158,49 +158,49 @@ a<ConfigItem> AsConfigItem(const T& x, const std::true_type&) {
 
 class ConfigListEntryRef : public ConfigItemRef {
  public:
-  ConfigListEntryRef(a<ConfigData> data,
-                     a<ConfigList> list, size_t index)
+  ConfigListEntryRef(an<ConfigData> data,
+                     an<ConfigList> list, size_t index)
       : ConfigItemRef(data), list_(list), index_(index) {
   }
   template <class T>
   ConfigListEntryRef& operator= (const T& x) {
-    SetItem(AsConfigItem(x, std::is_convertible<T, a<ConfigItem>>()));
+    SetItem(AsConfigItem(x, std::is_convertible<T, an<ConfigItem>>()));
     return *this;
   }
  protected:
-  a<ConfigItem> GetItem() const {
+  an<ConfigItem> GetItem() const {
     return list_->GetAt(index_);
   }
-  void SetItem(a<ConfigItem> item) {
+  void SetItem(an<ConfigItem> item) {
     list_->SetAt(index_, item);
     set_modified();
   }
  private:
-  a<ConfigList> list_;
+  an<ConfigList> list_;
   size_t index_;
 };
 
 class ConfigMapEntryRef : public ConfigItemRef {
  public:
-  ConfigMapEntryRef(a<ConfigData> data,
-                    a<ConfigMap> map, const string& key)
+  ConfigMapEntryRef(an<ConfigData> data,
+                    an<ConfigMap> map, const string& key)
       : ConfigItemRef(data), map_(map), key_(key) {
   }
   template <class T>
   ConfigMapEntryRef& operator= (const T& x) {
-    SetItem(AsConfigItem(x, std::is_convertible<T, a<ConfigItem>>()));
+    SetItem(AsConfigItem(x, std::is_convertible<T, an<ConfigItem>>()));
     return *this;
   }
  protected:
-  a<ConfigItem> GetItem() const {
+  an<ConfigItem> GetItem() const {
     return map_->Get(key_);
   }
-  void SetItem(a<ConfigItem> item) {
+  void SetItem(an<ConfigItem> item) {
     map_->Set(key_, item);
     set_modified();
   }
  private:
-  a<ConfigMap> map_;
+  an<ConfigMap> map_;
   string key_;
 };
 
@@ -239,10 +239,10 @@ class Config : public Class<Config, const string&>, public ConfigItemRef {
   bool GetDouble(const string& key, double* value);
   bool GetString(const string& key, string* value);
 
-  a<ConfigItem> GetItem(const string& key);
-  a<ConfigValue> GetValue(const string& key);
-  a<ConfigList> GetList(const string& key);
-  a<ConfigMap> GetMap(const string& key);
+  an<ConfigItem> GetItem(const string& key);
+  an<ConfigValue> GetValue(const string& key);
+  an<ConfigList> GetList(const string& key);
+  an<ConfigMap> GetMap(const string& key);
 
   // setters
   bool SetBool(const string& key, bool value);
@@ -251,17 +251,17 @@ class Config : public Class<Config, const string&>, public ConfigItemRef {
   bool SetString(const string& key, const char* value);
   bool SetString(const string& key, const string& value);
   // setter for adding / replacing items to the tree
-  bool SetItem(const string& key, a<ConfigItem> item);
+  bool SetItem(const string& key, an<ConfigItem> item);
 
   template <class T>
   Config& operator= (const T& x) {
-    SetItem(AsConfigItem(x, std::is_convertible<T, a<ConfigItem>>()));
+    SetItem(AsConfigItem(x, std::is_convertible<T, an<ConfigItem>>()));
     return *this;
   }
 
  protected:
-  a<ConfigItem> GetItem() const;
-  void SetItem(a<ConfigItem> item);
+  an<ConfigItem> GetItem() const;
+  void SetItem(an<ConfigItem> item);
  };
 
 // ConfigComponent class

--- a/include/rime/context.h
+++ b/include/rime/context.h
@@ -33,7 +33,7 @@ class Context {
   Preedit GetPreedit() const;
   bool IsComposing() const;
   bool HasMenu() const;
-  a<Candidate> GetSelectedCandidate() const;
+  an<Candidate> GetSelectedCandidate() const;
 
   bool PushInput(char ch);
   bool PushInput(const string& str);

--- a/include/rime/context.h
+++ b/include/rime/context.h
@@ -7,7 +7,6 @@
 #ifndef RIME_CONTEXT_H_
 #define RIME_CONTEXT_H_
 
-#include <string>
 #include <rime/common.h>
 #include <rime/commit_history.h>
 #include <rime/composition.h>
@@ -21,7 +20,7 @@ class Context {
  public:
   using Notifier = signal<void (Context* ctx)>;
   using OptionUpdateNotifier =
-      signal<void (Context* ctx, const std::string& option)>;
+      signal<void (Context* ctx, const string& option)>;
   using KeyEventNotifier =
       signal<void (Context* ctx, const KeyEvent& key_event)>;
 
@@ -29,15 +28,15 @@ class Context {
   ~Context() = default;
 
   bool Commit();
-  std::string GetCommitText() const;
-  std::string GetScriptText() const;
+  string GetCommitText() const;
+  string GetScriptText() const;
   Preedit GetPreedit() const;
   bool IsComposing() const;
   bool HasMenu() const;
-  shared_ptr<Candidate> GetSelectedCandidate() const;
+  a<Candidate> GetSelectedCandidate() const;
 
   bool PushInput(char ch);
-  bool PushInput(const std::string& str);
+  bool PushInput(const string& str);
   bool PopInput(size_t len = 1);
   bool DeleteInput(size_t len = 1);
   void Clear();
@@ -55,8 +54,8 @@ class Context {
   bool ClearNonConfirmedComposition();
   bool RefreshNonConfirmedComposition();
 
-  void set_input(const std::string& value);
-  const std::string& input() const { return input_; }
+  void set_input(const string& value);
+  const string& input() const { return input_; }
 
   void set_caret_pos(size_t caret_pos);
   size_t caret_pos() const { return caret_pos_; }
@@ -67,10 +66,10 @@ class Context {
   CommitHistory& commit_history() { return commit_history_; }
   const CommitHistory& commit_history() const { return commit_history_; }
 
-  void set_option(const std::string& name, bool value);
-  bool get_option(const std::string& name) const;
-  void set_property(const std::string& name, const std::string& value);
-  std::string get_property(const std::string& name) const;
+  void set_option(const string& name, bool value);
+  bool get_option(const string& name) const;
+  void set_property(const string& name, const string& value);
+  string get_property(const string& name) const;
   // options and properties starting with '_' are local to schema;
   // others are session scoped.
   void ClearTransientOptions();
@@ -87,12 +86,12 @@ class Context {
   }
 
  private:
-  std::string input_;
+  string input_;
   size_t caret_pos_ = 0;
   Composition composition_;
   CommitHistory commit_history_;
-  std::map<std::string, bool> options_;
-  std::map<std::string, std::string> properties_;
+  map<string, bool> options_;
+  map<string, string> properties_;
 
   Notifier commit_notifier_;
   Notifier select_notifier_;

--- a/include/rime/deployer.h
+++ b/include/rime/deployer.h
@@ -48,8 +48,8 @@ class Deployer : public Messenger {
                TaskInitializer arg = TaskInitializer());
   bool ScheduleTask(const string& task_name,
                     TaskInitializer arg = TaskInitializer());
-  void ScheduleTask(a<DeploymentTask> task);
-  a<DeploymentTask> NextTask();
+  void ScheduleTask(an<DeploymentTask> task);
+  an<DeploymentTask> NextTask();
   bool HasPendingTasks();
 
   bool Run();

--- a/include/rime/deployer.h
+++ b/include/rime/deployer.h
@@ -64,7 +64,7 @@ class Deployer : public Messenger {
   string user_data_sync_dir() const;
 
  private:
-  std::queue<a<DeploymentTask>> pending_tasks_;
+  std::queue<of<DeploymentTask>> pending_tasks_;
   std::mutex mutex_;
   std::future<void> work_;
   bool maintenance_mode_ = false;

--- a/include/rime/deployer.h
+++ b/include/rime/deployer.h
@@ -10,7 +10,6 @@
 #include <future>
 #include <mutex>
 #include <queue>
-#include <string>
 #include <boost/any.hpp>
 #include <rime/common.h>
 #include <rime/component.h>
@@ -33,24 +32,24 @@ class DeploymentTask : public Class<DeploymentTask, TaskInitializer> {
 class Deployer : public Messenger {
  public:
   // read-only access after library initialization {
-  std::string shared_data_dir;
-  std::string user_data_dir;
-  std::string sync_dir;
-  std::string user_id;
-  std::string distribution_name;
-  std::string distribution_code_name;
-  std::string distribution_version;
+  string shared_data_dir;
+  string user_data_dir;
+  string sync_dir;
+  string user_id;
+  string distribution_name;
+  string distribution_code_name;
+  string distribution_version;
   // }
 
   Deployer();
   ~Deployer();
 
-  bool RunTask(const std::string& task_name,
+  bool RunTask(const string& task_name,
                TaskInitializer arg = TaskInitializer());
-  bool ScheduleTask(const std::string& task_name,
+  bool ScheduleTask(const string& task_name,
                     TaskInitializer arg = TaskInitializer());
-  void ScheduleTask(shared_ptr<DeploymentTask> task);
-  shared_ptr<DeploymentTask> NextTask();
+  void ScheduleTask(a<DeploymentTask> task);
+  a<DeploymentTask> NextTask();
   bool HasPendingTasks();
 
   bool Run();
@@ -62,10 +61,10 @@ class Deployer : public Messenger {
   void JoinWorkThread();
   void JoinMaintenanceThread();
 
-  std::string user_data_sync_dir() const;
+  string user_data_sync_dir() const;
 
  private:
-  std::queue<shared_ptr<DeploymentTask>> pending_tasks_;
+  std::queue<a<DeploymentTask>> pending_tasks_;
   std::mutex mutex_;
   std::future<void> work_;
   bool maintenance_mode_ = false;

--- a/include/rime/dict/db.h
+++ b/include/rime/dict/db.h
@@ -49,9 +49,9 @@ class Db : public Class<Db, const string&> {
   virtual bool MetaFetch(const string& key, string* value) = 0;
   virtual bool MetaUpdate(const string& key, const string& value) = 0;
 
-  virtual a<DbAccessor> QueryMetadata() = 0;
-  virtual a<DbAccessor> QueryAll() = 0;
-  virtual a<DbAccessor> Query(const string &key) = 0;
+  virtual an<DbAccessor> QueryMetadata() = 0;
+  virtual an<DbAccessor> QueryAll() = 0;
+  virtual an<DbAccessor> Query(const string &key) = 0;
   virtual bool Fetch(const string &key, string *value) = 0;
   virtual bool Update(const string &key, const string &value) = 0;
   virtual bool Erase(const string &key) = 0;

--- a/include/rime/dict/db.h
+++ b/include/rime/dict/db.h
@@ -7,7 +7,6 @@
 #ifndef RIME_DB_H_
 #define RIME_DB_H_
 
-#include <string>
 #include <rime/common.h>
 #include <rime/component.h>
 
@@ -16,24 +15,24 @@ namespace rime {
 class DbAccessor {
  public:
   DbAccessor() = default;
-  explicit DbAccessor(const std::string& prefix)
+  explicit DbAccessor(const string& prefix)
       : prefix_(prefix) {}
   virtual ~DbAccessor() = default;
 
   virtual bool Reset() = 0;
-  virtual bool Jump(const std::string &key) = 0;
-  virtual bool GetNextRecord(std::string *key, std::string *value) = 0;
+  virtual bool Jump(const string &key) = 0;
+  virtual bool GetNextRecord(string *key, string *value) = 0;
   virtual bool exhausted() = 0;
 
  protected:
-  bool MatchesPrefix(const std::string& key);
+  bool MatchesPrefix(const string& key);
 
-  std::string prefix_;
+  string prefix_;
 };
 
-class Db : public Class<Db, const std::string&> {
+class Db : public Class<Db, const string&> {
  public:
-  explicit Db(const std::string& name);
+  explicit Db(const string& name);
   virtual ~Db() = default;
 
   bool Exists() const;
@@ -43,22 +42,22 @@ class Db : public Class<Db, const std::string&> {
   virtual bool OpenReadOnly() = 0;
   virtual bool Close() = 0;
 
-  virtual bool Backup(const std::string& snapshot_file) = 0;
-  virtual bool Restore(const std::string& snapshot_file) = 0;
+  virtual bool Backup(const string& snapshot_file) = 0;
+  virtual bool Restore(const string& snapshot_file) = 0;
 
   virtual bool CreateMetadata();
-  virtual bool MetaFetch(const std::string& key, std::string* value) = 0;
-  virtual bool MetaUpdate(const std::string& key, const std::string& value) = 0;
+  virtual bool MetaFetch(const string& key, string* value) = 0;
+  virtual bool MetaUpdate(const string& key, const string& value) = 0;
 
-  virtual shared_ptr<DbAccessor> QueryMetadata() = 0;
-  virtual shared_ptr<DbAccessor> QueryAll() = 0;
-  virtual shared_ptr<DbAccessor> Query(const std::string &key) = 0;
-  virtual bool Fetch(const std::string &key, std::string *value) = 0;
-  virtual bool Update(const std::string &key, const std::string &value) = 0;
-  virtual bool Erase(const std::string &key) = 0;
+  virtual a<DbAccessor> QueryMetadata() = 0;
+  virtual a<DbAccessor> QueryAll() = 0;
+  virtual a<DbAccessor> Query(const string &key) = 0;
+  virtual bool Fetch(const string &key, string *value) = 0;
+  virtual bool Update(const string &key, const string &value) = 0;
+  virtual bool Erase(const string &key) = 0;
 
-  const std::string& name() const { return name_; }
-  const std::string& file_name() const { return file_name_; }
+  const string& name() const { return name_; }
+  const string& file_name() const { return file_name_; }
   bool loaded() const { return loaded_; }
   bool readonly() const { return readonly_; }
   bool disabled() const { return disabled_; }
@@ -66,8 +65,8 @@ class Db : public Class<Db, const std::string&> {
   void enable() { disabled_ = false; }
 
  protected:
-  std::string name_;
-  std::string file_name_;
+  string name_;
+  string file_name_;
   bool loaded_ = false;
   bool readonly_ = false;
   bool disabled_ = false;

--- a/include/rime/dict/db_utils.h
+++ b/include/rime/dict/db_utils.h
@@ -7,7 +7,6 @@
 #ifndef RIME_DB_UTILS_H_
 #define RIME_DB_UTILS_H_
 
-#include <string>
 #include <rime/common.h>
 
 namespace rime {
@@ -15,8 +14,8 @@ namespace rime {
 class Sink {
  public:
   virtual ~Sink() = default;
-  virtual bool MetaPut(const std::string& key, const std::string& value) = 0;
-  virtual bool Put(const std::string& key, const std::string& value) = 0;
+  virtual bool MetaPut(const string& key, const string& value) = 0;
+  virtual bool Put(const string& key, const string& value) = 0;
 
   template <class SourceType>
   int operator<< (SourceType& source);
@@ -25,8 +24,8 @@ class Sink {
 class Source {
  public:
   virtual ~Source() = default;
-  virtual bool MetaGet(std::string* key, std::string* value) = 0;
-  virtual bool Get(std::string* key, std::string* value) = 0;
+  virtual bool MetaGet(string* key, string* value) = 0;
+  virtual bool Get(string* key, string* value) = 0;
 
   template <class SinkType>
   int operator>> (SinkType& sink);
@@ -51,8 +50,8 @@ class DbSink : public Sink {
  public:
   explicit DbSink(Db* db);
 
-  virtual bool MetaPut(const std::string& key, const std::string& value);
-  virtual bool Put(const std::string& key, const std::string& value);
+  virtual bool MetaPut(const string& key, const string& value);
+  virtual bool Put(const string& key, const string& value);
 
  protected:
   Db* db_;
@@ -62,13 +61,13 @@ class DbSource : public Source {
  public:
   explicit DbSource(Db* db);
 
-  virtual bool MetaGet(std::string* key, std::string* value);
-  virtual bool Get(std::string* key, std::string* value);
+  virtual bool MetaGet(string* key, string* value);
+  virtual bool Get(string* key, string* value);
 
  protected:
   Db* db_;
-  shared_ptr<DbAccessor> metadata_;
-  shared_ptr<DbAccessor> data_;
+  a<DbAccessor> metadata_;
+  a<DbAccessor> data_;
 };
 
 }  // namespace rime

--- a/include/rime/dict/db_utils.h
+++ b/include/rime/dict/db_utils.h
@@ -66,8 +66,8 @@ class DbSource : public Source {
 
  protected:
   Db* db_;
-  a<DbAccessor> metadata_;
-  a<DbAccessor> data_;
+  an<DbAccessor> metadata_;
+  an<DbAccessor> data_;
 };
 
 }  // namespace rime

--- a/include/rime/dict/dict_compiler.h
+++ b/include/rime/dict/dict_compiler.h
@@ -46,8 +46,8 @@ class DictCompiler {
   bool BuildReverseLookupDict(ReverseDb* db, uint32_t dict_file_checksum);
 
   string dict_name_;
-  a<Prism> prism_;
-  a<Table> table_;
+  an<Prism> prism_;
+  an<Table> table_;
   int options_ = 0;
   DictFileFinder dict_file_finder_;
 };

--- a/include/rime/dict/dict_compiler.h
+++ b/include/rime/dict/dict_compiler.h
@@ -7,9 +7,6 @@
 #ifndef RIME_DICT_COMPILER_H_
 #define RIME_DICT_COMPILER_H_
 
-#include <functional>
-#include <string>
-#include <vector>
 #include <rime/common.h>
 
 namespace rime {
@@ -22,7 +19,7 @@ class DictSettings;
 
 // return found dict file path, otherwize return empty string
 using DictFileFinder =
-    std::function<const std::string (const std::string& file_name)>;
+    function<const string (const string& file_name)>;
 
 class DictCompiler {
  public:
@@ -36,21 +33,21 @@ class DictCompiler {
   DictCompiler(Dictionary *dictionary,
                DictFileFinder finder = NULL);
 
-  bool Compile(const std::string &schema_file);
+  bool Compile(const string &schema_file);
   void set_options(int options) { options_ = options; }
 
  private:
-  std::string FindDictFile(const std::string& dict_name);
+  string FindDictFile(const string& dict_name);
   bool BuildTable(DictSettings* settings,
-                  const std::vector<std::string>& dict_files,
+                  const vector<string>& dict_files,
                   uint32_t dict_file_checksum);
-  bool BuildPrism(const std::string& schema_file,
+  bool BuildPrism(const string& schema_file,
                   uint32_t dict_file_checksum, uint32_t schema_file_checksum);
   bool BuildReverseLookupDict(ReverseDb* db, uint32_t dict_file_checksum);
 
-  std::string dict_name_;
-  shared_ptr<Prism> prism_;
-  shared_ptr<Table> table_;
+  string dict_name_;
+  a<Prism> prism_;
+  a<Table> table_;
   int options_ = 0;
   DictFileFinder dict_file_finder_;
 };

--- a/include/rime/dict/dict_settings.h
+++ b/include/rime/dict/dict_settings.h
@@ -8,7 +8,6 @@
 #define RIME_DICT_SETTINGS_H_
 
 #include <istream>
-#include <string>
 #include <rime/common.h>
 #include <rime/config.h>
 
@@ -18,15 +17,15 @@ class DictSettings : public Config {
  public:
   DictSettings();
   bool LoadDictHeader(std::istream& stream);
-  std::string dict_name();
-  std::string dict_version();
-  std::string sort_order();
+  string dict_name();
+  string dict_version();
+  string sort_order();
   bool use_preset_vocabulary();
   bool use_rule_based_encoder();
   int max_phrase_length();
   double min_phrase_weight();
   ConfigListPtr GetTables();
-  int GetColumnIndex(const std::string& column_label);
+  int GetColumnIndex(const string& column_label);
 };
 
 }  // namespace rime

--- a/include/rime/dict/dict_settings.h
+++ b/include/rime/dict/dict_settings.h
@@ -24,7 +24,7 @@ class DictSettings : public Config {
   bool use_rule_based_encoder();
   int max_phrase_length();
   double min_phrase_weight();
-  a<ConfigList> GetTables();
+  an<ConfigList> GetTables();
   int GetColumnIndex(const string& column_label);
 };
 

--- a/include/rime/dict/dict_settings.h
+++ b/include/rime/dict/dict_settings.h
@@ -24,7 +24,7 @@ class DictSettings : public Config {
   bool use_rule_based_encoder();
   int max_phrase_length();
   double min_phrase_weight();
-  ConfigListPtr GetTables();
+  a<ConfigList> GetTables();
   int GetColumnIndex(const string& column_label);
 };
 

--- a/include/rime/dict/dictionary.h
+++ b/include/rime/dict/dictionary.h
@@ -7,10 +7,6 @@
 #ifndef RIME_DICTIONARY_H_
 #define RIME_DICTIONARY_H_
 
-#include <list>
-#include <map>
-#include <string>
-#include <vector>
 #include <rime/common.h>
 #include <rime/component.h>
 #include <rime/dict/prism.h>
@@ -26,15 +22,15 @@ struct Chunk {
   const table::Entry* entries = nullptr;
   size_t size = 0;
   size_t cursor = 0;
-  std::string remaining_code;  // for predictive queries
+  string remaining_code;  // for predictive queries
   double credibility = 1.0;
 
   Chunk() = default;
   Chunk(const Code& c, const table::Entry* e, double cr = 1.0)
       : code(c), entries(e), size(1), cursor(0), credibility(cr) {}
   Chunk(const TableAccessor& a, double cr = 1.0)
-      : Chunk(a, std::string(), cr) {}
-  Chunk(const TableAccessor& a, const std::string& r, double cr = 1.0)
+      : Chunk(a, string(), cr) {}
+  Chunk(const TableAccessor& a, const string& r, double cr = 1.0)
       : code(a.index_code()), entries(a.entry()),
         size(a.remaining()), cursor(0), remaining_code(r), credibility(cr) {}
 };
@@ -43,10 +39,10 @@ bool compare_chunk_by_leading_element(const Chunk& a, const Chunk& b);
 
 }  // namespace dictionary
 
-class DictEntryIterator : protected std::list<dictionary::Chunk>,
+class DictEntryIterator : protected list<dictionary::Chunk>,
                           public DictEntryFilterBinder {
  public:
-  using Base = std::list<dictionary::Chunk>;
+  using Base = list<dictionary::Chunk>;
 
   DictEntryIterator();
   DictEntryIterator(const DictEntryIterator& other);
@@ -54,7 +50,7 @@ class DictEntryIterator : protected std::list<dictionary::Chunk>,
 
   void AddChunk(dictionary::Chunk&& chunk, Table* table);
   void Sort();
-  shared_ptr<DictEntry> Peek();
+  a<DictEntry> Peek();
   bool Next();
   bool Skip(size_t num_entries);
   bool exhausted() const;
@@ -65,11 +61,11 @@ class DictEntryIterator : protected std::list<dictionary::Chunk>,
 
  private:
   Table* table_;
-  shared_ptr<DictEntry> entry_;
+  a<DictEntry> entry_;
   size_t entry_count_;
 };
 
-struct DictEntryCollector : std::map<size_t, DictEntryIterator> {
+struct DictEntryCollector : map<size_t, DictEntryIterator> {
 };
 
 class Config;
@@ -79,49 +75,49 @@ struct Ticket;
 
 class Dictionary : public Class<Dictionary, const Ticket&> {
  public:
-  Dictionary(const std::string& name,
-             const shared_ptr<Table>& table,
-             const shared_ptr<Prism>& prism);
+  Dictionary(const string& name,
+             const a<Table>& table,
+             const a<Prism>& prism);
   virtual ~Dictionary();
 
   bool Exists() const;
   bool Remove();
   bool Load();
 
-  shared_ptr<DictEntryCollector> Lookup(const SyllableGraph& syllable_graph,
+  a<DictEntryCollector> Lookup(const SyllableGraph& syllable_graph,
                                         size_t start_pos,
                                         double initial_credibility = 1.0);
   // if predictive is true, do an expand search with limit,
   // otherwise do an exact match.
   // return num of matching keys.
   size_t LookupWords(DictEntryIterator* result,
-                     const std::string& str_code,
+                     const string& str_code,
                      bool predictive, size_t limit = 0);
   // translate syllable id sequence to string code
-  bool Decode(const Code& code, std::vector<std::string>* result);
+  bool Decode(const Code& code, vector<string>* result);
 
-  const std::string& name() const { return name_; }
+  const string& name() const { return name_; }
   bool loaded() const;
 
-  shared_ptr<Table> table() { return table_; }
-  shared_ptr<Prism> prism() { return prism_; }
+  a<Table> table() { return table_; }
+  a<Prism> prism() { return prism_; }
 
  private:
-  std::string name_;
-  shared_ptr<Table> table_;
-  shared_ptr<Prism> prism_;
+  string name_;
+  a<Table> table_;
+  a<Prism> prism_;
 };
 
 class DictionaryComponent : public Dictionary::Component {
  public:
   DictionaryComponent();
   Dictionary* Create(const Ticket& ticket);
-  Dictionary* CreateDictionaryWithName(const std::string& dict_name,
-                                       const std::string& prism_name);
+  Dictionary* CreateDictionaryWithName(const string& dict_name,
+                                       const string& prism_name);
 
  private:
-  std::map<std::string, weak_ptr<Prism>> prism_map_;
-  std::map<std::string, weak_ptr<Table>> table_map_;
+  map<string, weak<Prism>> prism_map_;
+  map<string, weak<Table>> table_map_;
 };
 
 }  // namespace rime

--- a/include/rime/dict/dictionary.h
+++ b/include/rime/dict/dictionary.h
@@ -50,7 +50,7 @@ class DictEntryIterator : protected list<dictionary::Chunk>,
 
   void AddChunk(dictionary::Chunk&& chunk, Table* table);
   void Sort();
-  a<DictEntry> Peek();
+  an<DictEntry> Peek();
   bool Next();
   bool Skip(size_t num_entries);
   bool exhausted() const;
@@ -61,7 +61,7 @@ class DictEntryIterator : protected list<dictionary::Chunk>,
 
  private:
   Table* table_;
-  a<DictEntry> entry_;
+  an<DictEntry> entry_;
   size_t entry_count_;
 };
 
@@ -76,15 +76,15 @@ struct Ticket;
 class Dictionary : public Class<Dictionary, const Ticket&> {
  public:
   Dictionary(const string& name,
-             const a<Table>& table,
-             const a<Prism>& prism);
+             const an<Table>& table,
+             const an<Prism>& prism);
   virtual ~Dictionary();
 
   bool Exists() const;
   bool Remove();
   bool Load();
 
-  a<DictEntryCollector> Lookup(const SyllableGraph& syllable_graph,
+  an<DictEntryCollector> Lookup(const SyllableGraph& syllable_graph,
                                         size_t start_pos,
                                         double initial_credibility = 1.0);
   // if predictive is true, do an expand search with limit,
@@ -99,13 +99,13 @@ class Dictionary : public Class<Dictionary, const Ticket&> {
   const string& name() const { return name_; }
   bool loaded() const;
 
-  a<Table> table() { return table_; }
-  a<Prism> prism() { return prism_; }
+  an<Table> table() { return table_; }
+  an<Prism> prism() { return prism_; }
 
  private:
   string name_;
-  a<Table> table_;
-  a<Prism> prism_;
+  an<Table> table_;
+  an<Prism> prism_;
 };
 
 class DictionaryComponent : public Dictionary::Component {

--- a/include/rime/dict/entry_collector.h
+++ b/include/rime/dict/entry_collector.h
@@ -7,11 +7,7 @@
 #ifndef RIME_ENTRY_COLLECTOR_H_
 #define RIME_ENTRY_COLLECTOR_H_
 
-#include <map>
 #include <queue>
-#include <set>
-#include <string>
-#include <vector>
 #include <rime/common.h>
 #include <rime/algo/encoder.h>
 #include <rime/dict/dictionary.h>
@@ -21,16 +17,16 @@ namespace rime {
 
 struct RawDictEntry {
   RawCode raw_code;
-  std::string text;
+  string text;
   double weight;
 };
 
 // code -> weight
-using WeightMap = std::map<std::string, double>;
+using WeightMap = map<string, double>;
 // word -> { code -> weight }
-using WordMap = std::map<std::string, WeightMap>;
+using WordMap = map<string, WeightMap>;
 // [ (word, weight), ... ]
-using EncodeQueue = std::queue<std::pair<std::string, std::string>>;
+using EncodeQueue = std::queue<std::pair<string, string>>;
 
 class PresetVocabulary;
 class DictSettings;
@@ -38,7 +34,7 @@ class DictSettings;
 class EntryCollector : public PhraseCollector {
  public:
   Syllabary syllabary;
-  std::vector<RawDictEntry> entries;
+  vector<RawDictEntry> entries;
   size_t num_entries = 0;
   ReverseLookupTable stems;
 
@@ -47,28 +43,28 @@ class EntryCollector : public PhraseCollector {
   ~EntryCollector();
 
   void Configure(DictSettings* settings);
-  void Collect(const std::vector<std::string>& dict_files);
+  void Collect(const vector<string>& dict_files);
 
   // export contents of table and prism to text files
-  void Dump(const std::string& file_name) const;
+  void Dump(const string& file_name) const;
 
-  void CreateEntry(const std::string &word,
-                   const std::string &code_str,
-                   const std::string &weight_str);
-  bool TranslateWord(const std::string& word,
-                     std::vector<std::string>* code);
+  void CreateEntry(const string &word,
+                   const string &code_str,
+                   const string &weight_str);
+  bool TranslateWord(const string& word,
+                     vector<string>* code);
  protected:
   void LoadPresetVocabulary(DictSettings* settings);
   // call Collect() multiple times for all required tables
-  void Collect(const std::string &dict_file);
+  void Collect(const string &dict_file);
   // encode all collected entries
   void Finish();
 
  protected:
-  unique_ptr<PresetVocabulary> preset_vocabulary;
-  unique_ptr<Encoder> encoder;
+  the<PresetVocabulary> preset_vocabulary;
+  the<Encoder> encoder;
   EncodeQueue encode_queue;
-  std::set<std::string/* word */> collection;
+  set<string/* word */> collection;
   WordMap words;
   WeightMap total_weight;
 };

--- a/include/rime/dict/entry_collector.h
+++ b/include/rime/dict/entry_collector.h
@@ -26,7 +26,7 @@ using WeightMap = map<string, double>;
 // word -> { code -> weight }
 using WordMap = map<string, WeightMap>;
 // [ (word, weight), ... ]
-using EncodeQueue = std::queue<std::pair<string, string>>;
+using EncodeQueue = std::queue<pair<string, string>>;
 
 class PresetVocabulary;
 class DictSettings;

--- a/include/rime/dict/level_db.h
+++ b/include/rime/dict/level_db.h
@@ -7,7 +7,6 @@
 #ifndef RIME_LEVEL_DB_H_
 #define RIME_LEVEL_DB_H_
 
-#include <string>
 #include <rime/dict/db.h>
 
 namespace rime {
@@ -21,16 +20,16 @@ class LevelDbAccessor : public DbAccessor {
  public:
   LevelDbAccessor();
   LevelDbAccessor(LevelDbCursor* cursor,
-                 const std::string& prefix);
+                 const string& prefix);
   virtual ~LevelDbAccessor();
 
   virtual bool Reset();
-  virtual bool Jump(const std::string& key);
-  virtual bool GetNextRecord(std::string* key, std::string* value);
+  virtual bool Jump(const string& key);
+  virtual bool GetNextRecord(string* key, string* value);
   virtual bool exhausted();
 
  private:
-  unique_ptr<LevelDbCursor> cursor_;
+  the<LevelDbCursor> cursor_;
   bool is_metadata_query_ = false;
 };
 
@@ -38,7 +37,7 @@ class LevelDb : public Db,
                 public Recoverable,
                 public Transactional {
  public:
-  LevelDb(const std::string& name, const std::string& db_type = "");
+  LevelDb(const string& name, const string& db_type = "");
   virtual ~LevelDb();
 
   virtual bool Remove();
@@ -46,19 +45,19 @@ class LevelDb : public Db,
   virtual bool OpenReadOnly();
   virtual bool Close();
 
-  virtual bool Backup(const std::string& snapshot_file);
-  virtual bool Restore(const std::string& snapshot_file);
+  virtual bool Backup(const string& snapshot_file);
+  virtual bool Restore(const string& snapshot_file);
 
   virtual bool CreateMetadata();
-  virtual bool MetaFetch(const std::string& key, std::string* value);
-  virtual bool MetaUpdate(const std::string& key, const std::string& value);
+  virtual bool MetaFetch(const string& key, string* value);
+  virtual bool MetaUpdate(const string& key, const string& value);
 
-  virtual shared_ptr<DbAccessor> QueryMetadata();
-  virtual shared_ptr<DbAccessor> QueryAll();
-  virtual shared_ptr<DbAccessor> Query(const std::string& key);
-  virtual bool Fetch(const std::string& key, std::string* value);
-  virtual bool Update(const std::string& key, const std::string& value);
-  virtual bool Erase(const std::string& key);
+  virtual a<DbAccessor> QueryMetadata();
+  virtual a<DbAccessor> QueryAll();
+  virtual a<DbAccessor> Query(const string& key);
+  virtual bool Fetch(const string& key, string* value);
+  virtual bool Update(const string& key, const string& value);
+  virtual bool Erase(const string& key);
 
   // Recoverable
   virtual bool Recover();
@@ -71,8 +70,8 @@ class LevelDb : public Db,
  private:
   void Initialize();
 
-  unique_ptr<LevelDbWrapper> db_;
-  std::string db_type_;
+  the<LevelDbWrapper> db_;
+  string db_type_;
 };
 
 }  // namespace rime

--- a/include/rime/dict/level_db.h
+++ b/include/rime/dict/level_db.h
@@ -52,9 +52,9 @@ class LevelDb : public Db,
   virtual bool MetaFetch(const string& key, string* value);
   virtual bool MetaUpdate(const string& key, const string& value);
 
-  virtual a<DbAccessor> QueryMetadata();
-  virtual a<DbAccessor> QueryAll();
-  virtual a<DbAccessor> Query(const string& key);
+  virtual an<DbAccessor> QueryMetadata();
+  virtual an<DbAccessor> QueryAll();
+  virtual an<DbAccessor> Query(const string& key);
   virtual bool Fetch(const string& key, string* value);
   virtual bool Update(const string& key, const string& value);
   virtual bool Erase(const string& key);

--- a/include/rime/dict/mapped_file.h
+++ b/include/rime/dict/mapped_file.h
@@ -88,7 +88,7 @@ class MappedFileImpl;
 
 class MappedFile : boost::noncopyable {
  protected:
-  explicit MappedFile(const std::string& file_name);
+  explicit MappedFile(const string& file_name);
   virtual ~MappedFile();
 
   bool Create(size_t capacity);
@@ -104,8 +104,8 @@ class MappedFile : boost::noncopyable {
   template <class T>
   Array<T>* CreateArray(size_t array_size);
 
-  String* CreateString(const std::string& str);
-  bool CopyString(const std::string& src, String* dest);
+  String* CreateString(const string& str);
+  bool CopyString(const string& src, String* dest);
 
   size_t capacity() const;
   char* address() const;
@@ -119,13 +119,13 @@ class MappedFile : boost::noncopyable {
   template <class T>
   T* Find(size_t offset);
 
-  const std::string& file_name() const { return file_name_; }
+  const string& file_name() const { return file_name_; }
   size_t file_size() const { return size_; }
 
  private:
-  std::string file_name_;
+  string file_name_;
   size_t size_ = 0;
-  unique_ptr<MappedFileImpl> file_;
+  the<MappedFileImpl> file_;
 };
 
 // member function definitions

--- a/include/rime/dict/preset_vocabulary.h
+++ b/include/rime/dict/preset_vocabulary.h
@@ -7,7 +7,6 @@
 #ifndef PRESET_VOCABULARY_H_
 #define PRESET_VOCABULARY_H_
 
-#include <string>
 #include <rime/common.h>
 
 namespace rime {
@@ -20,20 +19,20 @@ class PresetVocabulary {
   ~PresetVocabulary();
 
   // random access
-  bool GetWeightForEntry(const std::string& key, double* weight);
+  bool GetWeightForEntry(const string& key, double* weight);
   // traversing
   void Reset();
-  bool GetNextEntry(std::string* key, std::string* value);
-  bool IsQualifiedPhrase(const std::string& phrase,
-                         const std::string& weight_str);
+  bool GetNextEntry(string* key, string* value);
+  bool IsQualifiedPhrase(const string& phrase,
+                         const string& weight_str);
 
   void set_max_phrase_length(int length) { max_phrase_length_ = length; }
   void set_min_phrase_weight(double weight) { min_phrase_weight_ = weight; }
 
-  static std::string DictFilePath();
+  static string DictFilePath();
 
  protected:
-  unique_ptr<VocabularyDb> db_;
+  the<VocabularyDb> db_;
   int max_phrase_length_ = 0;
   double min_phrase_weight_ = 0.0;
 };

--- a/include/rime/dict/prism.h
+++ b/include/rime/dict/prism.h
@@ -9,9 +9,6 @@
 #ifndef RIME_PRISM_H_
 #define RIME_PRISM_H_
 
-#include <set>
-#include <string>
-#include <vector>
 #include <darts.h>
 #include <rime/common.h>
 #include <rime/algo/spelling.h>
@@ -68,7 +65,7 @@ class Prism : public MappedFile {
  public:
   using Match = Darts::DoubleArray::result_pair_type;
 
-  explicit Prism(const std::string& file_name);
+  explicit Prism(const string& file_name);
 
   bool Load();
   bool Save();
@@ -77,10 +74,10 @@ class Prism : public MappedFile {
              uint32_t dict_file_checksum = 0,
              uint32_t schema_file_checksum = 0);
 
-  bool HasKey(const std::string& key);
-  bool GetValue(const std::string& key, int* value);
-  void CommonPrefixSearch(const std::string& key, std::vector<Match>* result);
-  void ExpandSearch(const std::string& key, std::vector<Match>* result, size_t limit);
+  bool HasKey(const string& key);
+  bool GetValue(const string& key, int* value);
+  void CommonPrefixSearch(const string& key, vector<Match>* result);
+  void ExpandSearch(const string& key, vector<Match>* result, size_t limit);
   SpellingAccessor QuerySpelling(SyllableId spelling_id);
 
   size_t array_size() const;
@@ -89,7 +86,7 @@ class Prism : public MappedFile {
   uint32_t schema_file_checksum() const;
 
  private:
-  unique_ptr<Darts::DoubleArray> trie_;
+  the<Darts::DoubleArray> trie_;
   prism::Metadata* metadata_ = nullptr;
   prism::SpellingMap* spelling_map_ = nullptr;
   double format_ = 0.0;

--- a/include/rime/dict/reverse_lookup_dictionary.h
+++ b/include/rime/dict/reverse_lookup_dictionary.h
@@ -61,15 +61,15 @@ class ReverseDb : public MappedFile {
 class ReverseLookupDictionary
     : public Class<ReverseLookupDictionary, const Ticket&> {
  public:
-  explicit ReverseLookupDictionary(a<ReverseDb> db);
+  explicit ReverseLookupDictionary(an<ReverseDb> db);
   explicit ReverseLookupDictionary(const string& dict_name);
   bool Load();
   bool ReverseLookup(const string& text, string* result);
   bool LookupStems(const string& text, string* result);
-  a<DictSettings> GetDictSettings();
+  an<DictSettings> GetDictSettings();
 
  protected:
-  a<ReverseDb> db_;
+  an<ReverseDb> db_;
 };
 
 class ReverseLookupDictionaryComponent

--- a/include/rime/dict/reverse_lookup_dictionary.h
+++ b/include/rime/dict/reverse_lookup_dictionary.h
@@ -9,8 +9,6 @@
 #define RIME_REVERSE_LOOKUP_DICTIONARY_H_
 
 #include <stdint.h>
-#include <map>
-#include <string>
 #include <rime/common.h>
 #include <rime/component.h>
 #include <rime/dict/mapped_file.h>
@@ -40,10 +38,10 @@ class DictSettings;
 
 class ReverseDb : public MappedFile {
  public:
-  explicit ReverseDb(const std::string& dict_name);
+  explicit ReverseDb(const string& dict_name);
 
   bool Load();
-  bool Lookup(const std::string& text, std::string* result);
+  bool Lookup(const string& text, string* result);
 
   bool Build(DictSettings* settings,
              const Syllabary& syllabary,
@@ -56,22 +54,22 @@ class ReverseDb : public MappedFile {
 
  private:
   reverse::Metadata* metadata_ = nullptr;
-  unique_ptr<StringTable> key_trie_;
-  unique_ptr<StringTable> value_trie_;
+  the<StringTable> key_trie_;
+  the<StringTable> value_trie_;
 };
 
 class ReverseLookupDictionary
     : public Class<ReverseLookupDictionary, const Ticket&> {
  public:
-  explicit ReverseLookupDictionary(shared_ptr<ReverseDb> db);
-  explicit ReverseLookupDictionary(const std::string& dict_name);
+  explicit ReverseLookupDictionary(a<ReverseDb> db);
+  explicit ReverseLookupDictionary(const string& dict_name);
   bool Load();
-  bool ReverseLookup(const std::string& text, std::string* result);
-  bool LookupStems(const std::string& text, std::string* result);
-  shared_ptr<DictSettings> GetDictSettings();
+  bool ReverseLookup(const string& text, string* result);
+  bool LookupStems(const string& text, string* result);
+  a<DictSettings> GetDictSettings();
 
  protected:
-  shared_ptr<ReverseDb> db_;
+  a<ReverseDb> db_;
 };
 
 class ReverseLookupDictionaryComponent
@@ -80,7 +78,7 @@ class ReverseLookupDictionaryComponent
   ReverseLookupDictionaryComponent();
   ReverseLookupDictionary* Create(const Ticket& ticket);
  private:
-  std::map<std::string, weak_ptr<ReverseDb>> db_pool_;
+  map<string, weak<ReverseDb>> db_pool_;
 };
 
 }  // namespace rime

--- a/include/rime/dict/string_table.h
+++ b/include/rime/dict/string_table.h
@@ -8,9 +8,7 @@
 #ifndef RIME_STRING_TABLE_H_
 #define RIME_STRING_TABLE_H_
 
-#include <string>
 #include <utility>
-#include <vector>
 #include <marisa.h>
 #include <rime/common.h>
 
@@ -26,13 +24,13 @@ class StringTable {
   virtual ~StringTable() = default;
   StringTable(const char* ptr, size_t size);
 
-  bool HasKey(const std::string& key);
-  StringId Lookup(const std::string& key);
-  void CommonPrefixMatch(const std::string& query,
-                         std::vector<StringId>* result);
-  void Predict(const std::string& query,
-               std::vector<StringId>* result);
-  std::string GetString(StringId string_id);
+  bool HasKey(const string& key);
+  StringId Lookup(const string& key);
+  void CommonPrefixMatch(const string& query,
+                         vector<StringId>* result);
+  void Predict(const string& query,
+               vector<StringId>* result);
+  string GetString(StringId string_id);
 
   size_t NumKeys() const;
   size_t BinarySize() const;
@@ -43,7 +41,7 @@ class StringTable {
 
 class StringTableBuilder: public StringTable {
  public:
-  void Add(const std::string& key, double weight = 1.0,
+  void Add(const string& key, double weight = 1.0,
            StringId* reference = nullptr);
   void Clear();
   void Build();
@@ -53,7 +51,7 @@ class StringTableBuilder: public StringTable {
   void UpdateReferences();
 
   marisa::Keyset keys_;
-  std::vector<StringId*> references_;
+  vector<StringId*> references_;
 };
 
 }  // namespace rime

--- a/include/rime/dict/table.h
+++ b/include/rime/dict/table.h
@@ -9,10 +9,6 @@
 #define RIME_TABLE_H_
 
 #include <cstring>
-#include <map>
-#include <set>
-#include <string>
-#include <vector>
 #include <darts.h>
 #include <rime/common.h>
 #include <rime/dict/mapped_file.h>
@@ -135,14 +131,14 @@ class TableAccessor {
   double credibility_ = 1.0;
 };
 
-using TableQueryResult = std::map<int, std::vector<TableAccessor>>;
+using TableQueryResult = map<int, vector<TableAccessor>>;
 
 struct SyllableGraph;
 class TableQuery;
 
 class Table : public MappedFile {
  public:
-  Table(const std::string& file_name);
+  Table(const string& file_name);
   virtual ~Table();
 
   bool Load();
@@ -153,13 +149,13 @@ class Table : public MappedFile {
              uint32_t dict_file_checksum = 0);
 
   bool GetSyllabary(Syllabary* syllabary);
-  std::string GetSyllableById(int syllable_id);
+  string GetSyllableById(int syllable_id);
   TableAccessor QueryWords(int syllable_id);
   TableAccessor QueryPhrases(const Code& code);
   bool Query(const SyllableGraph& syll_graph,
              size_t start_pos,
              TableQueryResult* result);
-  std::string GetEntryText(const table::Entry& entry);
+  string GetEntryText(const table::Entry& entry);
 
   uint32_t dict_file_checksum() const;
 
@@ -173,18 +169,18 @@ class Table : public MappedFile {
   table::TailIndex* BuildTailIndex(const Code& prefix,
                                    const Vocabulary& vocabulary);
   bool BuildPhraseIndex(Code code, const Vocabulary& vocabulary,
-                        std::map<std::string, int>* index_data);
+                        map<string, int>* index_data);
   Array<table::Entry>* BuildEntryArray(const DictEntryList& entries);
   bool BuildEntryList(const DictEntryList& src, List<table::Entry>* dest);
   bool BuildEntry(const DictEntry& dict_entry, table::Entry* entry);
 
-  std::string GetString_v1(const table::StringType& x);
-  bool AddString_v1(const std::string& src, table::StringType* dest,
+  string GetString_v1(const table::StringType& x);
+  bool AddString_v1(const string& src, table::StringType* dest,
                     double weight);
 
   // v2
-  std::string GetString_v2(const table::StringType& x);
-  bool AddString_v2(const std::string& src, table::StringType* dest,
+  string GetString_v2(const table::StringType& x);
+  bool AddString_v2(const string& src, table::StringType* dest,
                     double weight);
   bool OnBuildStart_v2();
   bool OnBuildFinish_v2();
@@ -200,8 +196,8 @@ class Table : public MappedFile {
   struct TableFormat {
     const char* format_name;
 
-    std::string (Table::*GetString)(const table::StringType& x);
-    bool (Table::*AddString)(const std::string& src, table::StringType* dest,
+    string (Table::*GetString)(const table::StringType& x);
+    bool (Table::*AddString)(const string& src, table::StringType* dest,
                              double weight);
 
     bool (Table::*OnBuildStart)();
@@ -210,8 +206,8 @@ class Table : public MappedFile {
   } format_;
 
   // v2
-  unique_ptr<StringTable> string_table_;
-  unique_ptr<StringTableBuilder> string_table_builder_;
+  the<StringTable> string_table_;
+  the<StringTableBuilder> string_table_builder_;
 };
 
 }  // namespace rime

--- a/include/rime/dict/table_db.h
+++ b/include/rime/dict/table_db.h
@@ -7,14 +7,13 @@
 #ifndef RIME_TABLE_DB_H_
 #define RIME_TABLE_DB_H_
 
-#include <string>
 #include <rime/dict/text_db.h>
 
 namespace rime {
 
 class TableDb : public TextDb {
  public:
-  explicit TableDb(const std::string& name);
+  explicit TableDb(const string& name);
 
   static const TextFormat format;
 };
@@ -22,7 +21,7 @@ class TableDb : public TextDb {
 // read-only tabledb
 class StableDb : public TableDb {
  public:
-  explicit StableDb(const std::string& name);
+  explicit StableDb(const string& name);
 
   virtual bool Open();
 };

--- a/include/rime/dict/text_db.h
+++ b/include/rime/dict/text_db.h
@@ -7,8 +7,6 @@
 #ifndef RIME_TEXT_DB_H_
 #define RIME_TEXT_DB_H_
 
-#include <map>
-#include <string>
 #include <rime/dict/db.h>
 #include <rime/dict/tsv.h>
 
@@ -16,16 +14,16 @@ namespace rime {
 
 class TextDb;
 
-using TextDbData = std::map<std::string, std::string>;
+using TextDbData = map<string, string>;
 
 class TextDbAccessor : public DbAccessor {
  public:
-  TextDbAccessor(const TextDbData& data, const std::string& prefix);
+  TextDbAccessor(const TextDbData& data, const string& prefix);
   virtual ~TextDbAccessor();
 
   virtual bool Reset();
-  virtual bool Jump(const std::string& key);
-  virtual bool GetNextRecord(std::string* key, std::string* value);
+  virtual bool Jump(const string& key);
+  virtual bool GetNextRecord(string* key, string* value);
   virtual bool exhausted();
 
  private:
@@ -36,13 +34,13 @@ class TextDbAccessor : public DbAccessor {
 struct TextFormat {
   TsvParser parser;
   TsvFormatter formatter;
-  std::string file_description;
+  string file_description;
 };
 
 class TextDb : public Db {
  public:
-  TextDb(const std::string& name,
-         const std::string& db_type,
+  TextDb(const string& name,
+         const string& db_type,
          TextFormat format);
   virtual ~TextDb();
 
@@ -50,26 +48,26 @@ class TextDb : public Db {
   virtual bool OpenReadOnly();
   virtual bool Close();
 
-  virtual bool Backup(const std::string& snapshot_file);
-  virtual bool Restore(const std::string& snapshot_file);
+  virtual bool Backup(const string& snapshot_file);
+  virtual bool Restore(const string& snapshot_file);
 
   virtual bool CreateMetadata();
-  virtual bool MetaFetch(const std::string& key, std::string* value);
-  virtual bool MetaUpdate(const std::string& key, const std::string& value);
+  virtual bool MetaFetch(const string& key, string* value);
+  virtual bool MetaUpdate(const string& key, const string& value);
 
-  virtual shared_ptr<DbAccessor> QueryMetadata();
-  virtual shared_ptr<DbAccessor> QueryAll();
-  virtual shared_ptr<DbAccessor> Query(const std::string& key);
-  virtual bool Fetch(const std::string& key, std::string* value);
-  virtual bool Update(const std::string& key, const std::string& value);
-  virtual bool Erase(const std::string& key);
+  virtual a<DbAccessor> QueryMetadata();
+  virtual a<DbAccessor> QueryAll();
+  virtual a<DbAccessor> Query(const string& key);
+  virtual bool Fetch(const string& key, string* value);
+  virtual bool Update(const string& key, const string& value);
+  virtual bool Erase(const string& key);
 
  protected:
   void Clear();
-  bool LoadFromFile(const std::string& file);
-  bool SaveToFile(const std::string& file);
+  bool LoadFromFile(const string& file);
+  bool SaveToFile(const string& file);
 
-  std::string db_type_;
+  string db_type_;
   TextFormat format_;
   TextDbData metadata_;
   TextDbData data_;

--- a/include/rime/dict/text_db.h
+++ b/include/rime/dict/text_db.h
@@ -55,9 +55,9 @@ class TextDb : public Db {
   virtual bool MetaFetch(const string& key, string* value);
   virtual bool MetaUpdate(const string& key, const string& value);
 
-  virtual a<DbAccessor> QueryMetadata();
-  virtual a<DbAccessor> QueryAll();
-  virtual a<DbAccessor> Query(const string& key);
+  virtual an<DbAccessor> QueryMetadata();
+  virtual an<DbAccessor> QueryAll();
+  virtual an<DbAccessor> Query(const string& key);
   virtual bool Fetch(const string& key, string* value);
   virtual bool Update(const string& key, const string& value);
   virtual bool Erase(const string& key);

--- a/include/rime/dict/tsv.h
+++ b/include/rime/dict/tsv.h
@@ -7,20 +7,17 @@
 #ifndef RIME_TSV_H_
 #define RIME_TSV_H_
 
-#include <functional>
-#include <string>
-#include <vector>
 
 namespace rime {
 
-using Tsv = std::vector<std::string>;
+using Tsv = vector<string>;
 
-using TsvParser = std::function<bool (const Tsv& row,
-                                      std::string* key,
-                                      std::string* value)>;
+using TsvParser = function<bool (const Tsv& row,
+                                      string* key,
+                                      string* value)>;
 
-using TsvFormatter = std::function<bool (const std::string& key,
-                                         const std::string& value,
+using TsvFormatter = function<bool (const string& key,
+                                         const string& value,
                                          Tsv* row)>;
 
 class Sink;
@@ -28,28 +25,28 @@ class Source;
 
 class TsvReader {
  public:
-  TsvReader(const std::string& path, TsvParser parser)
+  TsvReader(const string& path, TsvParser parser)
       : path_(path), parser_(parser) {
   }
   // return number of records read
   int operator() (Sink* sink);
  protected:
-  std::string path_;
+  string path_;
   TsvParser parser_;
 };
 
 class TsvWriter {
  public:
-  TsvWriter(const std::string& path, TsvFormatter formatter)
+  TsvWriter(const string& path, TsvFormatter formatter)
       : path_(path), formatter_(formatter) {
   }
   // return number of records written
   int operator() (Source* source);
  protected:
-  std::string path_;
+  string path_;
   TsvFormatter formatter_;
  public:
-  std::string file_description;
+  string file_description;
 };
 
 template <class SinkType>

--- a/include/rime/dict/user_db.h
+++ b/include/rime/dict/user_db.h
@@ -60,7 +60,7 @@ class UserDbHelper {
   }
   UserDbHelper(const the<Db>& db) : db_(db.get()) {
   }
-  UserDbHelper(const a<Db>& db) : db_(db.get()) {
+  UserDbHelper(const an<Db>& db) : db_(db.get()) {
   }
 
   bool UpdateUserInfo();

--- a/include/rime/dict/user_db.h
+++ b/include/rime/dict/user_db.h
@@ -8,7 +8,6 @@
 #define RIME_USER_DB_H_
 
 #include <stdint.h>
-#include <string>
 #include <rime/component.h>
 #include <rime/dict/db.h>
 #include <rime/dict/db_utils.h>
@@ -24,10 +23,10 @@ struct UserDbValue {
   TickCount tick = 0;
 
   UserDbValue() = default;
-  UserDbValue(const std::string& value);
+  UserDbValue(const string& value);
 
-  std::string Pack() const;
-  bool Unpack(const std::string& value);
+  string Pack() const;
+  bool Unpack(const string& value);
 };
 
 /**
@@ -42,12 +41,12 @@ class UserDb {
   /// Abstract class for a user db component.
   class Component : public Db::Component {
    public:
-    virtual std::string extension() const = 0;
-    virtual std::string snapshot_extension() const = 0;
+    virtual string extension() const = 0;
+    virtual string snapshot_extension() const = 0;
   };
 
   /// Requires a registered component for a user db class.
-  static Component* Require(const std::string& name) {
+  static Component* Require(const string& name) {
     return static_cast<Component*>(Db::Require(name));
   }
 
@@ -59,20 +58,20 @@ class UserDbHelper {
  public:
   UserDbHelper(Db* db) : db_(db) {
   }
-  UserDbHelper(const unique_ptr<Db>& db) : db_(db.get()) {
+  UserDbHelper(const the<Db>& db) : db_(db.get()) {
   }
-  UserDbHelper(const shared_ptr<Db>& db) : db_(db.get()) {
+  UserDbHelper(const a<Db>& db) : db_(db.get()) {
   }
 
   bool UpdateUserInfo();
-  static bool IsUniformFormat(const std::string& name);
-  bool UniformBackup(const std::string& snapshot_file);
-  bool UniformRestore(const std::string& snapshot_file);
+  static bool IsUniformFormat(const string& name);
+  bool UniformBackup(const string& snapshot_file);
+  bool UniformRestore(const string& snapshot_file);
 
   bool IsUserDb();
-  std::string GetDbName();
-  std::string GetUserId();
-  std::string GetRimeVersion();
+  string GetDbName();
+  string GetUserId();
+  string GetRimeVersion();
 
  protected:
   Db* db_;
@@ -82,18 +81,18 @@ class UserDbHelper {
 template <class BaseDb>
 class UserDbWrapper : public BaseDb {
  public:
-  UserDbWrapper(const std::string& db_name);
+  UserDbWrapper(const string& db_name);
 
   virtual bool CreateMetadata() {
     return BaseDb::CreateMetadata() &&
         UserDbHelper(this).UpdateUserInfo();
   }
-  virtual bool Backup(const std::string& snapshot_file) {
+  virtual bool Backup(const string& snapshot_file) {
     return UserDbHelper::IsUniformFormat(snapshot_file) ?
         UserDbHelper(this).UniformBackup(snapshot_file) :
         BaseDb::Backup(snapshot_file);
   }
-  virtual bool Restore(const std::string& snapshot_file) {
+  virtual bool Restore(const string& snapshot_file) {
     return UserDbHelper::IsUniformFormat(snapshot_file) ?
         UserDbHelper(this).UniformRestore(snapshot_file) :
         BaseDb::Restore(snapshot_file);
@@ -103,22 +102,22 @@ class UserDbWrapper : public BaseDb {
 /// Provides information of the db file format by its base class.
 template <class BaseDb>
 struct UserDbFormat {
-  static const std::string extension;
-  static const std::string snapshot_extension;
+  static const string extension;
+  static const string snapshot_extension;
 };
 
 /// Implements a component that serves as a factory for a user db class.
 template <class BaseDb>
 class UserDbComponent : public UserDb::Component {
  public:
-  virtual Db* Create(const std::string& name) {
+  virtual Db* Create(const string& name) {
     return new UserDbWrapper<BaseDb>(name + extension());
   }
 
-  virtual std::string extension() const {
+  virtual string extension() const {
     return UserDbFormat<BaseDb>::extension;
   }
-  virtual std::string snapshot_extension() const {
+  virtual string snapshot_extension() const {
     return UserDbFormat<BaseDb>::snapshot_extension;
   }
 };
@@ -128,8 +127,8 @@ class UserDbMerger : public Sink {
   explicit UserDbMerger(Db* db);
   virtual ~UserDbMerger();
 
-  virtual bool MetaPut(const std::string& key, const std::string& value);
-  virtual bool Put(const std::string& key, const std::string& value);
+  virtual bool MetaPut(const string& key, const string& value);
+  virtual bool Put(const string& key, const string& value);
 
   void CloseMerge();
 
@@ -145,8 +144,8 @@ class UserDbImporter : public Sink {
  public:
   explicit UserDbImporter(Db* db);
 
-  virtual bool MetaPut(const std::string& key, const std::string& value);
-  virtual bool Put(const std::string& key, const std::string& value);
+  virtual bool MetaPut(const string& key, const string& value);
+  virtual bool Put(const string& key, const string& value);
 
  protected:
   Db* db_;

--- a/include/rime/dict/user_db_recovery_task.h
+++ b/include/rime/dict/user_db_recovery_task.h
@@ -16,13 +16,13 @@ class Db;
 
 class UserDbRecoveryTask : public DeploymentTask {
  public:
-  explicit UserDbRecoveryTask(shared_ptr<Db> db);
+  explicit UserDbRecoveryTask(a<Db> db);
   bool Run(Deployer* deployer);
 
  protected:
   void RestoreUserDataFromSnapshot(Deployer* deployer);
 
-  shared_ptr<Db> db_;
+  a<Db> db_;
 };
 
 class UserDbRecoveryTaskComponent : public UserDbRecoveryTask::Component {

--- a/include/rime/dict/user_db_recovery_task.h
+++ b/include/rime/dict/user_db_recovery_task.h
@@ -16,13 +16,13 @@ class Db;
 
 class UserDbRecoveryTask : public DeploymentTask {
  public:
-  explicit UserDbRecoveryTask(a<Db> db);
+  explicit UserDbRecoveryTask(an<Db> db);
   bool Run(Deployer* deployer);
 
  protected:
   void RestoreUserDataFromSnapshot(Deployer* deployer);
 
-  a<Db> db_;
+  an<Db> db_;
 };
 
 class UserDbRecoveryTaskComponent : public UserDbRecoveryTask::Component {

--- a/include/rime/dict/user_dictionary.h
+++ b/include/rime/dict/user_dictionary.h
@@ -22,11 +22,11 @@ class UserDictEntryIterator : public DictEntryFilterBinder {
  public:
   UserDictEntryIterator() = default;
 
-  void Add(const a<DictEntry>& entry);
+  void Add(const an<DictEntry>& entry);
   void SortRange(size_t start, size_t count);
   bool Release(DictEntryList* receiver);
 
-  a<DictEntry> Peek();
+  an<DictEntry> Peek();
   bool Next();
   bool exhausted() const {
     return !entries_ || index_ >= entries_->size();
@@ -36,7 +36,7 @@ class UserDictEntryIterator : public DictEntryFilterBinder {
   }
 
  protected:
-  a<DictEntryList> entries_;
+  an<DictEntryList> entries_;
   size_t index_ = 0;
 };
 
@@ -50,15 +50,15 @@ struct Ticket;
 
 class UserDictionary : public Class<UserDictionary, const Ticket&> {
  public:
-  explicit UserDictionary(const a<Db>& db);
+  explicit UserDictionary(const an<Db>& db);
   virtual ~UserDictionary();
 
-  void Attach(const a<Table>& table, const a<Prism>& prism);
+  void Attach(const an<Table>& table, const an<Prism>& prism);
   bool Load();
   bool loaded() const;
   bool readonly() const;
 
-  a<UserDictEntryCollector> Lookup(const SyllableGraph& syllable_graph,
+  an<UserDictEntryCollector> Lookup(const SyllableGraph& syllable_graph,
                                             size_t start_pos,
                                             size_t depth_limit = 0,
                                             double initial_credibility = 1.0);
@@ -79,7 +79,7 @@ class UserDictionary : public Class<UserDictionary, const Ticket&> {
   const string& name() const { return name_; }
   TickCount tick() const { return tick_; }
 
-  static a<DictEntry> CreateDictEntry(const string& key,
+  static an<DictEntry> CreateDictEntry(const string& key,
                                                const string& value,
                                                TickCount present_tick,
                                                double credibility = 1.0,
@@ -95,9 +95,9 @@ class UserDictionary : public Class<UserDictionary, const Ticket&> {
 
  private:
   string name_;
-  a<Db> db_;
-  a<Table> table_;
-  a<Prism> prism_;
+  an<Db> db_;
+  an<Table> table_;
+  an<Prism> prism_;
   TickCount tick_ = 0;
   time_t transaction_time_ = 0;
 };

--- a/include/rime/dict/user_dictionary.h
+++ b/include/rime/dict/user_dictionary.h
@@ -8,8 +8,6 @@
 #define RIME_USER_DICTIONARY_H_
 
 #include <time.h>
-#include <map>
-#include <string>
 #include <rime/common.h>
 #include <rime/component.h>
 #include <rime/dict/user_db.h>
@@ -17,18 +15,18 @@
 
 namespace rime {
 
-struct UserDictEntryCollector : std::map<size_t, DictEntryList> {
+struct UserDictEntryCollector : map<size_t, DictEntryList> {
 };
 
 class UserDictEntryIterator : public DictEntryFilterBinder {
  public:
   UserDictEntryIterator() = default;
 
-  void Add(const shared_ptr<DictEntry>& entry);
+  void Add(const a<DictEntry>& entry);
   void SortRange(size_t start, size_t count);
   bool Release(DictEntryList* receiver);
 
-  shared_ptr<DictEntry> Peek();
+  a<DictEntry> Peek();
   bool Next();
   bool exhausted() const {
     return !entries_ || index_ >= entries_->size();
@@ -38,7 +36,7 @@ class UserDictEntryIterator : public DictEntryFilterBinder {
   }
 
  protected:
-  shared_ptr<DictEntryList> entries_;
+  a<DictEntryList> entries_;
   size_t index_ = 0;
 };
 
@@ -52,54 +50,54 @@ struct Ticket;
 
 class UserDictionary : public Class<UserDictionary, const Ticket&> {
  public:
-  explicit UserDictionary(const shared_ptr<Db>& db);
+  explicit UserDictionary(const a<Db>& db);
   virtual ~UserDictionary();
 
-  void Attach(const shared_ptr<Table>& table, const shared_ptr<Prism>& prism);
+  void Attach(const a<Table>& table, const a<Prism>& prism);
   bool Load();
   bool loaded() const;
   bool readonly() const;
 
-  shared_ptr<UserDictEntryCollector> Lookup(const SyllableGraph& syllable_graph,
+  a<UserDictEntryCollector> Lookup(const SyllableGraph& syllable_graph,
                                             size_t start_pos,
                                             size_t depth_limit = 0,
                                             double initial_credibility = 1.0);
   size_t LookupWords(UserDictEntryIterator* result,
-                     const std::string& input,
+                     const string& input,
                      bool predictive,
                      size_t limit = 0,
-                     std::string* resume_key = NULL);
+                     string* resume_key = NULL);
   bool UpdateEntry(const DictEntry& entry, int commits);
   bool UpdateEntry(const DictEntry& entry, int commits,
-                   const std::string& new_entry_prefix);
+                   const string& new_entry_prefix);
   bool UpdateTickCount(TickCount increment);
 
   bool NewTransaction();
   bool RevertRecentTransaction();
   bool CommitPendingTransaction();
 
-  const std::string& name() const { return name_; }
+  const string& name() const { return name_; }
   TickCount tick() const { return tick_; }
 
-  static shared_ptr<DictEntry> CreateDictEntry(const std::string& key,
-                                               const std::string& value,
+  static a<DictEntry> CreateDictEntry(const string& key,
+                                               const string& value,
                                                TickCount present_tick,
                                                double credibility = 1.0,
-                                               std::string* full_code = NULL);
+                                               string* full_code = NULL);
 
  protected:
   bool Initialize();
   bool FetchTickCount();
-  bool TranslateCodeToString(const Code& code, std::string* result);
+  bool TranslateCodeToString(const Code& code, string* result);
   void DfsLookup(const SyllableGraph& syll_graph, size_t current_pos,
-                 const std::string& current_prefix,
+                 const string& current_prefix,
                  DfsState* state);
 
  private:
-  std::string name_;
-  shared_ptr<Db> db_;
-  shared_ptr<Table> table_;
-  shared_ptr<Prism> prism_;
+  string name_;
+  a<Db> db_;
+  a<Table> table_;
+  a<Prism> prism_;
   TickCount tick_ = 0;
   time_t transaction_time_ = 0;
 };
@@ -109,7 +107,7 @@ class UserDictionaryComponent : public UserDictionary::Component {
   UserDictionaryComponent();
   UserDictionary* Create(const Ticket& ticket);
  private:
-  std::map<std::string, weak_ptr<Db>> db_pool_;
+  map<string, weak<Db>> db_pool_;
 };
 
 }  // namespace rime

--- a/include/rime/dict/vocabulary.h
+++ b/include/rime/dict/vocabulary.h
@@ -49,7 +49,7 @@ class DictEntryList : public vector<of<DictEntry>> {
   void SortRange(size_t start, size_t count);
 };
 
-using DictEntryFilter = function<bool (a<DictEntry> entry)>;
+using DictEntryFilter = function<bool (an<DictEntry> entry)>;
 
 class DictEntryFilterBinder {
  public:
@@ -63,7 +63,7 @@ class Vocabulary;
 
 struct VocabularyPage {
   DictEntryList entries;
-  a<Vocabulary> next_level;
+  an<Vocabulary> next_level;
 };
 
 class Vocabulary : public map<int, VocabularyPage> {

--- a/include/rime/dict/vocabulary.h
+++ b/include/rime/dict/vocabulary.h
@@ -43,7 +43,7 @@ struct DictEntry {
   bool operator< (const DictEntry& other) const;
 };
 
-class DictEntryList : public vector<a<DictEntry>> {
+class DictEntryList : public vector<of<DictEntry>> {
  public:
   void Sort();
   void SortRange(size_t start, size_t count);

--- a/include/rime/dict/vocabulary.h
+++ b/include/rime/dict/vocabulary.h
@@ -9,20 +9,15 @@
 #define RIME_VOCABULARY_H_
 
 #include <stdint.h>
-#include <functional>
-#include <map>
-#include <set>
-#include <string>
-#include <vector>
 #include <rime/common.h>
 
 namespace rime {
 
-using Syllabary = std::set<std::string>;
+using Syllabary = set<string>;
 
 using SyllableId = int32_t;
 
-class Code : public std::vector<SyllableId> {
+class Code : public vector<SyllableId> {
  public:
   static const size_t kIndexCodeMaxLength = 3;
 
@@ -31,30 +26,30 @@ class Code : public std::vector<SyllableId> {
 
   void CreateIndex(Code* index_code);
 
-  std::string ToString() const;
+  string ToString() const;
 };
 
 struct DictEntry {
-  std::string text;
-  std::string comment;
-  std::string preedit;
+  string text;
+  string comment;
+  string preedit;
   double weight = 0.0;
   int commit_count = 0;
   Code code;  // multi-syllable code from prism
-  std::string custom_code;  // user defined code
+  string custom_code;  // user defined code
   int remaining_code_length = 0;
 
   DictEntry() = default;
   bool operator< (const DictEntry& other) const;
 };
 
-class DictEntryList : public std::vector<shared_ptr<DictEntry>> {
+class DictEntryList : public vector<a<DictEntry>> {
  public:
   void Sort();
   void SortRange(size_t start, size_t count);
 };
 
-using DictEntryFilter = std::function<bool (shared_ptr<DictEntry> entry)>;
+using DictEntryFilter = function<bool (a<DictEntry> entry)>;
 
 class DictEntryFilterBinder {
  public:
@@ -68,17 +63,17 @@ class Vocabulary;
 
 struct VocabularyPage {
   DictEntryList entries;
-  shared_ptr<Vocabulary> next_level;
+  a<Vocabulary> next_level;
 };
 
-class Vocabulary : public std::map<int, VocabularyPage> {
+class Vocabulary : public map<int, VocabularyPage> {
  public:
   DictEntryList* LocateEntries(const Code& code);
   void SortHomophones();
 };
 
 // word -> { code, ... }
-using ReverseLookupTable = std::map<std::string, std::set<std::string>>;
+using ReverseLookupTable = map<string, set<string>>;
 
 }  // namespace rime
 

--- a/include/rime/engine.h
+++ b/include/rime/engine.h
@@ -7,7 +7,6 @@
 #ifndef RIME_ENGINE_H_
 #define RIME_ENGINE_H_
 
-#include <string>
 #include <rime/common.h>
 #include <rime/messenger.h>
 
@@ -19,12 +18,12 @@ class Context;
 
 class Engine : public Messenger {
  public:
-  using CommitSink = signal<void (const std::string& commit_text)>;
+  using CommitSink = signal<void (const string& commit_text)>;
 
   virtual ~Engine();
   virtual bool ProcessKey(const KeyEvent& key_event) { return false; }
   virtual void ApplySchema(Schema* schema) {}
-  virtual void CommitText(std::string text) { sink_(text); }
+  virtual void CommitText(string text) { sink_(text); }
   virtual void Compose(Context* ctx) {}
 
   Schema* schema() const { return schema_.get(); }
@@ -43,8 +42,8 @@ class Engine : public Messenger {
  protected:
   Engine();
 
-  unique_ptr<Schema> schema_;
-  unique_ptr<Context> context_;
+  the<Schema> schema_;
+  the<Context> context_;
   CommitSink sink_;
   Context* active_context_ = nullptr;
 };

--- a/include/rime/filter.h
+++ b/include/rime/filter.h
@@ -25,7 +25,7 @@ class Filter : public Class<Filter, const Ticket&> {
       : engine_(ticket.engine), name_space_(ticket.name_space) {}
   virtual ~Filter() = default;
 
-  virtual shared_ptr<Translation> Apply(shared_ptr<Translation> translation,
+  virtual a<Translation> Apply(a<Translation> translation,
                                         CandidateList* candidates) = 0;
 
   virtual bool AppliesToSegment(Segment* segment) {
@@ -34,7 +34,7 @@ class Filter : public Class<Filter, const Ticket&> {
 
  protected:
   Engine* engine_;
-  std::string name_space_;
+  string name_space_;
 };
 
 }  // namespace rime

--- a/include/rime/filter.h
+++ b/include/rime/filter.h
@@ -25,7 +25,7 @@ class Filter : public Class<Filter, const Ticket&> {
       : engine_(ticket.engine), name_space_(ticket.name_space) {}
   virtual ~Filter() = default;
 
-  virtual a<Translation> Apply(a<Translation> translation,
+  virtual an<Translation> Apply(an<Translation> translation,
                                         CandidateList* candidates) = 0;
 
   virtual bool AppliesToSegment(Segment* segment) {

--- a/include/rime/formatter.h
+++ b/include/rime/formatter.h
@@ -22,11 +22,11 @@ class Formatter : public Class<Formatter, const Ticket&> {
       : engine_(ticket.engine), name_space_(ticket.name_space) {}
   virtual ~Formatter() = default;
 
-  virtual void Format(std::string* text) = 0;
+  virtual void Format(string* text) = 0;
 
  protected:
   Engine* engine_;
-  std::string name_space_;
+  string name_space_;
 };
 
 }  // namespace rime

--- a/include/rime/gear/abc_segmentor.h
+++ b/include/rime/gear/abc_segmentor.h
@@ -7,8 +7,6 @@
 #ifndef RIME_ABC_SEGMENTOR_H_
 #define RIME_ABC_SEGMENTOR_H_
 
-#include <set>
-#include <string>
 #include <rime/segmentor.h>
 
 namespace rime {
@@ -20,11 +18,11 @@ class AbcSegmentor : public Segmentor {
   virtual bool Proceed(Segmentation* segmentation);
 
  protected:
-  std::string alphabet_;
-  std::string delimiter_;
-  std::string initials_;
-  std::string finals_;
-  std::set<std::string> extra_tags_;
+  string alphabet_;
+  string delimiter_;
+  string initials_;
+  string finals_;
+  set<string> extra_tags_;
 };
 
 }  // namespace rime

--- a/include/rime/gear/affix_segmentor.h
+++ b/include/rime/gear/affix_segmentor.h
@@ -7,8 +7,6 @@
 #ifndef RIME_AFFIX_SEGMENTOR_H_
 #define RIME_AFFIX_SEGMENTOR_H_
 
-#include <set>
-#include <string>
 #include <rime/segmentor.h>
 
 namespace rime {
@@ -20,12 +18,12 @@ class AffixSegmentor : public Segmentor {
   virtual bool Proceed(Segmentation* segmentation);
 
  protected:
-  std::string tag_;
-  std::string prefix_;
-  std::string suffix_;
-  std::string tips_;
-  std::string closing_tips_;
-  std::set<std::string> extra_tags_;
+  string tag_;
+  string prefix_;
+  string suffix_;
+  string tips_;
+  string closing_tips_;
+  set<string> extra_tags_;
 };
 
 }  // namespace rime

--- a/include/rime/gear/ascii_composer.h
+++ b/include/rime/gear/ascii_composer.h
@@ -8,7 +8,6 @@
 #define RIME_ASCII_COMPOSER_H_
 
 #include <chrono>
-#include <map>
 #include <rime/common.h>
 #include <rime/component.h>
 #include <rime/processor.h>
@@ -26,7 +25,7 @@ enum AsciiModeSwitchStyle {
   kAsciiModeSwitchClear,
 };
 
-using AsciiModeSwitchKeyBindings = std::map<int /* keycode */,
+using AsciiModeSwitchKeyBindings = map<int /* keycode */,
                                             AsciiModeSwitchStyle>;
 
 class AsciiComposer : public Processor {

--- a/include/rime/gear/charset_filter.h
+++ b/include/rime/gear/charset_filter.h
@@ -7,7 +7,6 @@
 #ifndef RIME_CHARSET_FILTER_H_
 #define RIME_CHARSET_FILTER_H_
 
-#include <string>
 #include <rime/filter.h>
 #include <rime/translation.h>
 #include <rime/gear/filter_commons.h>
@@ -16,14 +15,14 @@ namespace rime {
 
 class CharsetFilterTranslation : public Translation {
  public:
-  CharsetFilterTranslation(shared_ptr<Translation> translation);
+  CharsetFilterTranslation(a<Translation> translation);
   virtual bool Next();
-  virtual shared_ptr<Candidate> Peek();
+  virtual a<Candidate> Peek();
 
  protected:
   bool LocateNextCandidate();
 
-  shared_ptr<Translation> translation_;
+  a<Translation> translation_;
 };
 
 struct DictEntry;
@@ -32,7 +31,7 @@ class CharsetFilter : public Filter, TagMatching {
  public:
   explicit CharsetFilter(const Ticket& ticket);
 
-  virtual shared_ptr<Translation> Apply(shared_ptr<Translation> translation,
+  virtual a<Translation> Apply(a<Translation> translation,
                                         CandidateList* candidates);
 
   virtual bool AppliesToSegment(Segment* segment) {
@@ -40,8 +39,8 @@ class CharsetFilter : public Filter, TagMatching {
   }
 
   // return true to accept, false to reject the tested item
-  static bool FilterText(const std::string& text);
-  static bool FilterDictEntry(shared_ptr<DictEntry> entry);
+  static bool FilterText(const string& text);
+  static bool FilterDictEntry(a<DictEntry> entry);
 };
 
 }  // namespace rime

--- a/include/rime/gear/charset_filter.h
+++ b/include/rime/gear/charset_filter.h
@@ -15,14 +15,14 @@ namespace rime {
 
 class CharsetFilterTranslation : public Translation {
  public:
-  CharsetFilterTranslation(a<Translation> translation);
+  CharsetFilterTranslation(an<Translation> translation);
   virtual bool Next();
-  virtual a<Candidate> Peek();
+  virtual an<Candidate> Peek();
 
  protected:
   bool LocateNextCandidate();
 
-  a<Translation> translation_;
+  an<Translation> translation_;
 };
 
 struct DictEntry;
@@ -31,7 +31,7 @@ class CharsetFilter : public Filter, TagMatching {
  public:
   explicit CharsetFilter(const Ticket& ticket);
 
-  virtual a<Translation> Apply(a<Translation> translation,
+  virtual an<Translation> Apply(an<Translation> translation,
                                         CandidateList* candidates);
 
   virtual bool AppliesToSegment(Segment* segment) {
@@ -40,7 +40,7 @@ class CharsetFilter : public Filter, TagMatching {
 
   // return true to accept, false to reject the tested item
   static bool FilterText(const string& text);
-  static bool FilterDictEntry(a<DictEntry> entry);
+  static bool FilterDictEntry(an<DictEntry> entry);
 };
 
 }  // namespace rime

--- a/include/rime/gear/chord_composer.h
+++ b/include/rime/gear/chord_composer.h
@@ -7,7 +7,6 @@
 #ifndef RIME_CHORD_COMPOSER_H_
 #define RIME_CHORD_COMPOSER_H_
 
-#include <set>
 #include <rime/common.h>
 #include <rime/component.h>
 #include <rime/processor.h>
@@ -23,7 +22,7 @@ class ChordComposer : public Processor {
   virtual ProcessResult ProcessKeyEvent(const KeyEvent& key_event);
 
  protected:
-  std::string SerializeChord();
+  string SerializeChord();
   void UpdateChord();
   void FinishChord();
   void ClearChord();
@@ -31,17 +30,17 @@ class ChordComposer : public Processor {
   void OnContextUpdate(Context* ctx);
   void OnUnhandledKey(Context* ctx, const KeyEvent& key);
 
-  std::string alphabet_;
-  std::string delimiter_;
+  string alphabet_;
+  string delimiter_;
   Projection algebra_;
   Projection output_format_;
   Projection prompt_format_;
 
-  std::set<char> pressed_;
-  std::set<char> chord_;
+  set<char> pressed_;
+  set<char> chord_;
   bool pass_thru_ = false;
   bool composing_ = false;
-  std::string sequence_;
+  string sequence_;
   connection update_connection_;
   connection unhandled_key_connection_;
 };

--- a/include/rime/gear/echo_translator.h
+++ b/include/rime/gear/echo_translator.h
@@ -15,7 +15,7 @@ class EchoTranslator : public Translator {
  public:
   EchoTranslator(const Ticket& ticket);
 
-  virtual a<Translation> Query(const string& input,
+  virtual an<Translation> Query(const string& input,
                                         const Segment& segment);
 };
 

--- a/include/rime/gear/echo_translator.h
+++ b/include/rime/gear/echo_translator.h
@@ -15,7 +15,7 @@ class EchoTranslator : public Translator {
  public:
   EchoTranslator(const Ticket& ticket);
 
-  virtual shared_ptr<Translation> Query(const std::string& input,
+  virtual a<Translation> Query(const string& input,
                                         const Segment& segment);
 };
 

--- a/include/rime/gear/editor.h
+++ b/include/rime/gear/editor.h
@@ -7,7 +7,6 @@
 #ifndef RIME_EDITOR_H_
 #define RIME_EDITOR_H_
 
-#include <map>
 #include <rime/common.h>
 #include <rime/component.h>
 #include <rime/key_event.h>
@@ -23,7 +22,7 @@ class Editor : public Processor {
   typedef ProcessResult CharHandler(Context* ctx, int ch);
   using HandlerPtr = void (Editor::*)(Context* ctx);
   using CharHandlerPtr = ProcessResult (Editor::*)(Context* ctx, int ch);
-  using KeyBindings = std::map<KeyEvent, HandlerPtr>;
+  using KeyBindings = map<KeyEvent, HandlerPtr>;
 
   Editor(const Ticket& ticket, bool auto_commit);
   ProcessResult ProcessKeyEvent(const KeyEvent& key_event);

--- a/include/rime/gear/fallback_segmentor.h
+++ b/include/rime/gear/fallback_segmentor.h
@@ -7,7 +7,6 @@
 #ifndef RIME_FALLBACK_SEGMENTOR_H_
 #define RIME_FALLBACK_SEGMENTOR_H_
 
-#include <string>
 #include <rime/segmentor.h>
 
 namespace rime {

--- a/include/rime/gear/filter_commons.h
+++ b/include/rime/gear/filter_commons.h
@@ -7,8 +7,6 @@
 #ifndef RIME_FILTER_COMMONS_H_
 #define RIME_FILTER_COMMONS_H_
 
-#include <string>
-#include <vector>
 
 namespace rime {
 
@@ -21,7 +19,7 @@ class TagMatching {
   bool TagsMatch(Segment* segment);
 
  protected:
-  std::vector<std::string> tags_;
+  vector<string> tags_;
 };
 
 }  // namespace rime

--- a/include/rime/gear/key_binder.h
+++ b/include/rime/gear/key_binder.h
@@ -26,7 +26,7 @@ class KeyBinder : public Processor {
   bool ReinterpretPagingKey(const KeyEvent& key_event);
   void PerformKeyBinding(const KeyBinding& binding);
 
-  unique_ptr<KeyBindings> key_bindings_;
+  the<KeyBindings> key_bindings_;
   bool redirecting_;
   int last_key_;
 };

--- a/include/rime/gear/memory.h
+++ b/include/rime/gear/memory.h
@@ -7,8 +7,6 @@
 #ifndef RIME_MEMORY_H_
 #define RIME_MEMORY_H_
 
-#include <string>
-#include <vector>
 #include <rime/common.h>
 #include <rime/dict/vocabulary.h>
 
@@ -23,13 +21,13 @@ class Phrase;
 class Memory;
 
 struct CommitEntry : DictEntry {
-  std::vector<const DictEntry*> elements;
+  vector<const DictEntry*> elements;
   Memory* memory;
 
   CommitEntry(Memory* a_memory = NULL) : memory(a_memory) {}
   bool empty() const { return text.empty(); }
   void Clear();
-  void AppendPhrase(const shared_ptr<Phrase>& phrase);
+  void AppendPhrase(const a<Phrase>& phrase);
   bool Save() const;
 };
 
@@ -57,8 +55,8 @@ class Memory {
   void OnDeleteEntry(Context* ctx);
   void OnUnhandledKey(Context* ctx, const KeyEvent& key);
 
-  unique_ptr<Dictionary> dict_;
-  unique_ptr<UserDictionary> user_dict_;
+  the<Dictionary> dict_;
+  the<UserDictionary> user_dict_;
 
  private:
   connection commit_connection_;

--- a/include/rime/gear/memory.h
+++ b/include/rime/gear/memory.h
@@ -27,7 +27,7 @@ struct CommitEntry : DictEntry {
   CommitEntry(Memory* a_memory = NULL) : memory(a_memory) {}
   bool empty() const { return text.empty(); }
   void Clear();
-  void AppendPhrase(const a<Phrase>& phrase);
+  void AppendPhrase(const an<Phrase>& phrase);
   bool Save() const;
 };
 

--- a/include/rime/gear/navigator.h
+++ b/include/rime/gear/navigator.h
@@ -7,7 +7,6 @@
 #ifndef RIME_NAVIGATOR_H_
 #define RIME_NAVIGATOR_H_
 
-#include <string>
 #include <rime/common.h>
 #include <rime/component.h>
 #include <rime/processor.h>
@@ -30,7 +29,7 @@ class Navigator : public Processor {
   bool Home(Context* ctx);
   bool End(Context* ctx);
 
-  std::string input_;
+  string input_;
   Spans spans_;
 };
 

--- a/include/rime/gear/poet.h
+++ b/include/rime/gear/poet.h
@@ -23,7 +23,7 @@ class Poet {
  public:
   Poet(Language* language) : language_(language) {}
 
-  a<Sentence> MakeSentence(const WordGraph& graph,
+  an<Sentence> MakeSentence(const WordGraph& graph,
                                     size_t total_length);
  protected:
   Language* language_;

--- a/include/rime/gear/poet.h
+++ b/include/rime/gear/poet.h
@@ -15,7 +15,7 @@
 
 namespace rime {
 
-using WordGraph = std::map<int, UserDictEntryCollector>;
+using WordGraph = map<int, UserDictEntryCollector>;
 
 class Language;
 
@@ -23,7 +23,7 @@ class Poet {
  public:
   Poet(Language* language) : language_(language) {}
 
-  shared_ptr<Sentence> MakeSentence(const WordGraph& graph,
+  a<Sentence> MakeSentence(const WordGraph& graph,
                                     size_t total_length);
  protected:
   Language* language_;

--- a/include/rime/gear/punctuator.h
+++ b/include/rime/gear/punctuator.h
@@ -21,13 +21,13 @@ class Engine;
 class PunctConfig {
  public:
   void LoadConfig(Engine* engine, bool load_symbols = false);
-  a<ConfigItem> GetPunctDefinition(const string key);
+  an<ConfigItem> GetPunctDefinition(const string key);
  protected:
-  a<ConfigMap> mapping_;
-  a<ConfigMap> preset_mapping_;
+  an<ConfigMap> mapping_;
+  an<ConfigMap> preset_mapping_;
   string shape_;
-  a<ConfigMap> symbols_;
-  a<ConfigMap> preset_symbols_;
+  an<ConfigMap> symbols_;
+  an<ConfigMap> preset_symbols_;
 };
 
 class Punctuator : public Processor {
@@ -36,14 +36,14 @@ class Punctuator : public Processor {
   virtual ProcessResult ProcessKeyEvent(const KeyEvent& key_event);
 
  protected:
-  bool ConfirmUniquePunct(const a<ConfigItem>& definition);
-  bool AlternatePunct(const string& key, const a<ConfigItem>& definition);
-  bool AutoCommitPunct(const a<ConfigItem>& definition);
-  bool PairPunct(const a<ConfigItem>& definition);
+  bool ConfirmUniquePunct(const an<ConfigItem>& definition);
+  bool AlternatePunct(const string& key, const an<ConfigItem>& definition);
+  bool AutoCommitPunct(const an<ConfigItem>& definition);
+  bool PairPunct(const an<ConfigItem>& definition);
 
   PunctConfig config_;
   bool use_space_ = false;
-  map<a<ConfigItem>, int> oddness_;
+  map<an<ConfigItem>, int> oddness_;
 };
 
 class PunctSegmentor : public Segmentor {
@@ -58,26 +58,26 @@ class PunctSegmentor : public Segmentor {
 class PunctTranslator : public Translator {
  public:
   PunctTranslator(const Ticket& ticket);
-  virtual a<Translation> Query(const string& input,
+  virtual an<Translation> Query(const string& input,
                                         const Segment& segment);
 
  protected:
-  a<Translation>
+  an<Translation>
   TranslateUniquePunct(const string& key,
                        const Segment& segment,
-                       const a<ConfigValue>& definition);
-  a<Translation>
+                       const an<ConfigValue>& definition);
+  an<Translation>
   TranslateAlternatingPunct(const string& key,
                             const Segment& segment,
-                            const a<ConfigList>& definition);
-  a<Translation>
+                            const an<ConfigList>& definition);
+  an<Translation>
   TranslateAutoCommitPunct(const string& key,
                            const Segment& segment,
-                           const a<ConfigMap>& definition);
-  a<Translation>
+                           const an<ConfigMap>& definition);
+  an<Translation>
   TranslatePairedPunct(const string& key,
                        const Segment& segment,
-                       const a<ConfigMap>& definition);
+                       const an<ConfigMap>& definition);
 
   PunctConfig config_;
 };

--- a/include/rime/gear/punctuator.h
+++ b/include/rime/gear/punctuator.h
@@ -7,7 +7,6 @@
 #ifndef RIME_PUNCTUATOR_H_
 #define RIME_PUNCTUATOR_H_
 
-#include <map>
 #include <rime/common.h>
 #include <rime/component.h>
 #include <rime/config.h>
@@ -22,11 +21,11 @@ class Engine;
 class PunctConfig {
  public:
   void LoadConfig(Engine* engine, bool load_symbols = false);
-  ConfigItemPtr GetPunctDefinition(const std::string key);
+  ConfigItemPtr GetPunctDefinition(const string key);
  protected:
   ConfigMapPtr mapping_;
   ConfigMapPtr preset_mapping_;
-  std::string shape_;
+  string shape_;
   ConfigMapPtr symbols_;
   ConfigMapPtr preset_symbols_;
 };
@@ -38,13 +37,13 @@ class Punctuator : public Processor {
 
  protected:
   bool ConfirmUniquePunct(const ConfigItemPtr& definition);
-  bool AlternatePunct(const std::string& key, const ConfigItemPtr& definition);
+  bool AlternatePunct(const string& key, const ConfigItemPtr& definition);
   bool AutoCommitPunct(const ConfigItemPtr& definition);
   bool PairPunct(const ConfigItemPtr& definition);
 
   PunctConfig config_;
   bool use_space_ = false;
-  std::map<ConfigItemPtr, int> oddness_;
+  map<ConfigItemPtr, int> oddness_;
 };
 
 class PunctSegmentor : public Segmentor {
@@ -59,24 +58,24 @@ class PunctSegmentor : public Segmentor {
 class PunctTranslator : public Translator {
  public:
   PunctTranslator(const Ticket& ticket);
-  virtual shared_ptr<Translation> Query(const std::string& input,
+  virtual a<Translation> Query(const string& input,
                                         const Segment& segment);
 
  protected:
-  shared_ptr<Translation>
-  TranslateUniquePunct(const std::string& key,
+  a<Translation>
+  TranslateUniquePunct(const string& key,
                        const Segment& segment,
                        const ConfigValuePtr& definition);
-  shared_ptr<Translation>
-  TranslateAlternatingPunct(const std::string& key,
+  a<Translation>
+  TranslateAlternatingPunct(const string& key,
                             const Segment& segment,
                             const ConfigListPtr& definition);
-  shared_ptr<Translation>
-  TranslateAutoCommitPunct(const std::string& key,
+  a<Translation>
+  TranslateAutoCommitPunct(const string& key,
                            const Segment& segment,
                            const ConfigMapPtr& definition);
-  shared_ptr<Translation>
-  TranslatePairedPunct(const std::string& key,
+  a<Translation>
+  TranslatePairedPunct(const string& key,
                        const Segment& segment,
                        const ConfigMapPtr& definition);
 

--- a/include/rime/gear/punctuator.h
+++ b/include/rime/gear/punctuator.h
@@ -21,13 +21,13 @@ class Engine;
 class PunctConfig {
  public:
   void LoadConfig(Engine* engine, bool load_symbols = false);
-  ConfigItemPtr GetPunctDefinition(const string key);
+  a<ConfigItem> GetPunctDefinition(const string key);
  protected:
-  ConfigMapPtr mapping_;
-  ConfigMapPtr preset_mapping_;
+  a<ConfigMap> mapping_;
+  a<ConfigMap> preset_mapping_;
   string shape_;
-  ConfigMapPtr symbols_;
-  ConfigMapPtr preset_symbols_;
+  a<ConfigMap> symbols_;
+  a<ConfigMap> preset_symbols_;
 };
 
 class Punctuator : public Processor {
@@ -36,14 +36,14 @@ class Punctuator : public Processor {
   virtual ProcessResult ProcessKeyEvent(const KeyEvent& key_event);
 
  protected:
-  bool ConfirmUniquePunct(const ConfigItemPtr& definition);
-  bool AlternatePunct(const string& key, const ConfigItemPtr& definition);
-  bool AutoCommitPunct(const ConfigItemPtr& definition);
-  bool PairPunct(const ConfigItemPtr& definition);
+  bool ConfirmUniquePunct(const a<ConfigItem>& definition);
+  bool AlternatePunct(const string& key, const a<ConfigItem>& definition);
+  bool AutoCommitPunct(const a<ConfigItem>& definition);
+  bool PairPunct(const a<ConfigItem>& definition);
 
   PunctConfig config_;
   bool use_space_ = false;
-  map<ConfigItemPtr, int> oddness_;
+  map<a<ConfigItem>, int> oddness_;
 };
 
 class PunctSegmentor : public Segmentor {
@@ -65,19 +65,19 @@ class PunctTranslator : public Translator {
   a<Translation>
   TranslateUniquePunct(const string& key,
                        const Segment& segment,
-                       const ConfigValuePtr& definition);
+                       const a<ConfigValue>& definition);
   a<Translation>
   TranslateAlternatingPunct(const string& key,
                             const Segment& segment,
-                            const ConfigListPtr& definition);
+                            const a<ConfigList>& definition);
   a<Translation>
   TranslateAutoCommitPunct(const string& key,
                            const Segment& segment,
-                           const ConfigMapPtr& definition);
+                           const a<ConfigMap>& definition);
   a<Translation>
   TranslatePairedPunct(const string& key,
                        const Segment& segment,
-                       const ConfigMapPtr& definition);
+                       const a<ConfigMap>& definition);
 
   PunctConfig config_;
 };

--- a/include/rime/gear/recognizer.h
+++ b/include/rime/gear/recognizer.h
@@ -7,8 +7,6 @@
 #ifndef RIME_RECOGNIZER_H_
 #define RIME_RECOGNIZER_H_
 
-#include <map>
-#include <string>
 #include <boost/regex.hpp>
 #include <rime/common.h>
 #include <rime/processor.h>
@@ -19,20 +17,20 @@ class Config;
 class Segmentation;
 
 struct RecognizerMatch {
-  std::string tag;
+  string tag;
   size_t start = 0, end = 0;
 
   RecognizerMatch() = default;
-  RecognizerMatch(const std::string& a_tag, size_t a_start, size_t an_end)
+  RecognizerMatch(const string& a_tag, size_t a_start, size_t an_end)
       : tag(a_tag), start(a_start), end(an_end) {}
 
   bool found() const { return start < end; }
 };
 
-class RecognizerPatterns : public std::map<std::string, boost::regex> {
+class RecognizerPatterns : public map<string, boost::regex> {
  public:
   void LoadConfig(Config* config);
-  RecognizerMatch GetMatch(const std::string& input,
+  RecognizerMatch GetMatch(const string& input,
                            const Segmentation& segmentation) const;
 };
 

--- a/include/rime/gear/reverse_lookup_filter.h
+++ b/include/rime/gear/reverse_lookup_filter.h
@@ -20,14 +20,14 @@ class ReverseLookupFilter : public Filter, TagMatching {
  public:
   explicit ReverseLookupFilter(const Ticket& ticket);
 
-  virtual a<Translation> Apply(a<Translation> translation,
+  virtual an<Translation> Apply(an<Translation> translation,
                                         CandidateList* candidates);
 
   virtual bool AppliesToSegment(Segment* segment) {
     return TagsMatch(segment);
   }
 
-  void Process(const a<Candidate>& cand);
+  void Process(const an<Candidate>& cand);
 
  protected:
   void Initialize();

--- a/include/rime/gear/reverse_lookup_filter.h
+++ b/include/rime/gear/reverse_lookup_filter.h
@@ -20,20 +20,20 @@ class ReverseLookupFilter : public Filter, TagMatching {
  public:
   explicit ReverseLookupFilter(const Ticket& ticket);
 
-  virtual shared_ptr<Translation> Apply(shared_ptr<Translation> translation,
+  virtual a<Translation> Apply(a<Translation> translation,
                                         CandidateList* candidates);
 
   virtual bool AppliesToSegment(Segment* segment) {
     return TagsMatch(segment);
   }
 
-  void Process(const shared_ptr<Candidate>& cand);
+  void Process(const a<Candidate>& cand);
 
  protected:
   void Initialize();
 
   bool initialized_ = false;
-  unique_ptr<ReverseLookupDictionary> rev_dict_;
+  the<ReverseLookupDictionary> rev_dict_;
   // settings
   bool overwrite_comment_ = false;
   Projection comment_formatter_;

--- a/include/rime/gear/reverse_lookup_translator.h
+++ b/include/rime/gear/reverse_lookup_translator.h
@@ -7,7 +7,6 @@
 #ifndef RIME_REVERSE_LOOKUP_TRANSLATOR_H_
 #define RIME_REVERSE_LOOKUP_TRANSLATOR_H_
 
-#include <string>
 #include <rime/common.h>
 #include <rime/translator.h>
 #include <rime/algo/algebra.h>
@@ -22,20 +21,20 @@ class ReverseLookupTranslator : public Translator {
  public:
   ReverseLookupTranslator(const Ticket& ticket);
 
-  virtual shared_ptr<Translation> Query(const std::string& input,
+  virtual a<Translation> Query(const string& input,
                                         const Segment& segment);
 
  protected:
   void Initialize();
 
-  std::string tag_;
+  string tag_;
   bool initialized_ = false;
-  unique_ptr<Dictionary> dict_;
-  unique_ptr<ReverseLookupDictionary> rev_dict_;
-  unique_ptr<TranslatorOptions> options_;
-  std::string prefix_;
-  std::string suffix_;
-  std::string tips_;
+  the<Dictionary> dict_;
+  the<ReverseLookupDictionary> rev_dict_;
+  the<TranslatorOptions> options_;
+  string prefix_;
+  string suffix_;
+  string tips_;
 };
 
 }  // namespace rime

--- a/include/rime/gear/reverse_lookup_translator.h
+++ b/include/rime/gear/reverse_lookup_translator.h
@@ -21,7 +21,7 @@ class ReverseLookupTranslator : public Translator {
  public:
   ReverseLookupTranslator(const Ticket& ticket);
 
-  virtual a<Translation> Query(const string& input,
+  virtual an<Translation> Query(const string& input,
                                         const Segment& segment);
 
  protected:

--- a/include/rime/gear/schema_list_translator.h
+++ b/include/rime/gear/schema_list_translator.h
@@ -7,6 +7,7 @@
 #ifndef RIME_SCHEMA_LIST_TRANSLATOR_H_
 #define RIME_SCHEMA_LIST_TRANSLATOR_H_
 
+#include <rime/common.h>
 #include <rime/translator.h>
 
 namespace rime {
@@ -15,7 +16,7 @@ class SchemaListTranslator : public Translator {
  public:
   SchemaListTranslator(const Ticket& ticket);
 
-  virtual shared_ptr<Translation> Query(const std::string& input,
+  virtual a<Translation> Query(const string& input,
                                         const Segment& segment);
 };
 

--- a/include/rime/gear/schema_list_translator.h
+++ b/include/rime/gear/schema_list_translator.h
@@ -16,7 +16,7 @@ class SchemaListTranslator : public Translator {
  public:
   SchemaListTranslator(const Ticket& ticket);
 
-  virtual a<Translation> Query(const string& input,
+  virtual an<Translation> Query(const string& input,
                                         const Segment& segment);
 };
 

--- a/include/rime/gear/script_translator.h
+++ b/include/rime/gear/script_translator.h
@@ -7,7 +7,6 @@
 #ifndef RIME_SCRIPT_TRANSLATOR_H_
 #define RIME_SCRIPT_TRANSLATOR_H_
 
-#include <string>
 #include <rime/common.h>
 #include <rime/translation.h>
 #include <rime/translator.h>
@@ -30,12 +29,12 @@ class ScriptTranslator : public Translator,
  public:
   ScriptTranslator(const Ticket& ticket);
 
-  virtual shared_ptr<Translation> Query(const std::string& input,
+  virtual a<Translation> Query(const string& input,
                                         const Segment& segment);
   virtual bool Memorize(const CommitEntry& commit_entry);
 
-  std::string FormatPreedit(const std::string& preedit);
-  std::string Spell(const Code& code);
+  string FormatPreedit(const string& preedit);
+  string Spell(const Code& code);
 
   // options
   int spelling_hints() const { return spelling_hints_; }

--- a/include/rime/gear/script_translator.h
+++ b/include/rime/gear/script_translator.h
@@ -29,7 +29,7 @@ class ScriptTranslator : public Translator,
  public:
   ScriptTranslator(const Ticket& ticket);
 
-  virtual a<Translation> Query(const string& input,
+  virtual an<Translation> Query(const string& input,
                                         const Segment& segment);
   virtual bool Memorize(const CommitEntry& commit_entry);
 

--- a/include/rime/gear/shape.h
+++ b/include/rime/gear/shape.h
@@ -17,7 +17,7 @@ class ShapeFormatter : public Formatter {
  public:
   ShapeFormatter(const Ticket& ticket) : Formatter(ticket) {
   }
-  virtual void Format(std::string* text);
+  virtual void Format(string* text);
 };
 
 class ShapeProcessor : public Processor {

--- a/include/rime/gear/simplifier.h
+++ b/include/rime/gear/simplifier.h
@@ -18,7 +18,7 @@ class Simplifier : public Filter, TagMatching {
  public:
   explicit Simplifier(const Ticket& ticket);
 
-  virtual a<Translation> Apply(a<Translation> translation,
+  virtual an<Translation> Apply(an<Translation> translation,
                                         CandidateList* candidates);
 
 
@@ -26,7 +26,7 @@ class Simplifier : public Filter, TagMatching {
     return TagsMatch(segment);
   }
 
-  bool Convert(const a<Candidate>& original,
+  bool Convert(const an<Candidate>& original,
                CandidateQueue* result);
 
  protected:

--- a/include/rime/gear/simplifier.h
+++ b/include/rime/gear/simplifier.h
@@ -7,8 +7,6 @@
 #ifndef RIME_SIMPLIFIER_H_
 #define RIME_SIMPLIFIER_H_
 
-#include <set>
-#include <string>
 #include <rime/filter.h>
 #include <rime/gear/filter_commons.h>
 
@@ -20,7 +18,7 @@ class Simplifier : public Filter, TagMatching {
  public:
   explicit Simplifier(const Ticket& ticket);
 
-  virtual shared_ptr<Translation> Apply(shared_ptr<Translation> translation,
+  virtual a<Translation> Apply(a<Translation> translation,
                                         CandidateList* candidates);
 
 
@@ -28,7 +26,7 @@ class Simplifier : public Filter, TagMatching {
     return TagsMatch(segment);
   }
 
-  bool Convert(const shared_ptr<Candidate>& original,
+  bool Convert(const a<Candidate>& original,
                CandidateQueue* result);
 
  protected:
@@ -37,12 +35,12 @@ class Simplifier : public Filter, TagMatching {
   void Initialize();
 
   bool initialized_ = false;
-  unique_ptr<Opencc> opencc_;
+  the<Opencc> opencc_;
   // settings
   TipsLevel tips_level_ =  kTipsNone;
-  std::string option_name_;
-  std::string opencc_config_;
-  std::set<std::string> excluded_types_;
+  string option_name_;
+  string opencc_config_;
+  set<string> excluded_types_;
 };
 
 }  // namespace rime

--- a/include/rime/gear/single_char_filter.h
+++ b/include/rime/gear/single_char_filter.h
@@ -15,7 +15,7 @@ class SingleCharFilter : public Filter {
  public:
   explicit SingleCharFilter(const Ticket& ticket);
 
-  virtual shared_ptr<Translation> Apply(shared_ptr<Translation> translation,
+  virtual a<Translation> Apply(a<Translation> translation,
                                         CandidateList* candidates);
 };
 

--- a/include/rime/gear/single_char_filter.h
+++ b/include/rime/gear/single_char_filter.h
@@ -15,7 +15,7 @@ class SingleCharFilter : public Filter {
  public:
   explicit SingleCharFilter(const Ticket& ticket);
 
-  virtual a<Translation> Apply(a<Translation> translation,
+  virtual an<Translation> Apply(an<Translation> translation,
                                         CandidateList* candidates);
 };
 

--- a/include/rime/gear/speller.h
+++ b/include/rime/gear/speller.h
@@ -29,10 +29,10 @@ class Speller : public Processor {
   bool AutoSelectPreviousMatch(Context* ctx, Segment* previous_segment);
   bool FindEarlierMatch(Context* ctx, size_t start, size_t end);
 
-  std::string alphabet_;
-  std::string delimiters_;
-  std::string initials_;
-  std::string finals_;
+  string alphabet_;
+  string delimiters_;
+  string initials_;
+  string finals_;
   int max_code_length_ = 0;
   bool auto_select_ = false;
   bool use_space_ = false;

--- a/include/rime/gear/switch_translator.h
+++ b/include/rime/gear/switch_translator.h
@@ -15,7 +15,7 @@ class SwitchTranslator : public Translator {
  public:
   SwitchTranslator(const Ticket& ticket);
 
-  virtual shared_ptr<Translation> Query(const std::string& input,
+  virtual a<Translation> Query(const string& input,
                                         const Segment& segment);
 };
 

--- a/include/rime/gear/switch_translator.h
+++ b/include/rime/gear/switch_translator.h
@@ -15,7 +15,7 @@ class SwitchTranslator : public Translator {
  public:
   SwitchTranslator(const Ticket& ticket);
 
-  virtual a<Translation> Query(const string& input,
+  virtual an<Translation> Query(const string& input,
                                         const Segment& segment);
 };
 

--- a/include/rime/gear/table_translator.h
+++ b/include/rime/gear/table_translator.h
@@ -7,7 +7,6 @@
 #ifndef RIME_TABLE_TRANSLATOR_H_
 #define RIME_TABLE_TRANSLATOR_H_
 
-#include <string>
 #include <rime/common.h>
 #include <rime/config.h>
 #include <rime/translation.h>
@@ -28,11 +27,11 @@ class TableTranslator : public Translator,
  public:
   TableTranslator(const Ticket& ticket);
 
-  virtual shared_ptr<Translation> Query(const std::string& input,
+  virtual a<Translation> Query(const string& input,
                                         const Segment& segment);
   virtual bool Memorize(const CommitEntry& commit_entry);
 
-  shared_ptr<Translation> MakeSentence(const std::string& input,
+  a<Translation> MakeSentence(const string& input,
                                        size_t start,
                                        bool include_prefix_phrases = false);
 
@@ -45,23 +44,23 @@ class TableTranslator : public Translator,
   bool sentence_over_completion_ = false;
   bool encode_commit_history_ = true;
   int max_phrase_length_ = 5;
-  unique_ptr<UnityTableEncoder> encoder_;
+  the<UnityTableEncoder> encoder_;
 };
 
 class TableTranslation : public Translation {
  public:
 
   TableTranslation(TranslatorOptions* options, Language* language,
-                   const std::string& input, size_t start, size_t end,
-                   const std::string& preedit);
+                   const string& input, size_t start, size_t end,
+                   const string& preedit);
   TableTranslation(TranslatorOptions* options, Language* language,
-                   const std::string& input, size_t start, size_t end,
-                   const std::string& preedit,
+                   const string& input, size_t start, size_t end,
+                   const string& preedit,
                    const DictEntryIterator& iter,
                    const UserDictEntryIterator& uter = UserDictEntryIterator());
 
   virtual bool Next();
-  virtual shared_ptr<Candidate> Peek();
+  virtual a<Candidate> Peek();
 
  protected:
   virtual bool FetchMoreUserPhrases() { return false; }
@@ -70,16 +69,16 @@ class TableTranslation : public Translation {
   bool CheckEmpty();
   bool PreferUserPhrase();
 
-  shared_ptr<DictEntry> PreferedEntry(bool prefer_user_phrase) {
+  a<DictEntry> PreferedEntry(bool prefer_user_phrase) {
     return prefer_user_phrase ? uter_.Peek() : iter_.Peek();
   }
 
   TranslatorOptions* options_;
   Language* language_;
-  std::string input_;
+  string input_;
   size_t start_;
   size_t end_;
-  std::string preedit_;
+  string preedit_;
   DictEntryIterator iter_;
   UserDictEntryIterator uter_;
 };

--- a/include/rime/gear/table_translator.h
+++ b/include/rime/gear/table_translator.h
@@ -27,11 +27,11 @@ class TableTranslator : public Translator,
  public:
   TableTranslator(const Ticket& ticket);
 
-  virtual a<Translation> Query(const string& input,
+  virtual an<Translation> Query(const string& input,
                                         const Segment& segment);
   virtual bool Memorize(const CommitEntry& commit_entry);
 
-  a<Translation> MakeSentence(const string& input,
+  an<Translation> MakeSentence(const string& input,
                                        size_t start,
                                        bool include_prefix_phrases = false);
 
@@ -60,7 +60,7 @@ class TableTranslation : public Translation {
                    const UserDictEntryIterator& uter = UserDictEntryIterator());
 
   virtual bool Next();
-  virtual a<Candidate> Peek();
+  virtual an<Candidate> Peek();
 
  protected:
   virtual bool FetchMoreUserPhrases() { return false; }
@@ -69,7 +69,7 @@ class TableTranslation : public Translation {
   bool CheckEmpty();
   bool PreferUserPhrase();
 
-  a<DictEntry> PreferedEntry(bool prefer_user_phrase) {
+  an<DictEntry> PreferedEntry(bool prefer_user_phrase) {
     return prefer_user_phrase ? uter_.Peek() : iter_.Peek();
   }
 

--- a/include/rime/gear/translator_commons.h
+++ b/include/rime/gear/translator_commons.h
@@ -7,9 +7,6 @@
 #ifndef RIME_TRANSLATOR_COMMONS_H_
 #define RIME_TRANSLATOR_COMMONS_H_
 
-#include <set>
-#include <string>
-#include <vector>
 #include <boost/regex.hpp>
 #include <rime/common.h>
 #include <rime/config.h>
@@ -23,7 +20,7 @@ namespace rime {
 
 //
 
-class Patterns : public std::vector<boost::regex> {
+class Patterns : public vector<boost::regex> {
  public:
   bool Load(ConfigListPtr patterns);
 };
@@ -46,12 +43,12 @@ class Spans {
   size_t end() const {
     return vertices_.empty() ? 0 : vertices_.back();
   }
-  void set_vertices(std::vector<size_t>&& vertices) {
+  void set_vertices(vector<size_t>&& vertices) {
     vertices_ = vertices;
   }
 
  private:
-  std::vector<size_t> vertices_;
+  vector<size_t> vertices_;
 };
 
 class Phrase;
@@ -70,22 +67,22 @@ class Language;
 class Phrase : public Candidate {
  public:
   Phrase(Language* language,
-         const std::string& type, size_t start, size_t end,
-         const shared_ptr<DictEntry>& entry)
+         const string& type, size_t start, size_t end,
+         const a<DictEntry>& entry)
       : Candidate(type, start, end),
         language_(language),
         entry_(entry) {
   }
-  const std::string& text() const { return entry_->text; }
-  std::string comment() const { return entry_->comment; }
-  std::string preedit() const { return entry_->preedit; }
-  void set_comment(const std::string& comment) {
+  const string& text() const { return entry_->text; }
+  string comment() const { return entry_->comment; }
+  string preedit() const { return entry_->preedit; }
+  void set_comment(const string& comment) {
     entry_->comment = comment;
   }
-  void set_preedit(const std::string& preedit) {
+  void set_preedit(const string& preedit) {
     entry_->preedit = preedit;
   }
-  void set_syllabifier(shared_ptr<PhraseSyllabifier> syllabifier) {
+  void set_syllabifier(a<PhraseSyllabifier> syllabifier) {
     syllabifier_ = syllabifier;
   }
 
@@ -100,8 +97,8 @@ class Phrase : public Candidate {
 
  protected:
   Language* language_;
-  shared_ptr<DictEntry> entry_;
-  shared_ptr<PhraseSyllabifier> syllabifier_;
+  a<DictEntry> entry_;
+  a<PhraseSyllabifier> syllabifier_;
 };
 
 //
@@ -121,16 +118,16 @@ class Sentence : public Phrase {
   void Extend(const DictEntry& entry, size_t end_pos);
   void Offset(size_t offset);
 
-  const std::vector<DictEntry>& components() const {
+  const vector<DictEntry>& components() const {
     return components_;
   }
-  const std::vector<size_t>& syllable_lengths() const {
+  const vector<size_t>& syllable_lengths() const {
     return syllable_lengths_;
   }
 
  protected:
-  std::vector<DictEntry> components_;
-  std::vector<size_t> syllable_lengths_;
+  vector<DictEntry> components_;
+  vector<size_t> syllable_lengths_;
 };
 
 //
@@ -140,11 +137,11 @@ struct Ticket;
 class TranslatorOptions {
  public:
   TranslatorOptions(const Ticket& ticket);
-  bool IsUserDictDisabledFor(const std::string& input) const;
+  bool IsUserDictDisabledFor(const string& input) const;
 
-  const std::string& delimiters() const { return delimiters_; }
-  const std::string& tag() const { return tag_; }
-  void set_tag(const std::string& tag) { tag_ = tag; }
+  const string& delimiters() const { return delimiters_; }
+  const string& tag() const { return tag_; }
+  void set_tag(const string& tag) { tag_ = tag; }
   bool enable_completion() const { return enable_completion_; }
   void set_enable_completion(bool enabled) { enable_completion_ = enabled; }
   bool strict_spelling() const { return strict_spelling_; }
@@ -155,8 +152,8 @@ class TranslatorOptions {
   Projection& comment_formatter() { return comment_formatter_; }
 
  protected:
-  std::string delimiters_;
-  std::string tag_ = "abc";
+  string delimiters_;
+  string tag_ = "abc";
   bool enable_completion_ = true;
   bool strict_spelling_ = false;
   double initial_quality_ = 0.;

--- a/include/rime/gear/translator_commons.h
+++ b/include/rime/gear/translator_commons.h
@@ -22,7 +22,7 @@ namespace rime {
 
 class Patterns : public vector<boost::regex> {
  public:
-  bool Load(ConfigListPtr patterns);
+  bool Load(a<ConfigList> patterns);
 };
 
 //

--- a/include/rime/gear/translator_commons.h
+++ b/include/rime/gear/translator_commons.h
@@ -22,7 +22,7 @@ namespace rime {
 
 class Patterns : public vector<boost::regex> {
  public:
-  bool Load(a<ConfigList> patterns);
+  bool Load(an<ConfigList> patterns);
 };
 
 //
@@ -68,7 +68,7 @@ class Phrase : public Candidate {
  public:
   Phrase(Language* language,
          const string& type, size_t start, size_t end,
-         const a<DictEntry>& entry)
+         const an<DictEntry>& entry)
       : Candidate(type, start, end),
         language_(language),
         entry_(entry) {
@@ -82,7 +82,7 @@ class Phrase : public Candidate {
   void set_preedit(const string& preedit) {
     entry_->preedit = preedit;
   }
-  void set_syllabifier(a<PhraseSyllabifier> syllabifier) {
+  void set_syllabifier(an<PhraseSyllabifier> syllabifier) {
     syllabifier_ = syllabifier;
   }
 
@@ -97,8 +97,8 @@ class Phrase : public Candidate {
 
  protected:
   Language* language_;
-  a<DictEntry> entry_;
-  a<PhraseSyllabifier> syllabifier_;
+  an<DictEntry> entry_;
+  an<PhraseSyllabifier> syllabifier_;
 };
 
 //

--- a/include/rime/gear/uniquifier.h
+++ b/include/rime/gear/uniquifier.h
@@ -15,7 +15,7 @@ class Uniquifier : public Filter {
  public:
   explicit Uniquifier(const Ticket& ticket);
 
-  virtual a<Translation> Apply(a<Translation> translation,
+  virtual an<Translation> Apply(an<Translation> translation,
                                         CandidateList* candidates);
 
 };

--- a/include/rime/gear/uniquifier.h
+++ b/include/rime/gear/uniquifier.h
@@ -15,7 +15,7 @@ class Uniquifier : public Filter {
  public:
   explicit Uniquifier(const Ticket& ticket);
 
-  virtual shared_ptr<Translation> Apply(shared_ptr<Translation> translation,
+  virtual a<Translation> Apply(a<Translation> translation,
                                         CandidateList* candidates);
 
 };

--- a/include/rime/gear/unity_table_encoder.h
+++ b/include/rime/gear/unity_table_encoder.h
@@ -23,25 +23,25 @@ class UnityTableEncoder : public TableEncoder, public PhraseCollector {
 
   bool Load(const Ticket& ticket);
 
-  void CreateEntry(const std::string& word,
-                   const std::string& code_str,
-                   const std::string& weight_str);
-  bool TranslateWord(const std::string& word,
-                     std::vector<std::string>* code);
+  void CreateEntry(const string& word,
+                   const string& code_str,
+                   const string& weight_str);
+  bool TranslateWord(const string& word,
+                     vector<string>* code);
 
   size_t LookupPhrases(UserDictEntryIterator* result,
-                       const std::string& input,
+                       const string& input,
                        bool predictive,
                        size_t limit = 0,
-                       std::string* resume_key = NULL);
+                       string* resume_key = NULL);
 
-  static bool HasPrefix(const std::string& key);
-  static bool AddPrefix(std::string* key);
-  static bool RemovePrefix(std::string* key);
+  static bool HasPrefix(const string& key);
+  static bool AddPrefix(string* key);
+  static bool RemovePrefix(string* key);
 
  protected:
   UserDictionary* user_dict_;
-  unique_ptr<ReverseLookupDictionary> rev_dict_;
+  the<ReverseLookupDictionary> rev_dict_;
 };
 
 }  // namespace rime

--- a/include/rime/key_event.h
+++ b/include/rime/key_event.h
@@ -9,8 +9,6 @@
 #define RIME_KEY_EVENT_H_
 
 #include <iostream>
-#include <string>
-#include <vector>
 #include <rime/common.h>
 #include <rime/key_table.h>
 
@@ -21,7 +19,7 @@ class KeyEvent {
   KeyEvent() = default;
   KeyEvent(int keycode, int modifier)
       : keycode_(keycode), modifier_(modifier) {}
-  KeyEvent(const std::string& repr);
+  KeyEvent(const string& repr);
 
   int keycode() const { return keycode_; }
   void keycode(int value) { keycode_ = value; }
@@ -37,10 +35,10 @@ class KeyEvent {
   // 按鍵表示為形如「狀態+鍵名」的文字
   // 若無鍵名，則以四位或六位十六进制数形式的文字來標識
   // 形如 "0x12ab", "0xfffffe"
-  std::string repr() const;
+  string repr() const;
 
   // 解析文字表示的按鍵
-  bool Parse(const std::string& repr);
+  bool Parse(const string& repr);
 
   bool operator== (const KeyEvent& other) const {
     return keycode_ == other.keycode_ && modifier_ == other.modifier_;
@@ -58,18 +56,18 @@ class KeyEvent {
 };
 
 // 按鍵序列
-class KeySequence : public std::vector<KeyEvent> {
+class KeySequence : public vector<KeyEvent> {
  public:
   KeySequence() = default;
-  KeySequence(const std::string& repr);
+  KeySequence(const string& repr);
 
   // 可表示為一串文字
   // 若其中包含不產生可打印字符的按鍵，以 {鍵名} 來標記
   // 組合鍵也用 {組合鍵狀態+鍵名} 來標記
-  std::string repr() const;
+  string repr() const;
 
   // 解析按鍵序列描述文字
-  bool Parse(const std::string& repr);
+  bool Parse(const string& repr);
 };
 
 inline std::ostream& operator<< (std::ostream& out, const KeyEvent& key_event) {

--- a/include/rime/lever/custom_settings.h
+++ b/include/rime/lever/custom_settings.h
@@ -7,7 +7,6 @@
 #ifndef RIME_CUSTOM_SETTINGS_H_
 #define RIME_CUSTOM_SETTINGS_H_
 
-#include <string>
 #include <rime/config.h>
 
 namespace rime {
@@ -17,16 +16,16 @@ class Deployer;
 class CustomSettings {
  public:
   CustomSettings(Deployer* deployer,
-                 const std::string& config_id,
-                 const std::string& generator_id);
+                 const string& config_id,
+                 const string& generator_id);
   virtual ~CustomSettings() = default;
 
   virtual bool Load();
   virtual bool Save();
-  ConfigValuePtr GetValue(const std::string& key);
-  ConfigListPtr GetList(const std::string& key);
-  ConfigMapPtr GetMap(const std::string& key);
-  bool Customize(const std::string& key, const ConfigItemPtr& item);
+  ConfigValuePtr GetValue(const string& key);
+  ConfigListPtr GetList(const string& key);
+  ConfigMapPtr GetMap(const string& key);
+  bool Customize(const string& key, const ConfigItemPtr& item);
   bool IsFirstRun();
   bool modified() const { return modified_; }
   Config* config() { return &config_; }
@@ -34,8 +33,8 @@ class CustomSettings {
  protected:
   Deployer* deployer_;
   bool modified_ = false;
-  std::string config_id_;
-  std::string generator_id_;
+  string config_id_;
+  string generator_id_;
   Config config_;
   Config custom_config_;
 };

--- a/include/rime/lever/custom_settings.h
+++ b/include/rime/lever/custom_settings.h
@@ -22,10 +22,10 @@ class CustomSettings {
 
   virtual bool Load();
   virtual bool Save();
-  ConfigValuePtr GetValue(const string& key);
-  ConfigListPtr GetList(const string& key);
-  ConfigMapPtr GetMap(const string& key);
-  bool Customize(const string& key, const ConfigItemPtr& item);
+  a<ConfigValue> GetValue(const string& key);
+  a<ConfigList> GetList(const string& key);
+  a<ConfigMap> GetMap(const string& key);
+  bool Customize(const string& key, const a<ConfigItem>& item);
   bool IsFirstRun();
   bool modified() const { return modified_; }
   Config* config() { return &config_; }

--- a/include/rime/lever/custom_settings.h
+++ b/include/rime/lever/custom_settings.h
@@ -22,10 +22,10 @@ class CustomSettings {
 
   virtual bool Load();
   virtual bool Save();
-  a<ConfigValue> GetValue(const string& key);
-  a<ConfigList> GetList(const string& key);
-  a<ConfigMap> GetMap(const string& key);
-  bool Customize(const string& key, const a<ConfigItem>& item);
+  an<ConfigValue> GetValue(const string& key);
+  an<ConfigList> GetList(const string& key);
+  an<ConfigMap> GetMap(const string& key);
+  bool Customize(const string& key, const an<ConfigItem>& item);
   bool IsFirstRun();
   bool modified() const { return modified_; }
   Config* config() { return &config_; }

--- a/include/rime/lever/customizer.h
+++ b/include/rime/lever/customizer.h
@@ -7,7 +7,6 @@
 #ifndef RIME_CUSTOMIZER_H_
 #define RIME_CUSTOMIZER_H_
 
-#include <string>
 #include <boost/filesystem.hpp>
 
 namespace rime {
@@ -16,7 +15,7 @@ class Customizer {
  public:
   Customizer(const boost::filesystem::path& source_path,
              const boost::filesystem::path& dest_path,
-             const std::string& version_key)
+             const string& version_key)
       : source_path_(source_path),
         dest_path_(dest_path),
         version_key_(version_key) {}
@@ -26,7 +25,7 @@ class Customizer {
  protected:
   boost::filesystem::path source_path_;
   boost::filesystem::path dest_path_;
-  std::string version_key_;
+  string version_key_;
 };
 
 }  // namespace rime

--- a/include/rime/lever/deployment_tasks.h
+++ b/include/rime/lever/deployment_tasks.h
@@ -7,7 +7,6 @@
 #ifndef RIME_DEPLOYMENT_TASKS_H_
 #define RIME_DEPLOYMENT_TASKS_H_
 
-#include <string>
 #include <rime/deployer.h>
 
 namespace rime {
@@ -26,37 +25,37 @@ class WorkspaceUpdate : public DeploymentTask {
   bool Run(Deployer* deployer);
 
  protected:
-  std::string GetSchemaPath(Deployer* deployer,
-                            const std::string& schema_id,
+  string GetSchemaPath(Deployer* deployer,
+                            const string& schema_id,
                             bool prefer_shared_copy);
 };
 
 // update a specific schema, build corresponding dictionary
 class SchemaUpdate : public DeploymentTask {
  public:
-  explicit SchemaUpdate(const std::string& schema_file)
+  explicit SchemaUpdate(const string& schema_file)
       : schema_file_(schema_file) {}
   SchemaUpdate(TaskInitializer arg);
   bool Run(Deployer* deployer);
   void set_verbose(bool verbose) { verbose_ = verbose; }
 
  protected:
-  std::string schema_file_;
+  string schema_file_;
   bool verbose_ = false;
 };
 
 // update a specific config file
 class ConfigFileUpdate : public DeploymentTask {
  public:
-  ConfigFileUpdate(const std::string& file_name,
-                   const std::string& version_key)
+  ConfigFileUpdate(const string& file_name,
+                   const string& version_key)
       : file_name_(file_name), version_key_(version_key) {}
   ConfigFileUpdate(TaskInitializer arg);
   bool Run(Deployer* deployer);
 
  protected:
-  std::string file_name_;
-  std::string version_key_;
+  string file_name_;
+  string version_key_;
 };
 
 // for installer

--- a/include/rime/lever/switcher_settings.h
+++ b/include/rime/lever/switcher_settings.h
@@ -7,36 +7,34 @@
 #ifndef RIME_SWITCHER_SETTINGS_H_
 #define RIME_SWITCHER_SETTINGS_H_
 
-#include <string>
-#include <vector>
 #include <boost/filesystem.hpp>
 #include "custom_settings.h"
 
 namespace rime {
 
 struct SchemaInfo {
-  std::string schema_id;
-  std::string name;
-  std::string version;
-  std::string author;
-  std::string description;
-  std::string file_path;
+  string schema_id;
+  string name;
+  string version;
+  string author;
+  string description;
+  string file_path;
 };
 
 class SwitcherSettings : public CustomSettings {
  public:
-  using SchemaList = std::vector<SchemaInfo>;
+  using SchemaList = vector<SchemaInfo>;
   // a list of schema_ids
-  using Selection = std::vector<std::string>;
+  using Selection = vector<string>;
   
   explicit SwitcherSettings(Deployer* deployer);
   bool Load();
   bool Select(Selection selection);
-  bool SetHotkeys(const std::string& hotkeys);
+  bool SetHotkeys(const string& hotkeys);
   
   const SchemaList& available() const { return available_; }
   const Selection& selection() const { return selection_; }
-  const std::string& hotkeys() const { return hotkeys_; }
+  const string& hotkeys() const { return hotkeys_; }
 
  private:
   void GetAvailableSchemasFromDirectory(const boost::filesystem::path& dir);
@@ -45,7 +43,7 @@ class SwitcherSettings : public CustomSettings {
 
   SchemaList available_;
   Selection selection_;
-  std::string hotkeys_;
+  string hotkeys_;
 };
 
 }  // namespace rime

--- a/include/rime/lever/user_dict_manager.h
+++ b/include/rime/lever/user_dict_manager.h
@@ -7,8 +7,6 @@
 #ifndef RIME_USER_DICT_MANAGER_H_
 #define RIME_USER_DICT_MANAGER_H_
 
-#include <string>
-#include <vector>
 #include <boost/filesystem.hpp>
 #include <rime/dict/user_db.h>
 
@@ -16,7 +14,7 @@ namespace rime {
 
 class Deployer;
 
-using UserDictList = std::vector<std::string>;
+using UserDictList = vector<string>;
 
 class UserDictManager {
  public:
@@ -27,15 +25,15 @@ class UserDictManager {
                        UserDb::Component* component = nullptr);
 
   // CAVEAT: the user dict should be closed before the following operations
-  bool Backup(const std::string& dict_name);
-  bool Restore(const std::string& snapshot_file);
-  bool UpgradeUserDict(const std::string& dict_name);
+  bool Backup(const string& dict_name);
+  bool Restore(const string& snapshot_file);
+  bool UpgradeUserDict(const string& dict_name);
   // returns num of exported entires, -1 denotes failure
-  int Export(const std::string& dict_name, const std::string& text_file);
+  int Export(const string& dict_name, const string& text_file);
   // returns num of imported entires, -1 denotes failure
-  int Import(const std::string& dict_name, const std::string& text_file);
+  int Import(const string& dict_name, const string& text_file);
 
-  bool Synchronize(const std::string& dict_name);
+  bool Synchronize(const string& dict_name);
   bool SynchronizeAll();
 
  protected:

--- a/include/rime/menu.h
+++ b/include/rime/menu.h
@@ -27,12 +27,12 @@ class Menu {
  public:
   Menu();
 
-  void AddTranslation(a<Translation> translation);
+  void AddTranslation(an<Translation> translation);
   void AddFilter(Filter* filter);
 
   size_t Prepare(size_t candidate_count);
   Page* CreatePage(size_t page_size, size_t page_no);
-  a<Candidate> GetCandidateAt(size_t index);
+  an<Candidate> GetCandidateAt(size_t index);
 
   // CAVEAT: returns the number of candidates currently obtained,
   // rather than the total number of available candidates.
@@ -41,8 +41,8 @@ class Menu {
   bool empty() const;
 
  private:
-  a<MergedTranslation> merged_;
-  a<Translation> result_;
+  an<MergedTranslation> merged_;
+  an<Translation> result_;
   CandidateList candidates_;
 };
 

--- a/include/rime/menu.h
+++ b/include/rime/menu.h
@@ -7,8 +7,6 @@
 #ifndef RIME_MENU_H_
 #define RIME_MENU_H_
 
-#include <functional>
-#include <vector>
 #include <rime/candidate.h>
 #include <rime/common.h>
 
@@ -29,12 +27,12 @@ class Menu {
  public:
   Menu();
 
-  void AddTranslation(shared_ptr<Translation> translation);
+  void AddTranslation(a<Translation> translation);
   void AddFilter(Filter* filter);
 
   size_t Prepare(size_t candidate_count);
   Page* CreatePage(size_t page_size, size_t page_no);
-  shared_ptr<Candidate> GetCandidateAt(size_t index);
+  a<Candidate> GetCandidateAt(size_t index);
 
   // CAVEAT: returns the number of candidates currently obtained,
   // rather than the total number of available candidates.
@@ -43,8 +41,8 @@ class Menu {
   bool empty() const;
 
  private:
-  shared_ptr<MergedTranslation> merged_;
-  shared_ptr<Translation> result_;
+  a<MergedTranslation> merged_;
+  a<Translation> result_;
   CandidateList candidates_;
 };
 

--- a/include/rime/messenger.h
+++ b/include/rime/messenger.h
@@ -7,15 +7,14 @@
 #ifndef RIME_MESSENGER_H_
 #define RIME_MESSENGER_H_
 
-#include <string>
 #include <rime/common.h>
 
 namespace rime {
 
 class Messenger {
  public:
-  using MessageSink = signal<void (const std::string& message_type,
-                                   const std::string& message_value)>;
+  using MessageSink = signal<void (const string& message_type,
+                                   const string& message_value)>;
 
   MessageSink& message_sink() { return message_sink_; }
 

--- a/include/rime/module.h
+++ b/include/rime/module.h
@@ -7,8 +7,6 @@
 #ifndef RIME_MODULE_H_
 #define RIME_MODULE_H_
 
-#include <map>
-#include <string>
 #include <unordered_set>
 #include <rime/common.h>
 
@@ -20,8 +18,8 @@ namespace rime {
 class ModuleManager {
  public:
   // module is supposed to be a pointer to static variable
-  void Register(const std::string& name, RimeModule* module);
-  RimeModule* Find(const std::string& name);
+  void Register(const string& name, RimeModule* module);
+  RimeModule* Find(const string& name);
 
   void LoadModule(RimeModule* module);
   void UnloadModules();
@@ -32,7 +30,7 @@ class ModuleManager {
   ModuleManager() {}
 
   // module registry
-  using ModuleMap = std::map<std::string, RimeModule*>;
+  using ModuleMap = map<string, RimeModule*>;
   ModuleMap map_;
   // set of loaded modules
   std::unordered_set<RimeModule*> loaded_;

--- a/include/rime/processor.h
+++ b/include/rime/processor.h
@@ -33,7 +33,7 @@ class Processor : public Class<Processor, const Ticket&> {
 
  protected:
   Engine* engine_;
-  std::string name_space_;
+  string name_space_;
 };
 
 }  // namespace rime

--- a/include/rime/registry.h
+++ b/include/rime/registry.h
@@ -7,8 +7,6 @@
 #ifndef RIME_REGISTRY_H_
 #define RIME_REGISTRY_H_
 
-#include <map>
-#include <string>
 #include <rime/common.h>
 
 namespace rime {
@@ -17,11 +15,11 @@ class ComponentBase;
 
 class Registry {
  public:
-  using ComponentMap = std::map<std::string, ComponentBase*>;
+  using ComponentMap = map<string, ComponentBase*>;
 
-  ComponentBase* Find(const std::string& name);
-  void Register(const std::string& name, ComponentBase* component);
-  void Unregister(const std::string& name);
+  ComponentBase* Find(const string& name);
+  void Register(const string& name, ComponentBase* component);
+  void Unregister(const string& name);
   void Clear();
 
   static Registry& instance();

--- a/include/rime/schema.h
+++ b/include/rime/schema.h
@@ -7,7 +7,6 @@
 #ifndef RIME_SCHEMA_H_
 #define RIME_SCHEMA_H_
 
-#include <string>
 #include <rime/common.h>
 #include <rime/config.h>  // for convenience
 
@@ -16,29 +15,29 @@ namespace rime {
 class Schema {
  public:
   Schema();
-  explicit Schema(const std::string& schema_id);
-  Schema(const std::string& schema_id, Config* config)
+  explicit Schema(const string& schema_id);
+  Schema(const string& schema_id, Config* config)
       : schema_id_(schema_id), config_(config) {}
 
-  const std::string& schema_id() const { return schema_id_; }
-  const std::string& schema_name() const { return schema_name_; }
+  const string& schema_id() const { return schema_id_; }
+  const string& schema_name() const { return schema_name_; }
 
   Config* config() const { return config_.get(); }
   void set_config(Config* config) { config_.reset(config); }
 
   int page_size() const { return page_size_; }
-  const std::string& select_keys() const { return select_keys_; }
-  void set_select_keys(const std::string& keys) { select_keys_ = keys; }
+  const string& select_keys() const { return select_keys_; }
+  void set_select_keys(const string& keys) { select_keys_ = keys; }
 
  private:
   void FetchUsefulConfigItems();
 
-  std::string schema_id_;
-  std::string schema_name_;
-  unique_ptr<Config> config_;
+  string schema_id_;
+  string schema_name_;
+  the<Config> config_;
   // frequently used config items
   int page_size_ = 5;
-  std::string select_keys_;
+  string select_keys_;
 };
 
 }  // namespace rime

--- a/include/rime/segmentation.h
+++ b/include/rime/segmentation.h
@@ -26,7 +26,7 @@ struct Segment {
   size_t end = 0;
   size_t length = 0;
   set<string> tags;
-  a<Menu> menu;
+  an<Menu> menu;
   size_t selected_index = 0;
   string prompt;
 
@@ -51,8 +51,8 @@ struct Segment {
     return tags.find(tag) != tags.end();
   }
 
-  a<Candidate> GetCandidateAt(size_t index) const;
-  a<Candidate> GetSelectedCandidate() const;
+  an<Candidate> GetCandidateAt(size_t index) const;
+  an<Candidate> GetSelectedCandidate() const;
 };
 
 class Segmentation : public vector<Segment> {

--- a/include/rime/segmentation.h
+++ b/include/rime/segmentation.h
@@ -7,9 +7,6 @@
 #ifndef RIME_SEGMENTATION_H_
 #define RIME_SEGMENTATION_H_
 
-#include <set>
-#include <string>
-#include <vector>
 #include <rime/common.h>
 
 namespace rime {
@@ -28,10 +25,10 @@ struct Segment {
   size_t start = 0;
   size_t end = 0;
   size_t length = 0;
-  std::set<std::string> tags;
-  shared_ptr<Menu> menu;
+  set<string> tags;
+  a<Menu> menu;
   size_t selected_index = 0;
-  std::string prompt;
+  string prompt;
 
   Segment() = default;
 
@@ -50,19 +47,19 @@ struct Segment {
   void Close();
   bool Reopen(size_t caret_pos);
 
-  bool HasTag(const std::string& tag) const {
+  bool HasTag(const string& tag) const {
     return tags.find(tag) != tags.end();
   }
 
-  shared_ptr<Candidate> GetCandidateAt(size_t index) const;
-  shared_ptr<Candidate> GetSelectedCandidate() const;
+  a<Candidate> GetCandidateAt(size_t index) const;
+  a<Candidate> GetSelectedCandidate() const;
 };
 
-class Segmentation : public std::vector<Segment> {
+class Segmentation : public vector<Segment> {
  public:
   Segmentation();
   virtual ~Segmentation() {}
-  void Reset(const std::string& input);
+  void Reset(const string& input);
   void Reset(size_t num_segments);
   bool AddSegment(const Segment& segment);
 
@@ -74,10 +71,10 @@ class Segmentation : public std::vector<Segment> {
   size_t GetCurrentSegmentLength() const;
   size_t GetConfirmedPosition() const;
 
-  const std::string& input() const { return input_; }
+  const string& input() const { return input_; }
 
  protected:
-  std::string input_;
+  string input_;
 };
 
 std::ostream& operator<< (std::ostream& out,

--- a/include/rime/segmentor.h
+++ b/include/rime/segmentor.h
@@ -25,7 +25,7 @@ class Segmentor : public Class<Segmentor, const Ticket&> {
 
  protected:
   Engine* engine_;
-  std::string name_space_;
+  string name_space_;
 };
 
 }  // namespace rime

--- a/include/rime/service.h
+++ b/include/rime/service.h
@@ -9,8 +9,6 @@
 
 #include <stdint.h>
 #include <time.h>
-#include <functional>
-#include <map>
 #include <mutex>
 #include <rime/common.h>
 #include <rime/deployer.h>
@@ -21,7 +19,7 @@ using SessionId = uintptr_t;
 
 static const SessionId kInvalidSessionId = 0;
 
-using NotificationHandler = std::function<void (SessionId session_id,
+using NotificationHandler = function<void (SessionId session_id,
                                                 const char* message_type,
                                                 const char* message_value)>;
 
@@ -45,14 +43,14 @@ class Session {
   Context* context() const;
   Schema* schema() const;
   time_t last_active_time() const { return last_active_time_; }
-  const std::string& commit_text() const { return commit_text_; }
+  const string& commit_text() const { return commit_text_; }
 
  private:
-  void OnCommit(const std::string& commit_text);
+  void OnCommit(const string& commit_text);
 
-  unique_ptr<Engine> engine_;
+  the<Engine> engine_;
   time_t last_active_time_ = 0;
-  std::string commit_text_;
+  string commit_text_;
 };
 
 class Service {
@@ -63,7 +61,7 @@ class Service {
   void StopService();
 
   SessionId CreateSession();
-  shared_ptr<Session> GetSession(SessionId session_id);
+  a<Session> GetSession(SessionId session_id);
   bool DestroySession(SessionId session_id);
   void CleanupStaleSessions();
   void CleanupAllSessions();
@@ -71,8 +69,8 @@ class Service {
   void SetNotificationHandler(const NotificationHandler& handler);
   void ClearNotificationHandler();
   void Notify(SessionId session_id,
-              const std::string& message_type,
-              const std::string& message_value);
+              const string& message_type,
+              const string& message_value);
 
   Deployer& deployer() { return deployer_; }
   bool disabled() { return !started_ || deployer_.IsMaintenanceMode(); }
@@ -82,7 +80,7 @@ class Service {
  private:
   Service();
 
-  using SessionMap = std::map<SessionId, shared_ptr<Session>>;
+  using SessionMap = map<SessionId, a<Session>>;
   SessionMap sessions_;
   Deployer deployer_;
   NotificationHandler notification_handler_;

--- a/include/rime/service.h
+++ b/include/rime/service.h
@@ -61,7 +61,7 @@ class Service {
   void StopService();
 
   SessionId CreateSession();
-  a<Session> GetSession(SessionId session_id);
+  an<Session> GetSession(SessionId session_id);
   bool DestroySession(SessionId session_id);
   void CleanupStaleSessions();
   void CleanupAllSessions();
@@ -80,7 +80,7 @@ class Service {
  private:
   Service();
 
-  using SessionMap = map<SessionId, a<Session>>;
+  using SessionMap = map<SessionId, an<Session>>;
   SessionMap sessions_;
   Deployer deployer_;
   NotificationHandler notification_handler_;

--- a/include/rime/signature.h
+++ b/include/rime/signature.h
@@ -7,7 +7,6 @@
 #ifndef RIME_SIGNATURE_H_
 #define RIME_SIGNATURE_H_
 
-#include <string>
 
 namespace rime {
 
@@ -16,14 +15,14 @@ class Deployer;
 
 class Signature {
  public:
-  Signature(const std::string& generator, const std::string& key = "signature")
+  Signature(const string& generator, const string& key = "signature")
       : generator_(generator), key_(key) {}
 
   bool Sign(Config* config, Deployer* deployer);
 
  private:
-  std::string generator_;
-  std::string key_;
+  string generator_;
+  string key_;
 };
 
 }  // namespace rime

--- a/include/rime/switcher.h
+++ b/include/rime/switcher.h
@@ -52,8 +52,8 @@ class Switcher : public Processor, public Engine {
   set<string> save_options_;
   bool fold_options_ = false;
 
-  vector<a<Processor>> processors_;
-  vector<a<Translator>> translators_;
+  vector<of<Processor>> processors_;
+  vector<of<Translator>> translators_;
   bool active_ = false;
 };
 

--- a/include/rime/switcher.h
+++ b/include/rime/switcher.h
@@ -7,9 +7,6 @@
 #ifndef RIME_SWITCHER_H_
 #define RIME_SWITCHER_H_
 
-#include <set>
-#include <string>
-#include <vector>
 #include <rime/common.h>
 #include <rime/engine.h>
 #include <rime/processor.h>
@@ -32,7 +29,7 @@ class Switcher : public Processor, public Engine {
 
   Schema* CreateSchema();
   void SelectNextSchema();
-  bool IsAutoSave(const std::string& option) const;
+  bool IsAutoSave(const string& option) const;
 
   void RefreshMenu();
   void Activate();
@@ -49,27 +46,27 @@ class Switcher : public Processor, public Engine {
   void HighlightNextSchema();
   void OnSelect(Context* ctx);
 
-  unique_ptr<Config> user_config_;
-  std::string caption_;
-  std::vector<KeyEvent> hotkeys_;
-  std::set<std::string> save_options_;
+  the<Config> user_config_;
+  string caption_;
+  vector<KeyEvent> hotkeys_;
+  set<string> save_options_;
   bool fold_options_ = false;
 
-  std::vector<shared_ptr<Processor>> processors_;
-  std::vector<shared_ptr<Translator>> translators_;
+  vector<a<Processor>> processors_;
+  vector<a<Translator>> translators_;
   bool active_ = false;
 };
 
 class SwitcherCommand {
  public:
-  SwitcherCommand(const std::string& keyword)
+  SwitcherCommand(const string& keyword)
       : keyword_(keyword) {
   }
   virtual void Apply(Switcher* switcher) = 0;
-  const std::string& keyword() const { return keyword_; }
+  const string& keyword() const { return keyword_; }
 
  protected:
-  std::string keyword_;
+  string keyword_;
 };
 
 }  // namespace rime

--- a/include/rime/ticket.h
+++ b/include/rime/ticket.h
@@ -7,7 +7,6 @@
 #ifndef RIME_TICKET_H_
 #define RIME_TICKET_H_
 
-#include <string>
 
 namespace rime {
 
@@ -17,15 +16,15 @@ class Schema;
 struct Ticket {
   Engine* engine = nullptr;
   Schema* schema = nullptr;
-  std::string name_space;
-  std::string klass;
+  string name_space;
+  string klass;
 
   Ticket() = default;
-  Ticket(Schema* s, const std::string& ns);
+  Ticket(Schema* s, const string& ns);
   // prescription: in the form of "klass" or "klass@alias"
   // where alias, if given, will override default name space
-  Ticket(Engine* e, const std::string& ns = "",
-         const std::string& prescription = "");
+  Ticket(Engine* e, const string& ns = "",
+         const string& prescription = "");
 };
 
 }  // namespace rime

--- a/include/rime/translation.h
+++ b/include/rime/translation.h
@@ -79,7 +79,7 @@ class UnionTranslation : public Translation {
   UnionTranslation& operator+= (a<Translation> t);
 
  protected:
-  list<a<Translation>> translations_;
+  list<of<Translation>> translations_;
 };
 
 a<UnionTranslation> operator+ (a<Translation> x, a<Translation> y);
@@ -99,7 +99,7 @@ class MergedTranslation : public Translation {
   void Elect();
 
   const CandidateList& previous_candidates_;
-  vector<a<Translation>> translations_;
+  vector<of<Translation>> translations_;
   size_t elected_ = 0;
 };
 

--- a/include/rime/translation.h
+++ b/include/rime/translation.h
@@ -8,10 +8,6 @@
 #ifndef RIME_TRANSLATION_H_
 #define RIME_TRANSLATION_H_
 
-#include <list>
-#include <set>
-#include <string>
-#include <vector>
 #include <rime/candidate.h>
 #include <rime/common.h>
 
@@ -26,11 +22,11 @@ class Translation {
   // something like a generator of candidates.
   virtual bool Next() = 0;
 
-  virtual shared_ptr<Candidate> Peek() = 0;
+  virtual a<Candidate> Peek() = 0;
 
   // should it provide the next candidate (negative value, zero) or
   // should it give up the chance for other translations (positive)?
-  virtual int Compare(shared_ptr<Translation> other,
+  virtual int Compare(a<Translation> other,
                       const CandidateList& candidates);
 
   bool exhausted() const { return exhausted_; }
@@ -44,15 +40,15 @@ class Translation {
 
 class UniqueTranslation : public Translation {
  public:
-  UniqueTranslation(shared_ptr<Candidate> candidate)
+  UniqueTranslation(a<Candidate> candidate)
       : candidate_(candidate) {
   }
 
   bool Next();
-  shared_ptr<Candidate> Peek();
+  a<Candidate> Peek();
 
  protected:
-  shared_ptr<Candidate> candidate_;
+  a<Candidate> candidate_;
 };
 
 class FifoTranslation : public Translation {
@@ -60,9 +56,9 @@ class FifoTranslation : public Translation {
   FifoTranslation();
 
   bool Next();
-  shared_ptr<Candidate> Peek();
+  a<Candidate> Peek();
 
-  void Append(shared_ptr<Candidate> candy);
+  void Append(a<Candidate> candy);
 
   size_t size() const {
     return candies_.size() - cursor_;
@@ -78,25 +74,24 @@ class UnionTranslation : public Translation {
   UnionTranslation();
 
   bool Next();
-  shared_ptr<Candidate> Peek();
+  a<Candidate> Peek();
 
-  UnionTranslation& operator+= (shared_ptr<Translation> t);
+  UnionTranslation& operator+= (a<Translation> t);
 
  protected:
-  std::list<shared_ptr<Translation>> translations_;
+  list<a<Translation>> translations_;
 };
 
-shared_ptr<UnionTranslation> operator+ (shared_ptr<Translation> a,
-                                        shared_ptr<Translation> b);
+a<UnionTranslation> operator+ (a<Translation> x, a<Translation> y);
 
 class MergedTranslation : public Translation {
  public:
   explicit MergedTranslation(const CandidateList& previous_candidates);
 
   bool Next();
-  shared_ptr<Candidate> Peek();
+  a<Candidate> Peek();
 
-  MergedTranslation& operator+= (shared_ptr<Translation> t);
+  MergedTranslation& operator+= (a<Translation> t);
 
   size_t size() const { return translations_.size(); }
 
@@ -104,49 +99,49 @@ class MergedTranslation : public Translation {
   void Elect();
 
   const CandidateList& previous_candidates_;
-  std::vector<shared_ptr<Translation>> translations_;
+  vector<a<Translation>> translations_;
   size_t elected_ = 0;
 };
 
 class CacheTranslation : public Translation {
  public:
-  CacheTranslation(shared_ptr<Translation> translation);
+  CacheTranslation(a<Translation> translation);
 
   virtual bool Next();
-  virtual shared_ptr<Candidate> Peek();
+  virtual a<Candidate> Peek();
 
  protected:
-  shared_ptr<Translation> translation_;
-  shared_ptr<Candidate> cache_;
+  a<Translation> translation_;
+  a<Candidate> cache_;
 };
 
 template <class T, class... Args>
-inline shared_ptr<Translation> Cached(Args&&... args) {
+inline a<Translation> Cached(Args&&... args) {
   return New<CacheTranslation>(New<T>(std::forward<Args>(args)...));
 }
 
 class DistinctTranslation : public CacheTranslation {
  public:
-  DistinctTranslation(shared_ptr<Translation> translation);
+  DistinctTranslation(a<Translation> translation);
   virtual bool Next();
 
  protected:
-  bool AlreadyHas(const std::string& text) const;
+  bool AlreadyHas(const string& text) const;
 
-  std::set<std::string> candidate_set_;
+  set<string> candidate_set_;
 };
 
 class PrefetchTranslation : public Translation {
  public:
-  PrefetchTranslation(shared_ptr<Translation> translation);
+  PrefetchTranslation(a<Translation> translation);
 
   virtual bool Next();
-  virtual shared_ptr<Candidate> Peek();
+  virtual a<Candidate> Peek();
 
  protected:
   virtual bool Replenish() { return false; }
 
-  shared_ptr<Translation> translation_;
+  a<Translation> translation_;
   CandidateQueue cache_;
 };
 

--- a/include/rime/translation.h
+++ b/include/rime/translation.h
@@ -22,11 +22,11 @@ class Translation {
   // something like a generator of candidates.
   virtual bool Next() = 0;
 
-  virtual a<Candidate> Peek() = 0;
+  virtual an<Candidate> Peek() = 0;
 
   // should it provide the next candidate (negative value, zero) or
   // should it give up the chance for other translations (positive)?
-  virtual int Compare(a<Translation> other,
+  virtual int Compare(an<Translation> other,
                       const CandidateList& candidates);
 
   bool exhausted() const { return exhausted_; }
@@ -40,15 +40,15 @@ class Translation {
 
 class UniqueTranslation : public Translation {
  public:
-  UniqueTranslation(a<Candidate> candidate)
+  UniqueTranslation(an<Candidate> candidate)
       : candidate_(candidate) {
   }
 
   bool Next();
-  a<Candidate> Peek();
+  an<Candidate> Peek();
 
  protected:
-  a<Candidate> candidate_;
+  an<Candidate> candidate_;
 };
 
 class FifoTranslation : public Translation {
@@ -56,9 +56,9 @@ class FifoTranslation : public Translation {
   FifoTranslation();
 
   bool Next();
-  a<Candidate> Peek();
+  an<Candidate> Peek();
 
-  void Append(a<Candidate> candy);
+  void Append(an<Candidate> candy);
 
   size_t size() const {
     return candies_.size() - cursor_;
@@ -74,24 +74,24 @@ class UnionTranslation : public Translation {
   UnionTranslation();
 
   bool Next();
-  a<Candidate> Peek();
+  an<Candidate> Peek();
 
-  UnionTranslation& operator+= (a<Translation> t);
+  UnionTranslation& operator+= (an<Translation> t);
 
  protected:
   list<of<Translation>> translations_;
 };
 
-a<UnionTranslation> operator+ (a<Translation> x, a<Translation> y);
+an<UnionTranslation> operator+ (an<Translation> x, an<Translation> y);
 
 class MergedTranslation : public Translation {
  public:
   explicit MergedTranslation(const CandidateList& previous_candidates);
 
   bool Next();
-  a<Candidate> Peek();
+  an<Candidate> Peek();
 
-  MergedTranslation& operator+= (a<Translation> t);
+  MergedTranslation& operator+= (an<Translation> t);
 
   size_t size() const { return translations_.size(); }
 
@@ -105,24 +105,24 @@ class MergedTranslation : public Translation {
 
 class CacheTranslation : public Translation {
  public:
-  CacheTranslation(a<Translation> translation);
+  CacheTranslation(an<Translation> translation);
 
   virtual bool Next();
-  virtual a<Candidate> Peek();
+  virtual an<Candidate> Peek();
 
  protected:
-  a<Translation> translation_;
-  a<Candidate> cache_;
+  an<Translation> translation_;
+  an<Candidate> cache_;
 };
 
 template <class T, class... Args>
-inline a<Translation> Cached(Args&&... args) {
+inline an<Translation> Cached(Args&&... args) {
   return New<CacheTranslation>(New<T>(std::forward<Args>(args)...));
 }
 
 class DistinctTranslation : public CacheTranslation {
  public:
-  DistinctTranslation(a<Translation> translation);
+  DistinctTranslation(an<Translation> translation);
   virtual bool Next();
 
  protected:
@@ -133,15 +133,15 @@ class DistinctTranslation : public CacheTranslation {
 
 class PrefetchTranslation : public Translation {
  public:
-  PrefetchTranslation(a<Translation> translation);
+  PrefetchTranslation(an<Translation> translation);
 
   virtual bool Next();
-  virtual a<Candidate> Peek();
+  virtual an<Candidate> Peek();
 
  protected:
   virtual bool Replenish() { return false; }
 
-  a<Translation> translation_;
+  an<Translation> translation_;
   CandidateQueue cache_;
 };
 

--- a/include/rime/translator.h
+++ b/include/rime/translator.h
@@ -25,12 +25,12 @@ class Translator : public Class<Translator, const Ticket&> {
       : engine_(ticket.engine), name_space_(ticket.name_space) {}
   virtual ~Translator() = default;
 
-  virtual shared_ptr<Translation> Query(const std::string& input,
+  virtual a<Translation> Query(const string& input,
                                         const Segment& segment) = 0;
 
  protected:
   Engine* engine_;
-  std::string name_space_;
+  string name_space_;
 };
 
 }  // namespace rime

--- a/include/rime/translator.h
+++ b/include/rime/translator.h
@@ -25,7 +25,7 @@ class Translator : public Class<Translator, const Ticket&> {
       : engine_(ticket.engine), name_space_(ticket.name_space) {}
   virtual ~Translator() = default;
 
-  virtual a<Translation> Query(const string& input,
+  virtual an<Translation> Query(const string& input,
                                         const Segment& segment) = 0;
 
  protected:

--- a/sample/src/sample_module.cc
+++ b/sample/src/sample_module.cc
@@ -11,11 +11,12 @@
 
 #include "trivial_translator.h"
 
+using namespace rime;
+
 static void rime_sample_initialize() {
   LOG(INFO) << "registering components from module 'sample'.";
-  rime::Registry& r = rime::Registry::instance();
-  r.Register("trivial_translator",
-             new rime::Component<sample::TrivialTranslator>);
+  Registry& r = Registry::instance();
+  r.Register("trivial_translator", new Component<sample::TrivialTranslator>);
 }
 
 static void rime_sample_finalize() {

--- a/sample/src/trivial_translator.cc
+++ b/sample/src/trivial_translator.cc
@@ -31,13 +31,13 @@ TrivialTranslator::TrivialTranslator(const Ticket& ticket)
   dictionary_["wan"] = "\xe8\x90\xac";  // 萬
 }
 
-shared_ptr<Translation> TrivialTranslator::Query(const std::string& input,
-                                                 const Segment& segment) {
+an<Translation> TrivialTranslator::Query(const string& input,
+                                         const Segment& segment) {
   if (!segment.HasTag("abc"))
     return nullptr;
   DLOG(INFO) << "input = '" << input
              << "', [" << segment.start << ", " << segment.end << ")";
-  std::string output = Translate(input);
+  string output = Translate(input);
   if (output.empty()) {
     return nullptr;
   }
@@ -50,10 +50,10 @@ shared_ptr<Translation> TrivialTranslator::Query(const std::string& input,
   return New<UniqueTranslation>(candidate);
 }
 
-std::string TrivialTranslator::Translate(const std::string& input) {
+string TrivialTranslator::Translate(const string& input) {
   const size_t kMinPinyinLength = 2;
   const size_t kMaxPinyinLength = 6;
-  std::string result;
+  string result;
   size_t input_len = input.length();
   for (size_t i = 0; i < input_len; ) {
     int translated = 0;
@@ -70,7 +70,7 @@ std::string TrivialTranslator::Translate(const std::string& input) {
       i += translated;
     }
     else {
-      return std::string();
+      return string();
     }
   }
   return result;

--- a/sample/src/trivial_translator.h
+++ b/sample/src/trivial_translator.h
@@ -22,13 +22,13 @@ class TrivialTranslator : public Translator {
  public:
   TrivialTranslator(const Ticket& ticket);
 
-  virtual shared_ptr<Translation> Query(const std::string& input,
-                                        const Segment& segment);
+  virtual an<Translation> Query(const string& input,
+                                const Segment& segment);
 
  private:
-  std::string Translate(const std::string& input);
+  string Translate(const string& input);
 
-  using TrivialDictionary = std::map<std::string, std::string>;
+  using TrivialDictionary = map<string, string>;
   TrivialDictionary dictionary_;
 };
 

--- a/sample/test/trivial_translator_test.cc
+++ b/sample/test/trivial_translator_test.cc
@@ -20,19 +20,19 @@ TEST(/*DISABLED_*/TrivialTranslatorTest, Query) {
   auto component = Translator::Require("trivial_translator");
   ASSERT_TRUE(component != NULL);
   Ticket ticket;
-  unique_ptr<Translator> translator(component->Create(ticket));
+  the<Translator> translator(component->Create(ticket));
   // make sure the dict object has been created
   ASSERT_TRUE(bool(translator));
   // lookup test
-  const std::string test_input("yiqianerbaisanshisi");
+  const string test_input("yiqianerbaisanshisi");
   // 一千二百三十四
-  const std::string expected_output("\xe4\xb8\x80"
-                                    "\xe5\x8d\x83"
-                                    "\xe4\xba\x8c"
-                                    "\xe7\x99\xbe"
-                                    "\xe4\xb8\x89"
-                                    "\xe5\x8d\x81"
-                                    "\xe5\x9b\x9b");
+  const string expected_output("\xe4\xb8\x80"
+                               "\xe5\x8d\x83"
+                               "\xe4\xba\x8c"
+                               "\xe7\x99\xbe"
+                               "\xe4\xb8\x89"
+                               "\xe5\x8d\x81"
+                               "\xe5\x9b\x9b");
   Segment segment(0, test_input.length());
   segment.tags.insert("abc");
   auto translation = translator->Query(test_input, segment);

--- a/src/algo/algebra.cc
+++ b/src/algo/algebra.cc
@@ -11,7 +11,7 @@
 
 namespace rime {
 
-bool Script::AddSyllable(const std::string& syllable) {
+bool Script::AddSyllable(const string& syllable) {
   if (find(syllable) != end())
     return false;
   Spelling spelling(syllable);
@@ -19,10 +19,10 @@ bool Script::AddSyllable(const std::string& syllable) {
   return true;
 }
 
-void Script::Merge(const std::string& s,
+void Script::Merge(const string& s,
                    const SpellingProperties& sp,
-                   const std::vector<Spelling>& v) {
-  std::vector<Spelling>& m((*this)[s]);
+                   const vector<Spelling>& v) {
+  vector<Spelling>& m((*this)[s]);
   for (const Spelling& x : v) {
     Spelling y(x);
     SpellingProperties& yy(y.properties);
@@ -48,7 +48,7 @@ void Script::Merge(const std::string& s,
   }
 }
 
-void Script::Dump(const std::string& file_name) const {
+void Script::Dump(const string& file_name) const {
   std::ofstream out(file_name.c_str());
   for (const value_type& v : *this) {
     bool first = true;
@@ -76,8 +76,8 @@ bool Projection::Load(ConfigListPtr settings) {
       success = false;
       break;
     }
-    const std::string &formula(v->str());
-    shared_ptr<Calculation> x;
+    const string &formula(v->str());
+    a<Calculation> x;
     try {
       x.reset(calc.Parse(formula));
     }
@@ -98,12 +98,12 @@ bool Projection::Load(ConfigListPtr settings) {
   return success;
 }
 
-bool Projection::Apply(std::string* value) {
+bool Projection::Apply(string* value) {
   if (!value || value->empty())
     return false;
   bool modified = false;
   Spelling s(*value);
-  for (shared_ptr<Calculation>& x : calculation_) {
+  for (a<Calculation>& x : calculation_) {
     try {
       if (x->Apply(&s))
         modified = true;
@@ -123,7 +123,7 @@ bool Projection::Apply(Script* value) {
     return false;
   bool modified = false;
   int round = 0;
-  for (shared_ptr<Calculation>& x : calculation_) {
+  for (a<Calculation>& x : calculation_) {
     ++round;
     DLOG(INFO) << "round #" << round;
     Script temp;

--- a/src/algo/algebra.cc
+++ b/src/algo/algebra.cc
@@ -64,13 +64,13 @@ void Script::Dump(const string& file_name) const {
   out.close();
 }
 
-bool Projection::Load(ConfigListPtr settings) {
+bool Projection::Load(a<ConfigList> settings) {
   if (!settings) return false;
   calculation_.clear();
   Calculus calc;
   bool success = true;
   for (size_t i = 0; i < settings->size(); ++i) {
-    ConfigValuePtr v(settings->GetValueAt(i));
+    a<ConfigValue> v(settings->GetValueAt(i));
     if (!v) {
       LOG(ERROR) << "Error loading formula #" << (i + 1) << ".";
       success = false;

--- a/src/algo/algebra.cc
+++ b/src/algo/algebra.cc
@@ -64,20 +64,20 @@ void Script::Dump(const string& file_name) const {
   out.close();
 }
 
-bool Projection::Load(a<ConfigList> settings) {
+bool Projection::Load(an<ConfigList> settings) {
   if (!settings) return false;
   calculation_.clear();
   Calculus calc;
   bool success = true;
   for (size_t i = 0; i < settings->size(); ++i) {
-    a<ConfigValue> v(settings->GetValueAt(i));
+    an<ConfigValue> v(settings->GetValueAt(i));
     if (!v) {
       LOG(ERROR) << "Error loading formula #" << (i + 1) << ".";
       success = false;
       break;
     }
     const string &formula(v->str());
-    a<Calculation> x;
+    an<Calculation> x;
     try {
       x.reset(calc.Parse(formula));
     }
@@ -103,7 +103,7 @@ bool Projection::Apply(string* value) {
     return false;
   bool modified = false;
   Spelling s(*value);
-  for (a<Calculation>& x : calculation_) {
+  for (an<Calculation>& x : calculation_) {
     try {
       if (x->Apply(&s))
         modified = true;
@@ -123,7 +123,7 @@ bool Projection::Apply(Script* value) {
     return false;
   bool modified = false;
   int round = 0;
-  for (a<Calculation>& x : calculation_) {
+  for (an<Calculation>& x : calculation_) {
     ++round;
     DLOG(INFO) << "round #" << round;
     Script temp;

--- a/src/algo/calculus.cc
+++ b/src/algo/calculus.cc
@@ -19,21 +19,21 @@ Calculus::Calculus() {
   Register("abbrev", &Abbreviation::Parse);
 }
 
-void Calculus::Register(const std::string& token,
+void Calculus::Register(const string& token,
                         Calculation::Factory* factory) {
   factories_[token] = factory;
 }
 
-Calculation* Calculus::Parse(const std::string& definition) {
+Calculation* Calculus::Parse(const string& definition) {
   size_t sep = definition.find_first_not_of("zyxwvutsrqponmlkjihgfedcba");
-  if (sep == std::string::npos)
+  if (sep == string::npos)
     return NULL;
-  std::vector<std::string> args;
+  vector<string> args;
   boost::split(args, definition,
                boost::is_from_range(definition[sep], definition[sep]));
   if (args.empty())
     return NULL;
-  std::map<std::string,
+  map<string,
            Calculation::Factory*>::iterator it = factories_.find(args[0]);
   if (it == factories_.end())
     return NULL;
@@ -43,15 +43,15 @@ Calculation* Calculus::Parse(const std::string& definition) {
 
 // Transliteration
 
-Calculation* Transliteration::Parse(const std::vector<std::string>& args) {
+Calculation* Transliteration::Parse(const vector<string>& args) {
   if (args.size() < 3)
     return NULL;
-  const std::string& left(args[1]);
-  const std::string& right(args[2]);
+  const string& left(args[1]);
+  const string& right(args[2]);
   const char* pl = left.c_str();
   const char* pr = right.c_str();
   uint32_t cl, cr;
-  std::map<uint32_t, uint32_t> char_map;
+  map<uint32_t, uint32_t> char_map;
   while ((cl = utf8::unchecked::next(pl)),
          (cr = utf8::unchecked::next(pr)),
          cl && cr) {
@@ -94,11 +94,11 @@ bool Transliteration::Apply(Spelling* spelling) {
 
 // Transformation
 
-Calculation* Transformation::Parse(const std::vector<std::string>& args) {
+Calculation* Transformation::Parse(const vector<string>& args) {
   if (args.size() < 3)
     return NULL;
-  const std::string& left(args[1]);
-  const std::string& right(args[2]);
+  const string& left(args[1]);
+  const string& right(args[2]);
   if (left.empty())
     return NULL;
   Transformation* x = new Transformation;
@@ -110,7 +110,7 @@ Calculation* Transformation::Parse(const std::vector<std::string>& args) {
 bool Transformation::Apply(Spelling* spelling) {
   if (!spelling || spelling->str.empty())
     return false;
-  std::string result(boost::regex_replace(spelling->str,
+  string result(boost::regex_replace(spelling->str,
                                           pattern_, replacement_));
   if (result == spelling->str)
     return false;
@@ -120,10 +120,10 @@ bool Transformation::Apply(Spelling* spelling) {
 
 // Erasion
 
-Calculation* Erasion::Parse(const std::vector<std::string>& args) {
+Calculation* Erasion::Parse(const vector<string>& args) {
   if (args.size() < 2)
     return NULL;
-  const std::string& pattern(args[1]);
+  const string& pattern(args[1]);
   if (pattern.empty())
     return NULL;
   Erasion* x = new Erasion;
@@ -142,11 +142,11 @@ bool Erasion::Apply(Spelling* spelling) {
 
 // Derivation
 
-Calculation* Derivation::Parse(const std::vector<std::string>& args) {
+Calculation* Derivation::Parse(const vector<string>& args) {
   if (args.size() < 3)
     return NULL;
-  const std::string& left(args[1]);
-  const std::string& right(args[2]);
+  const string& left(args[1]);
+  const string& right(args[2]);
   if (left.empty())
     return NULL;
   Derivation* x = new Derivation;
@@ -157,11 +157,11 @@ Calculation* Derivation::Parse(const std::vector<std::string>& args) {
 
 // Fuzzing
 
-Calculation* Fuzzing::Parse(const std::vector<std::string>& args) {
+Calculation* Fuzzing::Parse(const vector<string>& args) {
   if (args.size() < 3)
     return NULL;
-  const std::string& left(args[1]);
-  const std::string& right(args[2]);
+  const string& left(args[1]);
+  const string& right(args[2]);
   if (left.empty())
     return NULL;
   Fuzzing* x = new Fuzzing;
@@ -181,11 +181,11 @@ bool Fuzzing::Apply(Spelling* spelling) {
 
 // Abbreviation
 
-Calculation* Abbreviation::Parse(const std::vector<std::string>& args) {
+Calculation* Abbreviation::Parse(const vector<string>& args) {
   if (args.size() < 3)
     return NULL;
-  const std::string& left(args[1]);
-  const std::string& right(args[2]);
+  const string& left(args[1]);
+  const string& right(args[2]);
   if (left.empty())
     return NULL;
   Abbreviation* x = new Abbreviation;

--- a/src/algo/encoder.cc
+++ b/src/algo/encoder.cc
@@ -14,12 +14,12 @@ namespace rime {
 static const int kEncoderDfsLimit = 32;
 static const int kMaxPhraseLength = 32;
 
-std::string RawCode::ToString() const {
+string RawCode::ToString() const {
   return boost::join(*this, " ");
 }
 
-void RawCode::FromString(const std::string &code_str) {
-  boost::split(*dynamic_cast<std::vector<std::string> *>(this),
+void RawCode::FromString(const string &code_str) {
+  boost::split(*dynamic_cast<vector<string> *>(this),
                code_str,
                boost::algorithm::is_space(),
                boost::algorithm::token_compress_on);
@@ -58,7 +58,7 @@ bool TableEncoder::LoadSettings(Config* config) {
       auto rule = As<ConfigMap>(*it);
       if (!rule || !rule->HasKey("formula"))
         continue;
-      const std::string formula(rule->GetValue("formula")->str());
+      const string formula(rule->GetValue("formula")->str());
       TableEncodingRule r;
       if (!ParseFormula(formula, &r))
         continue;
@@ -108,7 +108,7 @@ bool TableEncoder::LoadSettings(Config* config) {
   return loaded_;
 }
 
-bool TableEncoder::ParseFormula(const std::string& formula,
+bool TableEncoder::ParseFormula(const string& formula,
                                 TableEncodingRule* rule) {
   if (formula.length() % 2 != 0) {
     LOG(ERROR) << "bad formula: '%s'" << formula;
@@ -133,7 +133,7 @@ bool TableEncoder::ParseFormula(const std::string& formula,
   return true;
 }
 
-bool TableEncoder::IsCodeExcluded(const std::string& code) {
+bool TableEncoder::IsCodeExcluded(const string& code) {
   for (const boost::regex& pattern : exclude_patterns_) {
     if (boost::regex_match(code, pattern))
       return true;
@@ -141,7 +141,7 @@ bool TableEncoder::IsCodeExcluded(const std::string& code) {
   return false;
 }
 
-bool TableEncoder::Encode(const RawCode& code, std::string* result) {
+bool TableEncoder::Encode(const RawCode& code, string* result) {
   int num_syllables = static_cast<int>(code.size());
   for (const TableEncodingRule& rule : encoding_rules_) {
     if (num_syllables < rule.min_word_length ||
@@ -208,7 +208,7 @@ bool TableEncoder::Encode(const RawCode& code, std::string* result) {
 //        beyond `start` is used to locate the encoding character at index -1.
 // returns string index in `code` for the character at virtual `index`.
 // may return a negative number if `index` does not exist in `code`.
-int TableEncoder::CalculateCodeIndex(const std::string& code, int index,
+int TableEncoder::CalculateCodeIndex(const string& code, int index,
                                      int start) {
   DLOG(INFO) << "code = " << code
              << ", index = " << index << ", start = " << start;
@@ -221,12 +221,12 @@ int TableEncoder::CalculateCodeIndex(const std::string& code, int index,
     // 'ab|cd|ef|g' ~ '(AaAb)Ay' -> 'abc'; start = 4, index = -2
     k = n - 1;
     size_t tail = code.find_first_of(tail_anchor_, start + 1);
-    if (tail != std::string::npos) {
+    if (tail != string::npos) {
       k = static_cast<int>(tail) - 1;
     }
     while (++index < 0) {
       while (--k >= 0 &&
-             tail_anchor_.find(code[k]) != std::string::npos) {
+             tail_anchor_.find(code[k]) != string::npos) {
       }
     }
   }
@@ -234,15 +234,15 @@ int TableEncoder::CalculateCodeIndex(const std::string& code, int index,
     // 'ab|cd|ef|g' ~ '(AaAb)Ac' -> 'abc'; index = 2
     while (index-- > 0) {
       while (++k < n &&
-             tail_anchor_.find(code[k]) != std::string::npos) {
+             tail_anchor_.find(code[k]) != string::npos) {
       }
     }
   }
   return k;
 }
 
-bool TableEncoder::EncodePhrase(const std::string& phrase,
-                                const std::string& value) {
+bool TableEncoder::EncodePhrase(const string& phrase,
+                                const string& value) {
   size_t phrase_length = utf8::unchecked::distance(
       phrase.c_str(), phrase.c_str() + phrase.length());
   if (static_cast<int>(phrase_length) > max_phrase_length_)
@@ -253,8 +253,8 @@ bool TableEncoder::EncodePhrase(const std::string& phrase,
   return DfsEncode(phrase, value, 0, &code, &limit);
 }
 
-bool TableEncoder::DfsEncode(const std::string& phrase,
-                             const std::string& value,
+bool TableEncoder::DfsEncode(const string& phrase,
+                             const string& value,
                              size_t start_pos,
                              RawCode* code,
                              int* limit) {
@@ -262,7 +262,7 @@ bool TableEncoder::DfsEncode(const std::string& phrase,
     if (limit) {
       --*limit;
     }
-    std::string encoded;
+    string encoded;
     if (Encode(*code, &encoded)) {
       DLOG(INFO) << "encode '" << phrase << "': "
                  << "[" << code->ToString() << "] -> [" << encoded << "]";
@@ -279,11 +279,11 @@ bool TableEncoder::DfsEncode(const std::string& phrase,
   const char* word_end = word_start;
   utf8::unchecked::next(word_end);
   size_t word_len = word_end - word_start;
-  std::string word(word_start, word_len);
+  string word(word_start, word_len);
   bool ret = false;
-  std::vector<std::string> translations;
+  vector<string> translations;
   if (collector_->TranslateWord(word, &translations)) {
-    for (const std::string& x : translations) {
+    for (const string& x : translations) {
       if (IsCodeExcluded(x)) {
         continue;
       }
@@ -303,8 +303,8 @@ ScriptEncoder::ScriptEncoder(PhraseCollector* collector)
     : Encoder(collector) {
 }
 
-bool ScriptEncoder::EncodePhrase(const std::string& phrase,
-                                 const std::string& value) {
+bool ScriptEncoder::EncodePhrase(const string& phrase,
+                                 const string& value) {
   size_t phrase_length = utf8::unchecked::distance(
       phrase.c_str(), phrase.c_str() + phrase.length());
   if (static_cast<int>(phrase_length) > kMaxPhraseLength)
@@ -315,8 +315,8 @@ bool ScriptEncoder::EncodePhrase(const std::string& phrase,
   return DfsEncode(phrase, value, 0, &code, &limit);
 }
 
-bool ScriptEncoder::DfsEncode(const std::string& phrase,
-                              const std::string& value,
+bool ScriptEncoder::DfsEncode(const string& phrase,
+                              const string& value,
                               size_t start_pos,
                               RawCode* code,
                               int* limit) {
@@ -329,10 +329,10 @@ bool ScriptEncoder::DfsEncode(const std::string& phrase,
   }
   bool ret = false;
   for (size_t k = phrase.length() - start_pos; k > 0; --k) {
-    std::string word(phrase.substr(start_pos, k));
-    std::vector<std::string> translations;
+    string word(phrase.substr(start_pos, k));
+    vector<string> translations;
     if (collector_->TranslateWord(word, &translations)) {
-      for (const std::string& x : translations) {
+      for (const string& x : translations) {
         code->push_back(x);
         bool ok = DfsEncode(phrase, value, start_pos + k, code, limit);
         ret = ret || ok;

--- a/src/algo/encoder.cc
+++ b/src/algo/encoder.cc
@@ -63,7 +63,7 @@ bool TableEncoder::LoadSettings(Config* config) {
       if (!ParseFormula(formula, &r))
         continue;
       r.min_word_length = r.max_word_length = 0;
-      if (ConfigValuePtr value = rule->GetValue("length_equal")) {
+      if (a<ConfigValue> value = rule->GetValue("length_equal")) {
         int length = 0;
         if (!value->GetInt(&length)) {
           LOG(ERROR) << "invalid length";

--- a/src/algo/encoder.cc
+++ b/src/algo/encoder.cc
@@ -63,7 +63,7 @@ bool TableEncoder::LoadSettings(Config* config) {
       if (!ParseFormula(formula, &r))
         continue;
       r.min_word_length = r.max_word_length = 0;
-      if (a<ConfigValue> value = rule->GetValue("length_equal")) {
+      if (an<ConfigValue> value = rule->GetValue("length_equal")) {
         int length = 0;
         if (!value->GetInt(&length)) {
           LOG(ERROR) << "invalid length";

--- a/src/algo/syllabifier.cc
+++ b/src/algo/syllabifier.cc
@@ -6,14 +6,13 @@
 // 2012-02-11 GONG Chen <chen.sst@gmail.com>
 //
 #include <queue>
-#include <utility>
 #include <boost/range/adaptor/reversed.hpp>
 #include <rime/dict/prism.h>
 #include <rime/algo/syllabifier.h>
 
 namespace rime {
 
-using Vertex = std::pair<size_t, SpellingType>;
+using Vertex = pair<size_t, SpellingType>;
 using VertexQueue = std::priority_queue<Vertex,
                                         vector<Vertex>,
                                         std::greater<Vertex>>;

--- a/src/algo/syllabifier.cc
+++ b/src/algo/syllabifier.cc
@@ -7,7 +7,6 @@
 //
 #include <queue>
 #include <utility>
-#include <vector>
 #include <boost/range/adaptor/reversed.hpp>
 #include <rime/dict/prism.h>
 #include <rime/algo/syllabifier.h>
@@ -16,10 +15,10 @@ namespace rime {
 
 using Vertex = std::pair<size_t, SpellingType>;
 using VertexQueue = std::priority_queue<Vertex,
-                                        std::vector<Vertex>,
+                                        vector<Vertex>,
                                         std::greater<Vertex>>;
 
-int Syllabifier::BuildSyllableGraph(const std::string &input,
+int Syllabifier::BuildSyllableGraph(const string &input,
                                     Prism &prism,
                                     SyllableGraph *graph) {
   if (input.empty())
@@ -45,7 +44,7 @@ int Syllabifier::BuildSyllableGraph(const std::string &input,
     DLOG(INFO) << "current_pos: " << current_pos;
 
     // see where we can go by advancing a syllable
-    std::vector<Prism::Match> matches;
+    vector<Prism::Match> matches;
     prism.CommonPrefixSearch(input.substr(current_pos), &matches);
     if (!matches.empty()) {
       auto& end_vertices(graph->edges[current_pos]);
@@ -54,7 +53,7 @@ int Syllabifier::BuildSyllableGraph(const std::string &input,
         size_t end_pos = current_pos + m.length;
         // consume trailing delimiters
         while (end_pos < input.length() &&
-               delimiters_.find(input[end_pos]) != std::string::npos)
+               delimiters_.find(input[end_pos]) != string::npos)
           ++end_pos;
         DLOG(INFO) << "end_pos: " << end_pos;
         bool matches_input = (current_pos == 0 && end_pos == input.length());
@@ -104,7 +103,7 @@ int Syllabifier::BuildSyllableGraph(const std::string &input,
   }
 
   DLOG(INFO) << "remove stale vertices and edges";
-  std::set<int> good;
+  set<int> good;
   good.insert(farthest);
   // fuzzy spellings are immune to invalidation by normal spellings
   SpellingType last_type = (std::max)(graph->vertices[farthest],
@@ -154,7 +153,7 @@ int Syllabifier::BuildSyllableGraph(const std::string &input,
   if (enable_completion_ && farthest < input.length()) {
     DLOG(INFO) << "completion enabled";
     const size_t kExpandSearchLimit = 512;
-    std::vector<Prism::Match> keys;
+    vector<Prism::Match> keys;
     prism.ExpandSearch(input.substr(farthest), &keys, kExpandSearchLimit);
     if (!keys.empty()) {
       size_t current_pos = farthest;

--- a/src/algo/utilities.cc
+++ b/src/algo/utilities.cc
@@ -5,17 +5,16 @@
 // 2013-01-30 GONG Chen <chen.sst@gmail.com>
 //
 #include <fstream>
-#include <vector>
 #include <boost/algorithm/string.hpp>
 #include <rime/algo/utilities.h>
 
 namespace rime {
 
-int CompareVersionString(const std::string& x, const std::string& y) {
+int CompareVersionString(const string& x, const string& y) {
   if (x.empty() && y.empty()) return 0;
   if (x.empty()) return -1;
   if (y.empty()) return 1;
-  std::vector<std::string> xx, yy;
+  vector<string> xx, yy;
   boost::split(xx, x, boost::is_any_of("."));
   boost::split(yy, y, boost::is_any_of("."));
   size_t i = 0;
@@ -31,9 +30,9 @@ int CompareVersionString(const std::string& x, const std::string& y) {
   return 0;
 }
 
-void ChecksumComputer::ProcessFile(const std::string& file_name) {
+void ChecksumComputer::ProcessFile(const string& file_name) {
   std::ifstream fin(file_name.c_str());
-  std::string file_content((std::istreambuf_iterator<char>(fin)),
+  string file_content((std::istreambuf_iterator<char>(fin)),
                            std::istreambuf_iterator<char>());
   crc_.process_bytes(file_content.data(), file_content.length());
 }

--- a/src/candidate.cc
+++ b/src/candidate.cc
@@ -8,21 +8,21 @@
 
 namespace rime {
 
-static shared_ptr<Candidate>
-UnpackShadowCandidate(const shared_ptr<Candidate>& cand) {
+static a<Candidate>
+UnpackShadowCandidate(const a<Candidate>& cand) {
   auto shadow = As<ShadowCandidate>(cand);
   return shadow ? shadow->item() : cand;
 }
 
-shared_ptr<Candidate>
-Candidate::GetGenuineCandidate(const shared_ptr<Candidate>& cand) {
+a<Candidate>
+Candidate::GetGenuineCandidate(const a<Candidate>& cand) {
   auto uniquified = As<UniquifiedCandidate>(cand);
   return UnpackShadowCandidate(uniquified ? uniquified->items().front() : cand);
 }
 
-std::vector<shared_ptr<Candidate>>
-Candidate::GetGenuineCandidates(const shared_ptr<Candidate>& cand) {
-  std::vector<shared_ptr<Candidate>> result;
+vector<a<Candidate>>
+Candidate::GetGenuineCandidates(const a<Candidate>& cand) {
+  vector<a<Candidate>> result;
   if (auto uniquified = As<UniquifiedCandidate>(cand)) {
     for (const auto& item : uniquified->items()) {
       result.push_back(UnpackShadowCandidate(item));

--- a/src/candidate.cc
+++ b/src/candidate.cc
@@ -20,9 +20,9 @@ Candidate::GetGenuineCandidate(const a<Candidate>& cand) {
   return UnpackShadowCandidate(uniquified ? uniquified->items().front() : cand);
 }
 
-vector<a<Candidate>>
+vector<of<Candidate>>
 Candidate::GetGenuineCandidates(const a<Candidate>& cand) {
-  vector<a<Candidate>> result;
+  vector<of<Candidate>> result;
   if (auto uniquified = As<UniquifiedCandidate>(cand)) {
     for (const auto& item : uniquified->items()) {
       result.push_back(UnpackShadowCandidate(item));

--- a/src/candidate.cc
+++ b/src/candidate.cc
@@ -8,20 +8,20 @@
 
 namespace rime {
 
-static a<Candidate>
-UnpackShadowCandidate(const a<Candidate>& cand) {
+static an<Candidate>
+UnpackShadowCandidate(const an<Candidate>& cand) {
   auto shadow = As<ShadowCandidate>(cand);
   return shadow ? shadow->item() : cand;
 }
 
-a<Candidate>
-Candidate::GetGenuineCandidate(const a<Candidate>& cand) {
+an<Candidate>
+Candidate::GetGenuineCandidate(const an<Candidate>& cand) {
   auto uniquified = As<UniquifiedCandidate>(cand);
   return UnpackShadowCandidate(uniquified ? uniquified->items().front() : cand);
 }
 
 vector<of<Candidate>>
-Candidate::GetGenuineCandidates(const a<Candidate>& cand) {
+Candidate::GetGenuineCandidates(const an<Candidate>& cand) {
   vector<of<Candidate>> result;
   if (auto uniquified = As<UniquifiedCandidate>(cand)) {
     for (const auto& item : uniquified->items()) {

--- a/src/commit_history.cc
+++ b/src/commit_history.cc
@@ -31,7 +31,7 @@ void CommitHistory::Push(const KeyEvent& key_event) {
 }
 
 void CommitHistory::Push(const Composition& composition,
-                         const std::string& input) {
+                         const string& input) {
   CommitRecord* last = NULL;
   size_t end = 0;
   for (const Segment& seg : composition) {
@@ -62,8 +62,8 @@ void CommitHistory::Push(const Composition& composition,
   }
 }
 
-std::string CommitHistory::repr() const {
-  std::string result;
+string CommitHistory::repr() const {
+  string result;
   for (const CommitRecord& record : *this) {
     result += "[" + record.type + "]" + record.text;
   }

--- a/src/composition.cc
+++ b/src/composition.cc
@@ -60,12 +60,12 @@ Preedit Composition::GetPreedit() const {
   return preedit;
 }
 
-std::string Composition::GetPrompt() const {
-  return empty() ? std::string() : back().prompt;
+string Composition::GetPrompt() const {
+  return empty() ? string() : back().prompt;
 }
 
-std::string Composition::GetCommitText() const {
-  std::string result;
+string Composition::GetCommitText() const {
+  string result;
   size_t end = 0;
   for (const Segment& seg : *this) {
     if (auto cand = seg.GetSelectedCandidate()) {
@@ -85,8 +85,8 @@ std::string Composition::GetCommitText() const {
   return result;
 }
 
-std::string Composition::GetScriptText() const {
-  std::string result;
+string Composition::GetScriptText() const {
+  string result;
   size_t start = 0;
   size_t end = 0;
   for (const Segment& seg : *this) {
@@ -104,8 +104,8 @@ std::string Composition::GetScriptText() const {
   return result;
 }
 
-std::string Composition::GetDebugText() const {
-  std::string result;
+string Composition::GetDebugText() const {
+  string result;
   int i = 0;
   for (const Segment& seg : *this) {
     if (i++ > 0)
@@ -113,7 +113,7 @@ std::string Composition::GetDebugText() const {
     if (!seg.tags.empty()) {
       result += "{";
       int j = 0;
-      for (const std::string& tag : seg.tags) {
+      for (const string& tag : seg.tags) {
         if (j++ > 0)
           result += ",";
         result += tag;

--- a/src/config.cc
+++ b/src/config.cc
@@ -24,16 +24,16 @@ class ConfigData {
   bool SaveToStream(std::ostream& stream);
   bool LoadFromFile(const string& file_name);
   bool SaveToFile(const string& file_name);
-  a<ConfigItem> Traverse(const string& key);
+  an<ConfigItem> Traverse(const string& key);
 
   bool modified() const { return modified_; }
   void set_modified() { modified_ = true; }
 
-  a<ConfigItem> root;
+  an<ConfigItem> root;
 
  protected:
-  static a<ConfigItem> ConvertFromYaml(const YAML::Node& yaml_node);
-  static void EmitYaml(a<ConfigItem> node,
+  static an<ConfigItem> ConvertFromYaml(const YAML::Node& yaml_node);
+  static void EmitYaml(an<ConfigItem> node,
                        YAML::Emitter* emitter,
                        int depth);
   static void EmitScalar(const string& str_value,
@@ -45,7 +45,7 @@ class ConfigData {
 
 class ConfigDataManager : public map<string, weak<ConfigData>> {
  public:
-  a<ConfigData> GetConfigData(const string& config_file_path);
+  an<ConfigData> GetConfigData(const string& config_file_path);
   bool ReloadConfigData(const string& config_file_path);
 
   static ConfigDataManager& instance();
@@ -163,25 +163,25 @@ bool ConfigValue::SetString(const string& value) {
 
 // ConfigList members
 
-a<ConfigItem> ConfigList::GetAt(size_t i) const {
+an<ConfigItem> ConfigList::GetAt(size_t i) const {
   if (i >= seq_.size())
     return nullptr;
   else
     return seq_[i];
 }
 
-a<ConfigValue> ConfigList::GetValueAt(size_t i) const {
+an<ConfigValue> ConfigList::GetValueAt(size_t i) const {
   return As<ConfigValue>(GetAt(i));
 }
 
-bool ConfigList::SetAt(size_t i, a<ConfigItem> element) {
+bool ConfigList::SetAt(size_t i, an<ConfigItem> element) {
   if (i >= seq_.size())
     seq_.resize(i + 1);
   seq_[i] = element;
   return true;
 }
 
-bool ConfigList::Insert(size_t i, a<ConfigItem> element) {
+bool ConfigList::Insert(size_t i, an<ConfigItem> element) {
   if (i > seq_.size()) {
     seq_.resize(i);
   }
@@ -189,7 +189,7 @@ bool ConfigList::Insert(size_t i, a<ConfigItem> element) {
   return true;
 }
 
-bool ConfigList::Append(a<ConfigItem> element) {
+bool ConfigList::Append(an<ConfigItem> element) {
   seq_.push_back(element);
   return true;
 }
@@ -222,7 +222,7 @@ bool ConfigMap::HasKey(const string& key) const {
   return bool(Get(key));
 }
 
-a<ConfigItem> ConfigMap::Get(const string& key) const {
+an<ConfigItem> ConfigMap::Get(const string& key) const {
   auto it = map_.find(key);
   if (it == map_.end())
     return nullptr;
@@ -230,11 +230,11 @@ a<ConfigItem> ConfigMap::Get(const string& key) const {
     return it->second;
 }
 
-a<ConfigValue> ConfigMap::GetValue(const string& key) const {
+an<ConfigValue> ConfigMap::GetValue(const string& key) const {
   return As<ConfigValue>(Get(key));
 }
 
-bool ConfigMap::Set(const string& key, a<ConfigItem> element) {
+bool ConfigMap::Set(const string& key, an<ConfigItem> element) {
   map_[key] = element;
   return true;
 }
@@ -306,14 +306,14 @@ string ConfigItemRef::ToString() const {
   return value;
 }
 
-a<ConfigList> ConfigItemRef::AsList() {
+an<ConfigList> ConfigItemRef::AsList() {
   auto list = As<ConfigList>(GetItem());
   if (!list)
     SetItem(list = New<ConfigList>());
   return list;
 }
 
-a<ConfigMap> ConfigItemRef::AsMap() {
+an<ConfigMap> ConfigItemRef::AsMap() {
   auto map = As<ConfigMap>(GetItem());
   if (!map)
     SetItem(map = New<ConfigMap>());
@@ -324,7 +324,7 @@ void ConfigItemRef::Clear() {
   SetItem(nullptr);
 }
 
-bool ConfigItemRef::Append(a<ConfigItem> item) {
+bool ConfigItemRef::Append(an<ConfigItem> item) {
   if (AsList()->Append(item)) {
     set_modified();
     return true;
@@ -423,22 +423,22 @@ bool Config::GetString(const string& key, string* value) {
   return p && p->GetString(value);
 }
 
-a<ConfigItem> Config::GetItem(const string& key) {
+an<ConfigItem> Config::GetItem(const string& key) {
   DLOG(INFO) << "read: " << key;
   return data_->Traverse(key);
 }
 
-a<ConfigValue> Config::GetValue(const string& key) {
+an<ConfigValue> Config::GetValue(const string& key) {
   DLOG(INFO) << "read: " << key;
   return As<ConfigValue>(data_->Traverse(key));
 }
 
-a<ConfigList> Config::GetList(const string& key) {
+an<ConfigList> Config::GetList(const string& key) {
   DLOG(INFO) << "read: " << key;
   return As<ConfigList>(data_->Traverse(key));
 }
 
-a<ConfigMap> Config::GetMap(const string& key) {
+an<ConfigMap> Config::GetMap(const string& key) {
   DLOG(INFO) << "read: " << key;
   return As<ConfigMap>(data_->Traverse(key));
 }
@@ -467,12 +467,12 @@ static inline bool IsListItemReference(const string& key) {
   return !key.empty() && key[0] == '@';
 }
 
-static size_t ResolveListIndex(a<ConfigItem> p, const string& key,
+static size_t ResolveListIndex(an<ConfigItem> p, const string& key,
                                bool read_only = false) {
   //if (!IsListItemReference(key)) {
   //  return 0;
   //}
-  a<ConfigList> list = As<ConfigList>(p);
+  an<ConfigList> list = As<ConfigList>(p);
   if (!list) {
     return 0;
   }
@@ -515,7 +515,7 @@ static size_t ResolveListIndex(a<ConfigItem> p, const string& key,
   return index;
 }
 
-bool Config::SetItem(const string& key, a<ConfigItem> item) {
+bool Config::SetItem(const string& key, an<ConfigItem> item) {
   LOG(INFO) << "write: " << key;
   if (key.empty() || key == "/") {
     data_->root = item;
@@ -525,7 +525,7 @@ bool Config::SetItem(const string& key, a<ConfigItem> item) {
   if (!data_->root) {
     data_->root = New<ConfigMap>();
   }
-  a<ConfigItem> p(data_->root);
+  an<ConfigItem> p(data_->root);
   vector<string> keys;
   boost::split(keys, key, boost::is_any_of("/"));
   size_t k = keys.size() - 1;
@@ -551,7 +551,7 @@ bool Config::SetItem(const string& key, a<ConfigItem> item) {
       return true;
     }
     else {
-      a<ConfigItem> next;
+      an<ConfigItem> next;
       if (node_type == ConfigItem::kList) {
         next = As<ConfigList>(p)->GetAt(list_index);
       }
@@ -580,11 +580,11 @@ bool Config::SetItem(const string& key, a<ConfigItem> item) {
   return false;
 }
 
-a<ConfigItem> Config::GetItem() const {
+an<ConfigItem> Config::GetItem() const {
   return data_->root;
 }
 
-void Config::SetItem(a<ConfigItem> item) {
+void Config::SetItem(an<ConfigItem> item) {
   data_->root = item;
   set_modified();
 }
@@ -611,9 +611,9 @@ ConfigDataManager& ConfigDataManager::instance() {
   return *s_instance;
 }
 
-a<ConfigData>
+an<ConfigData>
 ConfigDataManager::GetConfigData(const string& config_file_path) {
-  a<ConfigData> sp;
+  an<ConfigData> sp;
   // keep a weak reference to the shared config data in the manager
   weak<ConfigData>& wp((*this)[config_file_path]);
   if (wp.expired()) {  // create a new copy and load it
@@ -632,7 +632,7 @@ bool ConfigDataManager::ReloadConfigData(const string& config_file_path) {
   if (it == end()) {  // never loaded
     return false;
   }
-  a<ConfigData> sp = it->second.lock();
+  an<ConfigData> sp = it->second.lock();
   if (!sp)  {  // already been freed
     erase(it);
     return false;
@@ -715,7 +715,7 @@ bool ConfigData::SaveToFile(const string& file_name) {
   return SaveToStream(out);
 }
 
-a<ConfigItem> ConfigData::Traverse(const string& key) {
+an<ConfigItem> ConfigData::Traverse(const string& key) {
   DLOG(INFO) << "traverse: " << key;
   if (key.empty() || key == "/") {
     return root;
@@ -723,7 +723,7 @@ a<ConfigItem> ConfigData::Traverse(const string& key) {
   vector<string> keys;
   boost::split(keys, key, boost::is_any_of("/"));
   // find the YAML::Node, and wrap it!
-  a<ConfigItem> p = root;
+  an<ConfigItem> p = root;
   for (auto it = keys.begin(), end = keys.end(); it != end; ++it) {
     ConfigItem::ValueType node_type = ConfigItem::kMap;
     size_t list_index = 0;
@@ -744,7 +744,7 @@ a<ConfigItem> ConfigData::Traverse(const string& key) {
   return p;
 }
 
-a<ConfigItem> ConfigData::ConvertFromYaml(const YAML::Node& node) {
+an<ConfigItem> ConfigData::ConvertFromYaml(const YAML::Node& node) {
   if (YAML::NodeType::Null == node.Type()) {
     return nullptr;
   }
@@ -782,7 +782,7 @@ void ConfigData::EmitScalar(const string& str_value,
   *emitter << str_value;
 }
 
-void ConfigData::EmitYaml(a<ConfigItem> node,
+void ConfigData::EmitYaml(an<ConfigItem> node,
                           YAML::Emitter* emitter,
                           int depth) {
   if (!node || !emitter) return;

--- a/src/context.cc
+++ b/src/context.cc
@@ -62,7 +62,7 @@ bool Context::HasMenu() const {
   return menu && !menu->empty();
 }
 
-a<Candidate> Context::GetSelectedCandidate() const {
+an<Candidate> Context::GetSelectedCandidate() const {
   if (composition_.empty())
     return nullptr;
   return composition_.back().GetSelectedCandidate();

--- a/src/context.cc
+++ b/src/context.cc
@@ -22,13 +22,13 @@ bool Context::Commit() {
   return true;
 }
 
-std::string Context::GetCommitText() const {
+string Context::GetCommitText() const {
   if (get_option("dumb"))
-    return std::string();
+    return string();
   return composition_.GetCommitText();
 }
 
-std::string Context::GetScriptText() const {
+string Context::GetScriptText() const {
   return composition_.GetScriptText();
 }
 
@@ -37,7 +37,7 @@ Preedit Context::GetPreedit() const {
   preedit.caret_pos = preedit.text.length();
   if (IsComposing()) {
     if (get_option("soft_cursor")) {
-      const std::string caret("\xe2\x80\xb8");
+      const string caret("\xe2\x80\xb8");
       preedit.text += caret;
     }
     auto prompt = composition_.GetPrompt();
@@ -62,7 +62,7 @@ bool Context::HasMenu() const {
   return menu && !menu->empty();
 }
 
-shared_ptr<Candidate> Context::GetSelectedCandidate() const {
+a<Candidate> Context::GetSelectedCandidate() const {
   if (composition_.empty())
     return nullptr;
   return composition_.back().GetSelectedCandidate();
@@ -81,7 +81,7 @@ bool Context::PushInput(char ch) {
   return true;
 }
 
-bool Context::PushInput(const std::string& str) {
+bool Context::PushInput(const string& str) {
   if (caret_pos_ >= input_.length()) {
     input_ += str;
     caret_pos_ = input_.length();
@@ -250,18 +250,18 @@ void Context::set_composition(Composition&& comp) {
   composition_ = std::move(comp);
 }
 
-void Context::set_input(const std::string& value) {
+void Context::set_input(const string& value) {
   input_ = value;
   caret_pos_ = input_.length();
   update_notifier_(this);
 }
 
-void Context::set_option(const std::string& name, bool value) {
+void Context::set_option(const string& name, bool value) {
   options_[name] = value;
   option_update_notifier_(this, name);
 }
 
-bool Context::get_option(const std::string& name) const {
+bool Context::get_option(const string& name) const {
   auto it = options_.find(name);
   if (it != options_.end())
     return it->second;
@@ -269,17 +269,17 @@ bool Context::get_option(const std::string& name) const {
     return false;
 }
 
-void Context::set_property(const std::string& name,
-                           const std::string& value) {
+void Context::set_property(const string& name,
+                           const string& value) {
   properties_[name] = value;
 }
 
-std::string Context::get_property(const std::string& name) const {
+string Context::get_property(const string& name) const {
   auto it = properties_.find(name);
   if (it != properties_.end())
     return it->second;
   else
-    return std::string();
+    return string();
 }
 
 void Context::ClearTransientOptions() {

--- a/src/deployer.cc
+++ b/src/deployer.cc
@@ -48,7 +48,7 @@ bool Deployer::ScheduleTask(const string& task_name, TaskInitializer arg) {
     LOG(ERROR) << "unknown deployment task: " << task_name;
     return false;
   }
-  a<DeploymentTask> t(c->Create(arg));
+  an<DeploymentTask> t(c->Create(arg));
   if (!t) {
     LOG(ERROR) << "error creating deployment task: " << task_name;
     return false;
@@ -57,12 +57,12 @@ bool Deployer::ScheduleTask(const string& task_name, TaskInitializer arg) {
   return true;
 }
 
-void Deployer::ScheduleTask(a<DeploymentTask> task) {
+void Deployer::ScheduleTask(an<DeploymentTask> task) {
   std::lock_guard<std::mutex> lock(mutex_);
   pending_tasks_.push(task);
 }
 
-a<DeploymentTask> Deployer::NextTask() {
+an<DeploymentTask> Deployer::NextTask() {
   std::lock_guard<std::mutex> lock(mutex_);
   if (!pending_tasks_.empty()) {
     auto result = pending_tasks_.front();

--- a/src/deployer.cc
+++ b/src/deployer.cc
@@ -22,19 +22,19 @@ Deployer::~Deployer() {
   JoinWorkThread();
 }
 
-std::string Deployer::user_data_sync_dir() const {
+string Deployer::user_data_sync_dir() const {
   boost::filesystem::path p(sync_dir);
   p /= user_id;
   return p.string();
 }
 
-bool Deployer::RunTask(const std::string& task_name, TaskInitializer arg) {
+bool Deployer::RunTask(const string& task_name, TaskInitializer arg) {
   auto c = DeploymentTask::Require(task_name);
   if (!c) {
     LOG(ERROR) << "unknown deployment task: " << task_name;
     return false;
   }
-  unique_ptr<DeploymentTask> t(c->Create(arg));
+  the<DeploymentTask> t(c->Create(arg));
   if (!t) {
     LOG(ERROR) << "error creating deployment task: " << task_name;
     return false;
@@ -42,13 +42,13 @@ bool Deployer::RunTask(const std::string& task_name, TaskInitializer arg) {
   return t->Run(this);
 }
 
-bool Deployer::ScheduleTask(const std::string& task_name, TaskInitializer arg) {
+bool Deployer::ScheduleTask(const string& task_name, TaskInitializer arg) {
   auto c = DeploymentTask::Require(task_name);
   if (!c) {
     LOG(ERROR) << "unknown deployment task: " << task_name;
     return false;
   }
-  shared_ptr<DeploymentTask> t(c->Create(arg));
+  a<DeploymentTask> t(c->Create(arg));
   if (!t) {
     LOG(ERROR) << "error creating deployment task: " << task_name;
     return false;
@@ -57,12 +57,12 @@ bool Deployer::ScheduleTask(const std::string& task_name, TaskInitializer arg) {
   return true;
 }
 
-void Deployer::ScheduleTask(shared_ptr<DeploymentTask> task) {
+void Deployer::ScheduleTask(a<DeploymentTask> task) {
   std::lock_guard<std::mutex> lock(mutex_);
   pending_tasks_.push(task);
 }
 
-shared_ptr<DeploymentTask> Deployer::NextTask() {
+a<DeploymentTask> Deployer::NextTask() {
   std::lock_guard<std::mutex> lock(mutex_);
   if (!pending_tasks_.empty()) {
     auto result = pending_tasks_.front();

--- a/src/dict/db.cc
+++ b/src/dict/db.cc
@@ -14,13 +14,13 @@ namespace rime {
 
 // DbAccessor members
 
-bool DbAccessor::MatchesPrefix(const std::string& key) {
+bool DbAccessor::MatchesPrefix(const string& key) {
   return boost::starts_with(key, prefix_);
 }
 
 // Db members
 
-Db::Db(const std::string& name) : name_(name) {
+Db::Db(const string& name) : name_(name) {
   boost::filesystem::path path(name);
   if (path.has_parent_path()) {
     file_name_ = name;

--- a/src/dict/db_utils.cc
+++ b/src/dict/db_utils.cc
@@ -13,7 +13,7 @@ int Source::Dump(Sink* sink) {
   if (!sink)
     return 0;
   int num_entries = 0;
-  std::string key, value;
+  string key, value;
   while (MetaGet(&key, &value)) {
     if (sink->MetaPut(key, value))
       ++num_entries;
@@ -28,11 +28,11 @@ int Source::Dump(Sink* sink) {
 DbSink::DbSink(Db* db) : db_(db) {
 }
 
-bool DbSink::MetaPut(const std::string& key, const std::string& value) {
+bool DbSink::MetaPut(const string& key, const string& value) {
   return db_ && db_->MetaUpdate(key, value);
 }
 
-bool DbSink::Put(const std::string& key, const std::string& value) {
+bool DbSink::Put(const string& key, const string& value) {
   return db_ && db_->Update(key, value);
 }
 
@@ -42,11 +42,11 @@ DbSource::DbSource(Db* db)
       data_(db->QueryAll()) {
 }
 
-bool DbSource::MetaGet(std::string* key, std::string* value) {
+bool DbSource::MetaGet(string* key, string* value) {
   return metadata_ && metadata_->GetNextRecord(key, value);
 }
 
-bool DbSource::Get(std::string* key, std::string* value) {
+bool DbSource::Get(string* key, string* value) {
   return data_ && data_->GetNextRecord(key, value);
 }
 

--- a/src/dict/dict_compiler.cc
+++ b/src/dict/dict_compiler.cc
@@ -5,8 +5,6 @@
 // 2011-11-27 GONG Chen <chen.sst@gmail.com>
 //
 #include <fstream>
-#include <map>
-#include <set>
 #include <boost/filesystem.hpp>
 #include <rime/algo/algebra.h>
 #include <rime/algo/utilities.h>
@@ -28,11 +26,11 @@ DictCompiler::DictCompiler(Dictionary *dictionary, DictFileFinder finder)
       dict_file_finder_(finder) {
 }
 
-bool DictCompiler::Compile(const std::string &schema_file) {
+bool DictCompiler::Compile(const string &schema_file) {
   LOG(INFO) << "compiling:";
   bool build_table_from_source = true;
   DictSettings settings;
-  std::string dict_file(FindDictFile(dict_name_));
+  string dict_file(FindDictFile(dict_name_));
   if (dict_file.empty()) {
     build_table_from_source = false;
   }
@@ -46,12 +44,12 @@ bool DictCompiler::Compile(const std::string &schema_file) {
     LOG(INFO) << "dict name: " << settings.dict_name();
     LOG(INFO) << "dict version: " << settings.dict_version();
   }
-  std::vector<std::string> dict_files;
+  vector<string> dict_files;
   auto tables = settings.GetTables();
   for(auto it = tables->begin(); it != tables->end(); ++it) {
     if (!Is<ConfigValue>(*it))
       continue;
-    std::string dict_file(FindDictFile(As<ConfigValue>(*it)->str()));
+    string dict_file(FindDictFile(As<ConfigValue>(*it)->str()));
     if (dict_file.empty())
       return false;
     dict_files.push_back(dict_file);
@@ -119,8 +117,8 @@ bool DictCompiler::Compile(const std::string &schema_file) {
   return true;
 }
 
-std::string DictCompiler::FindDictFile(const std::string& dict_name) {
-  std::string dict_file(dict_name + ".dict.yaml");
+string DictCompiler::FindDictFile(const string& dict_name) {
+  string dict_file(dict_name + ".dict.yaml");
   if (dict_file_finder_) {
     dict_file = dict_file_finder_(dict_file);
   }
@@ -128,7 +126,7 @@ std::string DictCompiler::FindDictFile(const std::string& dict_name) {
 }
 
 bool DictCompiler::BuildTable(DictSettings* settings,
-                              const std::vector<std::string>& dict_files,
+                              const vector<string>& dict_files,
                               uint32_t dict_file_checksum) {
   LOG(INFO) << "building table...";
   EntryCollector collector;
@@ -142,7 +140,7 @@ bool DictCompiler::BuildTable(DictSettings* settings,
   Vocabulary vocabulary;
   // build .table.bin
   {
-    std::map<std::string, SyllableId> syllable_to_id;
+    map<string, SyllableId> syllable_to_id;
     SyllableId syllable_id = 0;
     for (const auto& s : collector.syllabary) {
       syllable_to_id[s] = syllable_id++;
@@ -186,7 +184,7 @@ bool DictCompiler::BuildTable(DictSettings* settings,
   return true;
 }
 
-bool DictCompiler::BuildPrism(const std::string &schema_file,
+bool DictCompiler::BuildPrism(const string &schema_file,
                               uint32_t dict_file_checksum, uint32_t schema_file_checksum) {
   LOG(INFO) << "building prism...";
   // get syllabary from table

--- a/src/dict/dict_settings.cc
+++ b/src/dict/dict_settings.cc
@@ -19,7 +19,7 @@ bool DictSettings::LoadDictHeader(std::istream& stream) {
     return false;
   }
   std::stringstream header;
-  std::string line;
+  string line;
   while (getline(stream, line)) {
     boost::algorithm::trim_right(line);
     header << line << std::endl;
@@ -37,15 +37,15 @@ bool DictSettings::LoadDictHeader(std::istream& stream) {
   return true;
 }
 
-std::string DictSettings::dict_name() {
+string DictSettings::dict_name() {
   return (*this)["name"].ToString();
 }
 
-std::string DictSettings::dict_version() {
+string DictSettings::dict_version() {
   return (*this)["version"].ToString();
 }
 
-std::string DictSettings::sort_order() {
+string DictSettings::sort_order() {
   return (*this)["sort"].ToString();
 }
 
@@ -72,7 +72,7 @@ ConfigListPtr DictSettings::GetTables() {
   for (auto it = imports->begin(); it != imports->end(); ++it) {
     if (!Is<ConfigValue>(*it))
       continue;
-    std::string table = As<ConfigValue>(*it)->str();
+    string table = As<ConfigValue>(*it)->str();
     if (table == dict_name()) {
       LOG(WARNING) << "cannot import '" << table << "' from itself.";
       continue;
@@ -82,7 +82,7 @@ ConfigListPtr DictSettings::GetTables() {
   return tables;
 }
 
-int DictSettings::GetColumnIndex(const std::string& column_label) {
+int DictSettings::GetColumnIndex(const string& column_label) {
   if ((*this)["columns"].IsNull()) {
     // default
     if (column_label == "text") return 0;

--- a/src/dict/dict_settings.cc
+++ b/src/dict/dict_settings.cc
@@ -65,7 +65,7 @@ double DictSettings::min_phrase_weight() {
   return (*this)["min_phrase_weight"].ToDouble();
 }
 
-a<ConfigList> DictSettings::GetTables() {
+an<ConfigList> DictSettings::GetTables() {
   auto tables = New<ConfigList>();
   tables->Append((*this)["name"]);
   auto imports = (*this)["import_tables"].AsList();

--- a/src/dict/dict_settings.cc
+++ b/src/dict/dict_settings.cc
@@ -65,7 +65,7 @@ double DictSettings::min_phrase_weight() {
   return (*this)["min_phrase_weight"].ToDouble();
 }
 
-ConfigListPtr DictSettings::GetTables() {
+a<ConfigList> DictSettings::GetTables() {
   auto tables = New<ConfigList>();
   tables->Append((*this)["name"]);
   auto imports = (*this)["import_tables"].AsList();

--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -103,7 +103,7 @@ void DictEntryIterator::PrepareEntry() {
   }
 }
 
-shared_ptr<DictEntry> DictEntryIterator::Peek() {
+a<DictEntry> DictEntryIterator::Peek() {
   while (!entry_ && !empty()) {
     PrepareEntry();
     if (filter_ && !filter_(entry_)) {
@@ -145,9 +145,9 @@ bool DictEntryIterator::Skip(size_t num_entries) {
 
 // Dictionary members
 
-Dictionary::Dictionary(const std::string& name,
-                       const shared_ptr<Table>& table,
-                       const shared_ptr<Prism>& prism)
+Dictionary::Dictionary(const string& name,
+                       const a<Table>& table,
+                       const a<Prism>& prism)
     : name_(name), table_(table), prism_(prism) {
 }
 
@@ -155,7 +155,7 @@ Dictionary::~Dictionary() {
   // should not close shared table and prism objects
 }
 
-shared_ptr<DictEntryCollector>
+a<DictEntryCollector>
 Dictionary::Lookup(const SyllableGraph& syllable_graph,
                    size_t start_pos,
                    double initial_credibility) {
@@ -194,13 +194,13 @@ Dictionary::Lookup(const SyllableGraph& syllable_graph,
 }
 
 size_t Dictionary::LookupWords(DictEntryIterator* result,
-                               const std::string& str_code,
+                               const string& str_code,
                                bool predictive,
                                size_t expand_search_limit) {
   DLOG(INFO) << "lookup: " << str_code;
   if (!loaded())
     return 0;
-  std::vector<Prism::Match> keys;
+  vector<Prism::Match> keys;
   if (predictive) {
     prism_->ExpandSearch(str_code, &keys, expand_search_limit);
   }
@@ -219,9 +219,9 @@ size_t Dictionary::LookupWords(DictEntryIterator* result,
       SpellingType type = accessor.properties().type;
       accessor.Next();
       if (type > kNormalSpelling) continue;
-      std::string remaining_code;
+      string remaining_code;
       if (match.length > code_length) {
-        std::string syllable = table_->GetSyllableById(syllable_id);
+        string syllable = table_->GetSyllableById(syllable_id);
         if (syllable.length() > code_length)
           remaining_code = syllable.substr(code_length);
       }
@@ -235,12 +235,12 @@ size_t Dictionary::LookupWords(DictEntryIterator* result,
   return keys.size();
 }
 
-bool Dictionary::Decode(const Code& code, std::vector<std::string>* result) {
+bool Dictionary::Decode(const Code& code, vector<string>* result) {
   if (!result || !table_)
     return false;
   result->clear();
   for (SyllableId c : code) {
-    std::string s = table_->GetSyllableById(c);
+    string s = table_->GetSyllableById(c);
     if (s.empty())
       return false;
     result->push_back(s);
@@ -285,7 +285,7 @@ DictionaryComponent::DictionaryComponent() {
 Dictionary* DictionaryComponent::Create(const Ticket& ticket) {
   if (!ticket.schema) return NULL;
   Config* config = ticket.schema->config();
-  std::string dict_name;
+  string dict_name;
   if (!config->GetString(ticket.name_space + "/dictionary", &dict_name)) {
     LOG(ERROR) << ticket.name_space << "/dictionary not specified in schema '"
                << ticket.schema->schema_id() << "'.";
@@ -294,7 +294,7 @@ Dictionary* DictionaryComponent::Create(const Ticket& ticket) {
   if (dict_name.empty()) {
     return NULL;  // not requiring static dictionary
   }
-  std::string prism_name;
+  string prism_name;
   if (!config->GetString(ticket.name_space + "/prism", &prism_name)) {
     prism_name = dict_name;
   }
@@ -302,8 +302,8 @@ Dictionary* DictionaryComponent::Create(const Ticket& ticket) {
 }
 
 Dictionary*
-DictionaryComponent::CreateDictionaryWithName(const std::string& dict_name,
-                                              const std::string& prism_name) {
+DictionaryComponent::CreateDictionaryWithName(const string& dict_name,
+                                              const string& prism_name) {
   // obtain prism and table objects
   boost::filesystem::path path(Service::instance().deployer().user_data_dir);
   auto table = table_map_[dict_name].lock();

--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -103,7 +103,7 @@ void DictEntryIterator::PrepareEntry() {
   }
 }
 
-a<DictEntry> DictEntryIterator::Peek() {
+an<DictEntry> DictEntryIterator::Peek() {
   while (!entry_ && !empty()) {
     PrepareEntry();
     if (filter_ && !filter_(entry_)) {
@@ -146,8 +146,8 @@ bool DictEntryIterator::Skip(size_t num_entries) {
 // Dictionary members
 
 Dictionary::Dictionary(const string& name,
-                       const a<Table>& table,
-                       const a<Prism>& prism)
+                       const an<Table>& table,
+                       const an<Prism>& prism)
     : name_(name), table_(table), prism_(prism) {
 }
 
@@ -155,7 +155,7 @@ Dictionary::~Dictionary() {
   // should not close shared table and prism objects
 }
 
-a<DictEntryCollector>
+an<DictEntryCollector>
 Dictionary::Lookup(const SyllableGraph& syllable_graph,
                    size_t start_pos,
                    double initial_credibility) {

--- a/src/dict/entry_collector.cc
+++ b/src/dict/entry_collector.cc
@@ -33,8 +33,8 @@ void EntryCollector::Configure(DictSettings* settings) {
   encoder->LoadSettings(settings);
 }
 
-void EntryCollector::Collect(const std::vector<std::string>& dict_files) {
-  for (const std::string& dict_file : dict_files) {
+void EntryCollector::Collect(const vector<string>& dict_files) {
+  for (const string& dict_file : dict_files) {
     Collect(dict_file);
   }
   Finish();
@@ -51,7 +51,7 @@ void EntryCollector::LoadPresetVocabulary(DictSettings* settings) {
   }
 }
 
-void EntryCollector::Collect(const std::string& dict_file) {
+void EntryCollector::Collect(const string& dict_file) {
   LOG(INFO) << "collecting entries from " << dict_file;
   // read table
   std::ifstream fin(dict_file.c_str());
@@ -70,7 +70,7 @@ void EntryCollector::Collect(const std::string& dict_file) {
     return;
   }
   bool enable_comment = true;
-  std::string line;
+  string line;
   while (getline(fin, line)) {
     boost::algorithm::trim_right(line);
     // skip empty lines and comments
@@ -83,7 +83,7 @@ void EntryCollector::Collect(const std::string& dict_file) {
       continue;
     }
     // read a dict entry
-    std::vector<std::string> row;
+    vector<string> row;
     boost::algorithm::split(row, line,
                             boost::algorithm::is_any_of("\t"));
     int num_columns = static_cast<int>(row.size());
@@ -92,9 +92,9 @@ void EntryCollector::Collect(const std::string& dict_file) {
       continue;
     }
     const auto& word(row[text_column]);
-    std::string code_str;
-    std::string weight_str;
-    std::string stem_str;
+    string code_str;
+    string weight_str;
+    string stem_str;
     if (code_column != -1 &&
         num_columns > code_column && !row[code_column].empty())
       code_str = row[code_column];
@@ -136,7 +136,7 @@ void EntryCollector::Finish() {
   LOG(INFO) << "Pass 2: total " << num_entries << " entries collected.";
   if (preset_vocabulary) {
     preset_vocabulary->Reset();
-    std::string phrase, weight_str;
+    string phrase, weight_str;
     while (preset_vocabulary->GetNextEntry(&phrase, &weight_str)) {
       if (collection.find(phrase) != collection.end())
         continue;
@@ -148,9 +148,9 @@ void EntryCollector::Finish() {
   LOG(INFO) << "Pass 3: total " << num_entries << " entries collected.";
 }
 
-void EntryCollector::CreateEntry(const std::string &word,
-                                 const std::string &code_str,
-                                 const std::string &weight_str) {
+void EntryCollector::CreateEntry(const string &word,
+                                 const string &code_str,
+                                 const string &weight_str) {
   RawDictEntry e;
   e.raw_code.FromString(code_str);
   e.text = word;
@@ -181,7 +181,7 @@ void EntryCollector::CreateEntry(const std::string &word,
     }
   }
   // learn new syllables
-  for (const std::string& s : e.raw_code) {
+  for (const string& s : e.raw_code) {
     if (syllabary.find(s) == syllabary.end())
       syllabary.insert(s);
   }
@@ -200,11 +200,11 @@ void EntryCollector::CreateEntry(const std::string &word,
   ++num_entries;
 }
 
-bool EntryCollector::TranslateWord(const std::string& word,
-                                   std::vector<std::string>* result) {
+bool EntryCollector::TranslateWord(const string& word,
+                                   vector<string>* result) {
   ReverseLookupTable::const_iterator s = stems.find(word);
   if (s != stems.end()) {
-    for (const std::string& stem : s->second) {
+    for (const string& stem : s->second) {
       result->push_back(stem);
     }
     return true;
@@ -223,10 +223,10 @@ bool EntryCollector::TranslateWord(const std::string& word,
   return false;
 }
 
-void EntryCollector::Dump(const std::string& file_name) const {
+void EntryCollector::Dump(const string& file_name) const {
   std::ofstream out(file_name.c_str());
   out << "# syllabary:" << std::endl;
-  for (const std::string& syllable : syllabary) {
+  for (const string& syllable : syllabary) {
     out << "# - " << syllable << std::endl;
   }
   out << std::endl;

--- a/src/dict/level_db.cc
+++ b/src/dict/level_db.cc
@@ -167,18 +167,18 @@ void LevelDb::Initialize() {
   db_.reset(new LevelDbWrapper);
 }
 
-a<DbAccessor> LevelDb::QueryMetadata() {
+an<DbAccessor> LevelDb::QueryMetadata() {
   return Query(kMetaCharacter);
 }
 
-a<DbAccessor> LevelDb::QueryAll() {
-  a<DbAccessor> all = Query("");
+an<DbAccessor> LevelDb::QueryAll() {
+  an<DbAccessor> all = Query("");
   if (all)
     all->Jump(" ");  // skip metadata
   return all;
 }
 
-a<DbAccessor> LevelDb::Query(const string& key) {
+an<DbAccessor> LevelDb::Query(const string& key) {
   if (!loaded())
     return nullptr;
   return New<LevelDbAccessor>(db_->CreateCursor(), key);

--- a/src/dict/mapped_file.cc
+++ b/src/dict/mapped_file.cc
@@ -47,7 +47,7 @@ class MappedFileImpl {
     kOpenReadWrite,
   };
 
-  MappedFileImpl(const std::string& file_name, OpenMode mode) {
+  MappedFileImpl(const string& file_name, OpenMode mode) {
     boost::interprocess::mode_t file_mapping_mode =
         (mode == kOpenReadOnly) ? boost::interprocess::read_only
                                 : boost::interprocess::read_write;
@@ -69,12 +69,12 @@ class MappedFileImpl {
   }
 
  private:
-  unique_ptr<boost::interprocess::file_mapping> file_;
-  unique_ptr<boost::interprocess::mapped_region> region_;
+  the<boost::interprocess::file_mapping> file_;
+  the<boost::interprocess::mapped_region> region_;
 
 };
 
-MappedFile::MappedFile(const std::string& file_name)
+MappedFile::MappedFile(const string& file_name)
     : file_name_(file_name) {
 }
 
@@ -172,7 +172,7 @@ bool MappedFile::Resize(size_t capacity) {
   return true;
 }
 
-String* MappedFile::CreateString(const std::string& str) {
+String* MappedFile::CreateString(const string& str) {
   String* ret = Allocate<String>();
   if (ret && !str.empty()) {
     CopyString(str, ret);
@@ -180,7 +180,7 @@ String* MappedFile::CreateString(const std::string& str) {
   return ret;
 }
 
-bool MappedFile::CopyString(const std::string& src, String* dest) {
+bool MappedFile::CopyString(const string& src, String* dest) {
   if (!dest)
     return false;
   size_t size = src.length() + 1;

--- a/src/dict/preset_vocabulary.cc
+++ b/src/dict/preset_vocabulary.cc
@@ -14,18 +14,18 @@
 namespace rime {
 
 struct VocabularyDb : public TextDb {
-  explicit VocabularyDb(const std::string& path);
-  shared_ptr<DbAccessor> cursor;
+  explicit VocabularyDb(const string& path);
+  a<DbAccessor> cursor;
   static const TextFormat format;
 };
 
-VocabularyDb::VocabularyDb(const std::string& path)
+VocabularyDb::VocabularyDb(const string& path)
     : TextDb(path, "vocabulary", VocabularyDb::format) {
 }
 
 static bool rime_vocabulary_entry_parser(const Tsv& row,
-                                         std::string* key,
-                                         std::string* value) {
+                                         string* key,
+                                         string* value) {
   if (row.size() < 1 || row[0].empty()) {
     return false;
   }
@@ -34,8 +34,8 @@ static bool rime_vocabulary_entry_parser(const Tsv& row,
   return true;
 }
 
-static bool rime_vocabulary_entry_formatter(const std::string& key,
-                                            const std::string& value,
+static bool rime_vocabulary_entry_formatter(const string& key,
+                                            const string& value,
                                             Tsv* tsv) {
   //Tsv& row(*tsv);
   //row.push_back(key);
@@ -49,7 +49,7 @@ const TextFormat VocabularyDb::format = {
   "Rime vocabulary",
 };
 
-std::string PresetVocabulary::DictFilePath() {
+string PresetVocabulary::DictFilePath() {
   boost::filesystem::path path(Service::instance().deployer().shared_data_dir);
   path /= "essay.txt";
   return path.string();
@@ -67,8 +67,8 @@ PresetVocabulary::~PresetVocabulary() {
     db_->Close();
 }
 
-bool PresetVocabulary::GetWeightForEntry(const std::string &key, double *weight) {
-  std::string weight_str;
+bool PresetVocabulary::GetWeightForEntry(const string &key, double *weight) {
+  string weight_str;
   if (!db_ || !db_->Fetch(key, &weight_str))
     return false;
   try {
@@ -85,7 +85,7 @@ void PresetVocabulary::Reset() {
     db_->cursor->Reset();
 }
 
-bool PresetVocabulary::GetNextEntry(std::string *key, std::string *value) {
+bool PresetVocabulary::GetNextEntry(string *key, string *value) {
   if (!db_ || !db_->cursor)
     return false;
   bool got = false;
@@ -96,8 +96,8 @@ bool PresetVocabulary::GetNextEntry(std::string *key, std::string *value) {
   return got;
 }
 
-bool PresetVocabulary::IsQualifiedPhrase(const std::string& phrase,
-                                         const std::string& weight_str) {
+bool PresetVocabulary::IsQualifiedPhrase(const string& phrase,
+                                         const string& weight_str) {
   if (max_phrase_length_ > 0) {
     size_t length = utf8::unchecked::distance(phrase.c_str(),
                                               phrase.c_str() + phrase.length());

--- a/src/dict/preset_vocabulary.cc
+++ b/src/dict/preset_vocabulary.cc
@@ -15,7 +15,7 @@ namespace rime {
 
 struct VocabularyDb : public TextDb {
   explicit VocabularyDb(const string& path);
-  a<DbAccessor> cursor;
+  an<DbAccessor> cursor;
   static const TextFormat format;
 };
 

--- a/src/dict/prism.cc
+++ b/src/dict/prism.cc
@@ -11,16 +11,16 @@
 #include <rime/algo/algebra.h>
 #include <rime/dict/prism.h>
 
+namespace rime {
+
 namespace {
 
 struct node_t {
-  rime::string key;
+  string key;
   size_t node_pos;
 };
 
 }  // namespace
-
-namespace rime {
 
 const char kPrismFormat[] = "Rime::Prism/1.0";
 

--- a/src/dict/prism.cc
+++ b/src/dict/prism.cc
@@ -14,7 +14,7 @@
 namespace {
 
 struct node_t {
-  std::string key;
+  rime::string key;
   size_t node_pos;
 };
 
@@ -69,7 +69,7 @@ SpellingProperties SpellingAccessor::properties() const {
   return props;
 }
 
-Prism::Prism(const std::string& file_name)
+Prism::Prism(const string& file_name)
   : MappedFile(file_name), trie_(new Darts::DoubleArray) {
 }
 
@@ -130,7 +130,7 @@ bool Prism::Build(const Syllabary& syllabary,
   // building double-array trie
   size_t num_syllables = syllabary.size();
   size_t num_spellings = script ? script->size() : syllabary.size();
-  std::vector<const char*> keys(num_spellings);
+  vector<const char*> keys(num_spellings);
   size_t key_id = 0;
   size_t map_size = 0;
   if (script) {
@@ -172,12 +172,12 @@ bool Prism::Build(const Syllabary& syllabary,
   metadata_ = metadata;
   // alphabet
   {
-    std::set<char> alphabet;
+    set<char> alphabet;
     for (size_t i = 0; i < num_spellings; ++i)
       for (const char* p = keys[i]; *p; ++p)
         alphabet.insert(*p);
     char* p = metadata->alphabet;
-    std::set<char>::const_iterator c = alphabet.begin();
+    set<char>::const_iterator c = alphabet.begin();
     for (; c != alphabet.end(); ++p, ++c)
       *p = *c;
     *p = '\0';
@@ -193,7 +193,7 @@ bool Prism::Build(const Syllabary& syllabary,
   metadata->double_array_size = array_size;
   // building spelling map
   if (script) {
-    std::map<std::string, SyllableId> syllable_to_id;
+    map<string, SyllableId> syllable_to_id;
     SyllableId syll_id = 0;
     for (auto it = syllabary.begin(); it != syllabary.end(); ++it) {
       syllable_to_id[*it] = syll_id++;
@@ -235,12 +235,12 @@ bool Prism::Build(const Syllabary& syllabary,
   return true;
 }
 
-bool Prism::HasKey(const std::string& key) {
+bool Prism::HasKey(const string& key) {
   int value = trie_->exactMatchSearch<int>(key.c_str());
   return value != -1;
 }
 
-bool Prism::GetValue(const std::string& key, int* value) {
+bool Prism::GetValue(const string& key, int* value) {
   int result = trie_->exactMatchSearch<int>(key.c_str());
   if (result == -1) {
     return false;
@@ -251,8 +251,8 @@ bool Prism::GetValue(const std::string& key, int* value) {
 
 // Given a key, search all the keys in the tree that share
 // a common prefix with that key.
-void Prism::CommonPrefixSearch(const std::string& key,
-                               std::vector<Match>* result) {
+void Prism::CommonPrefixSearch(const string& key,
+                               vector<Match>* result) {
   if (!result || key.empty())
     return;
   size_t len = key.length();
@@ -262,8 +262,8 @@ void Prism::CommonPrefixSearch(const std::string& key,
   result->resize(num_results);
 }
 
-void Prism::ExpandSearch(const std::string& key,
-                         std::vector<Match>* result,
+void Prism::ExpandSearch(const string& key,
+                         vector<Match>* result,
                          size_t limit) {
   if (!result)
     return;
@@ -288,7 +288,7 @@ void Prism::ExpandSearch(const std::string& key,
     const char* c = (format_ > 1.0 - DBL_EPSILON) ? metadata_->alphabet
                                                   : kDefaultAlphabet;
     for (; *c; ++c) {
-      std::string k = node.key + *c;
+      string k = node.key + *c;
       size_t k_pos = node.key.length();
       size_t n_pos = node.node_pos;
       ret = trie_->traverse(k.c_str(), n_pos, k_pos);

--- a/src/dict/reverse_lookup_dictionary.cc
+++ b/src/dict/reverse_lookup_dictionary.cc
@@ -196,7 +196,7 @@ uint32_t ReverseDb::dict_file_checksum() const {
   return metadata_ ? metadata_->dict_file_checksum : 0;
 }
 
-ReverseLookupDictionary::ReverseLookupDictionary(a<ReverseDb> db)
+ReverseLookupDictionary::ReverseLookupDictionary(an<ReverseDb> db)
     : db_(db) {
 }
 
@@ -219,8 +219,8 @@ bool ReverseLookupDictionary::LookupStems(const string& text,
   return db_->Lookup(text + kStemKeySuffix, result);
 }
 
-a<DictSettings> ReverseLookupDictionary::GetDictSettings() {
-  a<DictSettings> settings;
+an<DictSettings> ReverseLookupDictionary::GetDictSettings() {
+  an<DictSettings> settings;
   reverse::Metadata* metadata = db_->metadata();
   if (metadata && !metadata->dict_settings.empty()) {
     string yaml(metadata->dict_settings.c_str());

--- a/src/dict/reverse_lookup_dictionary.cc
+++ b/src/dict/reverse_lookup_dictionary.cc
@@ -24,12 +24,12 @@ const size_t kReverseFormatPrefixLen = sizeof(kReverseFormatPrefix) - 1;
 
 static const char* kStemKeySuffix = "\x1fstem";
 
-static std::string reverse_db_file_name(const std::string& dict_name) {
+static string reverse_db_file_name(const string& dict_name) {
   boost::filesystem::path dir(Service::instance().deployer().user_data_dir);
   return (dir / dict_name).string() + ".reverse.bin";
 }
 
-ReverseDb::ReverseDb(const std::string& dict_name)
+ReverseDb::ReverseDb(const string& dict_name)
     : MappedFile(reverse_db_file_name(dict_name)) {
 }
 
@@ -66,7 +66,7 @@ bool ReverseDb::Load() {
   return true;
 }
 
-bool ReverseDb::Lookup(const std::string& text, std::string* result) {
+bool ReverseDb::Lookup(const string& text, string* result) {
   if (!key_trie_ || !value_trie_ || !metadata_->index.size) {
     return false;
   }
@@ -87,7 +87,7 @@ bool ReverseDb::Build(DictSettings* settings,
   LOG(INFO) << "building reversedb...";
   ReverseLookupTable rev_table;
   int syllable_id = 0;
-  for (const std::string& syllable : syllabary) {
+  for (const string& syllable : syllabary) {
     auto it = vocabulary.find(syllable_id++);
     if (it == vocabulary.end())
       continue;
@@ -99,21 +99,21 @@ bool ReverseDb::Build(DictSettings* settings,
   StringTableBuilder key_trie_builder;
   StringTableBuilder value_trie_builder;
   size_t entry_count = rev_table.size() + stems.size();
-  std::vector<StringId> key_ids(entry_count);
-  std::vector<StringId> value_ids(entry_count);
+  vector<StringId> key_ids(entry_count);
+  vector<StringId> value_ids(entry_count);
   int i = 0;
   // save reverse lookup entries
   for (const auto& v : rev_table) {
-    const std::string& key(v.first);
-    std::string value(boost::algorithm::join(v.second, " "));
+    const string& key(v.first);
+    string value(boost::algorithm::join(v.second, " "));
     key_trie_builder.Add(key, 1.0, &key_ids[i]);
     value_trie_builder.Add(value, 1.0, &value_ids[i]);
     ++i;
   }
   // save stems
   for (const auto& v : stems) {
-    std::string key(v.first + kStemKeySuffix);
-    std::string value(boost::algorithm::join(v.second, " "));
+    string key(v.first + kStemKeySuffix);
+    string value(boost::algorithm::join(v.second, " "));
     key_trie_builder.Add(key, 1.0, &key_ids[i]);
     value_trie_builder.Add(value, 1.0, &value_ids[i]);
     ++i;
@@ -122,7 +122,7 @@ bool ReverseDb::Build(DictSettings* settings,
   value_trie_builder.Build();
 
   // dict settings required by UniTE
-  std::string dict_settings;
+  string dict_settings;
   if (settings && settings->use_rule_based_encoder()) {
     std::ostringstream yaml;
     settings->SaveToStream(yaml);
@@ -196,11 +196,11 @@ uint32_t ReverseDb::dict_file_checksum() const {
   return metadata_ ? metadata_->dict_file_checksum : 0;
 }
 
-ReverseLookupDictionary::ReverseLookupDictionary(shared_ptr<ReverseDb> db)
+ReverseLookupDictionary::ReverseLookupDictionary(a<ReverseDb> db)
     : db_(db) {
 }
 
-ReverseLookupDictionary::ReverseLookupDictionary(const std::string& dict_name)
+ReverseLookupDictionary::ReverseLookupDictionary(const string& dict_name)
     : db_(new ReverseDb(dict_name)) {
 }
 
@@ -208,22 +208,22 @@ bool ReverseLookupDictionary::Load() {
   return db_ && (db_->IsOpen() || db_->Load());
 }
 
-bool ReverseLookupDictionary::ReverseLookup(const std::string& text,
-                                            std::string* result) {
+bool ReverseLookupDictionary::ReverseLookup(const string& text,
+                                            string* result) {
   return db_->Lookup(text, result);
 
 }
 
-bool ReverseLookupDictionary::LookupStems(const std::string& text,
-                                          std::string* result) {
+bool ReverseLookupDictionary::LookupStems(const string& text,
+                                          string* result) {
   return db_->Lookup(text + kStemKeySuffix, result);
 }
 
-shared_ptr<DictSettings> ReverseLookupDictionary::GetDictSettings() {
-  shared_ptr<DictSettings> settings;
+a<DictSettings> ReverseLookupDictionary::GetDictSettings() {
+  a<DictSettings> settings;
   reverse::Metadata* metadata = db_->metadata();
   if (metadata && !metadata->dict_settings.empty()) {
-    std::string yaml(metadata->dict_settings.c_str());
+    string yaml(metadata->dict_settings.c_str());
     std::istringstream iss(yaml);
     settings = New<DictSettings>();
     if (!settings->LoadFromStream(iss)) {
@@ -240,7 +240,7 @@ ReverseLookupDictionary*
 ReverseLookupDictionaryComponent::Create(const Ticket& ticket) {
   if (!ticket.schema) return NULL;
   Config* config = ticket.schema->config();
-  std::string dict_name;
+  string dict_name;
   if (!config->GetString(ticket.name_space + "/dictionary",
                          &dict_name)) {
     // missing!

--- a/src/dict/string_table.cc
+++ b/src/dict/string_table.cc
@@ -16,13 +16,13 @@ StringTable::StringTable(const char* ptr, size_t size) {
   trie_.map(ptr, size);
 }
 
-bool StringTable::HasKey(const std::string& key) {
+bool StringTable::HasKey(const string& key) {
   marisa::Agent agent;
   agent.set_query(key.c_str());
   return trie_.lookup(agent);
 }
 
-StringId StringTable::Lookup(const std::string& key) {
+StringId StringTable::Lookup(const string& key) {
   marisa::Agent agent;
   agent.set_query(key.c_str());
   if(trie_.lookup(agent)) {
@@ -33,8 +33,8 @@ StringId StringTable::Lookup(const std::string& key) {
   }
 }
 
-void StringTable::CommonPrefixMatch(const std::string& query,
-                                    std::vector<StringId>* result) {
+void StringTable::CommonPrefixMatch(const string& query,
+                                    vector<StringId>* result) {
   marisa::Agent agent;
   agent.set_query(query.c_str());
   result->clear();
@@ -43,8 +43,8 @@ void StringTable::CommonPrefixMatch(const std::string& query,
   }
 }
 
-void StringTable::Predict(const std::string& query,
-                          std::vector<StringId>* result) {
+void StringTable::Predict(const string& query,
+                          vector<StringId>* result) {
   marisa::Agent agent;
   agent.set_query(query.c_str());
   result->clear();
@@ -53,7 +53,7 @@ void StringTable::Predict(const std::string& query,
   }
 }
 
-std::string StringTable::GetString(StringId string_id) {
+string StringTable::GetString(StringId string_id) {
   marisa::Agent agent;
   agent.set_query(string_id);
   try {
@@ -61,9 +61,9 @@ std::string StringTable::GetString(StringId string_id) {
   }
   catch (const marisa::Exception& ex) {
     LOG(ERROR) << "invalid id for string table: " << string_id;
-    return std::string();
+    return string();
   }
-  return std::string(agent.key().ptr(), agent.key().length());
+  return string(agent.key().ptr(), agent.key().length());
 }
 
 size_t StringTable::NumKeys() const {
@@ -74,7 +74,7 @@ size_t StringTable::BinarySize() const {
   return trie_.io_size();
 }
 
-void StringTableBuilder::Add(const std::string& key,
+void StringTableBuilder::Add(const string& key,
                              double weight,
                              StringId* reference) {
   keys_.push_back(key.c_str(), key.length(), (float)weight);

--- a/src/dict/table.cc
+++ b/src/dict/table.cc
@@ -623,7 +623,7 @@ bool Table::Query(const SyllableGraph& syll_graph, size_t start_pos,
       start_pos >= syll_graph.interpreted_length)
     return false;
   result->clear();
-  std::queue<std::pair<size_t, TableQuery>> q;
+  std::queue<pair<size_t, TableQuery>> q;
   TableQuery initial_state(index_);
   q.push({start_pos, initial_state});
   while (!q.empty()) {

--- a/src/dict/table.cc
+++ b/src/dict/table.cc
@@ -8,7 +8,6 @@
 #include <cstring>
 #include <algorithm>
 #include <queue>
-#include <vector>
 #include <utility>
 #include <rime/common.h>
 #include <rime/algo/syllabifier.h>
@@ -45,7 +44,7 @@ class TableQuery {
  protected:
   size_t level_ = 0;
   Code index_code_;
-  std::vector<double> credibility_;
+  vector<double> credibility_;
 
  private:
   bool Walk(SyllableId syllable_id);
@@ -245,20 +244,20 @@ TableAccessor TableQuery::Access(SyllableId syllable_id,
   return TableAccessor();
 }
 
-std::string Table::GetString_v1(const table::StringType& x) {
+string Table::GetString_v1(const table::StringType& x) {
  return x.str().c_str();
 }
 
-bool Table::AddString_v1(const std::string& src, table::StringType* dest,
+bool Table::AddString_v1(const string& src, table::StringType* dest,
                          double /*weight*/) {
   return CopyString(src, &dest->str());
 }
 
-std::string Table::GetString_v2(const table::StringType& x) {
+string Table::GetString_v2(const table::StringType& x) {
   return string_table_->GetString(x.str_id());
 }
 
-bool Table::AddString_v2(const std::string& src, table::StringType* dest,
+bool Table::AddString_v2(const string& src, table::StringType* dest,
                          double weight) {
   string_table_builder_->Add(src, weight, &dest->str_id());
   return true;
@@ -309,7 +308,7 @@ void Table::SelectTableFormat(double format_version) {
   }
 }
 
-Table::Table(const std::string& file_name) : MappedFile(file_name) {
+Table::Table(const string& file_name) : MappedFile(file_name) {
 }
 
 Table::~Table() {
@@ -413,7 +412,7 @@ bool Table::Build(const Syllabary& syllabary, const Vocabulary& vocabulary,
   }
   else {
     size_t i = 0;
-    for (const std::string& syllable : syllabary) {
+    for (const string& syllable : syllabary) {
       RIME_THIS_CALL(format_.AddString)(syllable, &syllabary_->at[i++], 0.0);
     }
   }
@@ -591,11 +590,11 @@ bool Table::GetSyllabary(Syllabary* result) {
   }
   return true;
 }
-std::string Table::GetSyllableById(SyllableId syllable_id) {
+string Table::GetSyllableById(SyllableId syllable_id) {
   if (!syllabary_ ||
       syllable_id < 0 ||
       syllable_id >= static_cast<SyllableId>(syllabary_->size))
-    return std::string();
+    return string();
   return RIME_THIS_CALL(format_.GetString)(syllabary_->at[syllable_id]);
 }
 
@@ -661,7 +660,7 @@ bool Table::Query(const SyllableGraph& syll_graph, size_t start_pos,
   return !result->empty();
 }
 
-std::string Table::GetEntryText(const table::Entry& entry) {
+string Table::GetEntryText(const table::Entry& entry) {
   return RIME_THIS_CALL(format_.GetString)(entry.text);
 }
 

--- a/src/dict/table_db.cc
+++ b/src/dict/table_db.cc
@@ -17,13 +17,13 @@
 namespace rime {
 
 static bool rime_table_entry_parser(const Tsv& row,
-                                    std::string* key,
-                                    std::string* value) {
+                                    string* key,
+                                    string* value) {
   if (row.size() < 2 ||
       row[0].empty() || row[1].empty()) {
     return false;
   }
-  std::string code(row[1]);
+  string code(row[1]);
   boost::algorithm::trim(code);
   *key = code + " \t" + row[0];
   UserDbValue v;
@@ -40,8 +40,8 @@ static bool rime_table_entry_parser(const Tsv& row,
   return true;
 }
 
-static bool rime_table_entry_formatter(const std::string& key,
-                                       const std::string& value,
+static bool rime_table_entry_formatter(const string& key,
+                                       const string& value,
                                        Tsv* tsv) {
   Tsv& row(*tsv);
   // key ::= code <space> <Tab> phrase
@@ -55,7 +55,7 @@ static bool rime_table_entry_formatter(const std::string& key,
     return false;
   boost::algorithm::trim(row[0]);  // remove trailing space
   row[0].swap(row[1]);
-  row.push_back(boost::lexical_cast<std::string>(v.commits));
+  row.push_back(boost::lexical_cast<string>(v.commits));
   return true;
 }
 
@@ -65,13 +65,13 @@ const TextFormat TableDb::format = {
   "Rime table",
 };
 
-TableDb::TableDb(const std::string& name)
+TableDb::TableDb(const string& name)
     : TextDb(name + ".txt", "tabledb", TableDb::format) {
 }
 
 // StableDb
 
-StableDb::StableDb(const std::string& name)
+StableDb::StableDb(const string& name)
     : TableDb(name) {}
 
 bool StableDb::Open() {

--- a/src/dict/text_db.cc
+++ b/src/dict/text_db.cc
@@ -12,7 +12,7 @@ namespace rime {
 // TextDbAccessor memebers
 
 TextDbAccessor::TextDbAccessor(const TextDbData& data,
-                               const std::string& prefix)
+                               const string& prefix)
     : DbAccessor(prefix), data_(data) {
   Reset();
 }
@@ -25,12 +25,12 @@ bool TextDbAccessor::Reset() {
   return iter_ != data_.end();
 }
 
-bool TextDbAccessor::Jump(const std::string& key) {
+bool TextDbAccessor::Jump(const string& key) {
   iter_ = data_.lower_bound(key);
   return iter_ != data_.end();
 }
 
-bool TextDbAccessor::GetNextRecord(std::string* key, std::string* value) {
+bool TextDbAccessor::GetNextRecord(string* key, string* value) {
   if (!key || !value || exhausted())
     return false;
   *key = iter_->first;
@@ -45,8 +45,8 @@ bool TextDbAccessor::exhausted() {
 
 // TextDb members
 
-TextDb::TextDb(const std::string& name,
-               const std::string& db_type,
+TextDb::TextDb(const string& name,
+               const string& db_type,
                TextFormat format)
     : Db(name), db_type_(db_type), format_(format) {
 }
@@ -56,23 +56,23 @@ TextDb::~TextDb() {
     Close();
 }
 
-shared_ptr<DbAccessor> TextDb::QueryMetadata() {
+a<DbAccessor> TextDb::QueryMetadata() {
   if (!loaded())
     return nullptr;
   return New<TextDbAccessor>(metadata_, "");
 }
 
-shared_ptr<DbAccessor> TextDb::QueryAll() {
+a<DbAccessor> TextDb::QueryAll() {
   return Query("");
 }
 
-shared_ptr<DbAccessor> TextDb::Query(const std::string& key) {
+a<DbAccessor> TextDb::Query(const string& key) {
   if (!loaded())
     return nullptr;
   return New<TextDbAccessor>(data_, key);
 }
 
-bool TextDb::Fetch(const std::string& key, std::string* value) {
+bool TextDb::Fetch(const string& key, string* value) {
   if (!value || !loaded())
     return false;
   TextDbData::const_iterator it = data_.find(key);
@@ -82,7 +82,7 @@ bool TextDb::Fetch(const std::string& key, std::string* value) {
   return true;
 }
 
-bool TextDb::Update(const std::string& key, const std::string& value) {
+bool TextDb::Update(const string& key, const string& value) {
   if (!loaded() || readonly())
     return false;
   DLOG(INFO) << "update db entry: " << key << " => " << value;
@@ -91,7 +91,7 @@ bool TextDb::Update(const std::string& key, const std::string& value) {
   return true;
 }
 
-bool TextDb::Erase(const std::string& key) {
+bool TextDb::Erase(const string& key) {
   if (!loaded() || readonly())
     return false;
   DLOG(INFO) << "erase db entry: " << key;
@@ -108,7 +108,7 @@ bool TextDb::Open() {
   readonly_ = false;
   loaded_ = !Exists() || LoadFromFile(file_name());
   if (loaded_) {
-    std::string db_name;
+    string db_name;
     if (!MetaFetch("/db_name", &db_name)) {
       if (!CreateMetadata()) {
         LOG(ERROR) << "error creating metadata.";
@@ -156,7 +156,7 @@ void TextDb::Clear() {
   data_.clear();
 }
 
-bool TextDb::Backup(const std::string& snapshot_file) {
+bool TextDb::Backup(const string& snapshot_file) {
   if (!loaded())
     return false;
   LOG(INFO) << "backing up db '" << name() << "' to " << snapshot_file;
@@ -168,7 +168,7 @@ bool TextDb::Backup(const std::string& snapshot_file) {
   return true;
 }
 
-bool TextDb::Restore(const std::string& snapshot_file) {
+bool TextDb::Restore(const string& snapshot_file) {
   if (!loaded() || readonly())
     return false;
   if (!LoadFromFile(snapshot_file)) {
@@ -185,7 +185,7 @@ bool TextDb::CreateMetadata() {
       MetaUpdate("/db_type", db_type_);
 }
 
-bool TextDb::MetaFetch(const std::string& key, std::string* value) {
+bool TextDb::MetaFetch(const string& key, string* value) {
   if (!value || !loaded())
     return false;
   TextDbData::const_iterator it = metadata_.find(key);
@@ -195,7 +195,7 @@ bool TextDb::MetaFetch(const std::string& key, std::string* value) {
   return true;
 }
 
-bool TextDb::MetaUpdate(const std::string& key, const std::string& value) {
+bool TextDb::MetaUpdate(const string& key, const string& value) {
   if (!loaded() || readonly())
     return false;
   DLOG(INFO) << "update db metadata: " << key << " => " << value;
@@ -204,7 +204,7 @@ bool TextDb::MetaUpdate(const std::string& key, const std::string& value) {
   return true;
 }
 
-bool TextDb::LoadFromFile(const std::string& file) {
+bool TextDb::LoadFromFile(const string& file) {
   Clear();
   TsvReader reader(file, format_.parser);
   DbSink sink(this);
@@ -220,7 +220,7 @@ bool TextDb::LoadFromFile(const std::string& file) {
   return true;
 }
 
-bool TextDb::SaveToFile(const std::string& file) {
+bool TextDb::SaveToFile(const string& file) {
   TsvWriter writer(file, format_.formatter);
   writer.file_description = format_.file_description;
   DbSource source(this);

--- a/src/dict/text_db.cc
+++ b/src/dict/text_db.cc
@@ -56,17 +56,17 @@ TextDb::~TextDb() {
     Close();
 }
 
-a<DbAccessor> TextDb::QueryMetadata() {
+an<DbAccessor> TextDb::QueryMetadata() {
   if (!loaded())
     return nullptr;
   return New<TextDbAccessor>(metadata_, "");
 }
 
-a<DbAccessor> TextDb::QueryAll() {
+an<DbAccessor> TextDb::QueryAll() {
   return Query("");
 }
 
-a<DbAccessor> TextDb::Query(const string& key) {
+an<DbAccessor> TextDb::Query(const string& key) {
   if (!loaded())
     return nullptr;
   return New<TextDbAccessor>(data_, key);

--- a/src/dict/tsv.cc
+++ b/src/dict/tsv.cc
@@ -16,7 +16,7 @@ int TsvReader::operator() (Sink* sink) {
   if (!sink) return 0;
   LOG(INFO) << "reading tsv file: " << path_;
   std::ifstream fin(path_.c_str());
-  std::string line, key, value;
+  string line, key, value;
   Tsv row;
   int line_no = 0;
   int num_entries = 0;
@@ -64,7 +64,7 @@ int TsvWriter::operator() (Source* source) {
   if (!file_description.empty()) {
     fout << "# " << file_description << std::endl;
   }
-  std::string key, value;
+  string key, value;
   while (source->MetaGet(&key, &value)) {
     fout << "#@" << key << '\t' << value << std::endl;
   }

--- a/src/dict/user_db.cc
+++ b/src/dict/user_db.cc
@@ -5,7 +5,6 @@
 // 2011-11-02 GONG Chen <chen.sst@gmail.com>
 //
 #include <cstdlib>
-#include <vector>
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
@@ -16,24 +15,24 @@
 
 namespace rime {
 
-UserDbValue::UserDbValue(const std::string& value) {
+UserDbValue::UserDbValue(const string& value) {
   Unpack(value);
 }
 
-std::string UserDbValue::Pack() const {
+string UserDbValue::Pack() const {
   return boost::str(boost::format("c=%1% d=%2% t=%3%") %
                     commits % dee % tick);
 }
 
-bool UserDbValue::Unpack(const std::string& value) {
-  std::vector<std::string> kv;
+bool UserDbValue::Unpack(const string& value) {
+  vector<string> kv;
   boost::split(kv, value, boost::is_any_of(" "));
-  for (const std::string& k_eq_v : kv) {
+  for (const string& k_eq_v : kv) {
     size_t eq = k_eq_v.find('=');
-    if (eq == std::string::npos)
+    if (eq == string::npos)
       continue;
-    std::string k(k_eq_v.substr(0, eq));
-    std::string v(k_eq_v.substr(eq + 1));
+    string k(k_eq_v.substr(0, eq));
+    string v(k_eq_v.substr(eq + 1));
     try {
       if (k == "c") {
         commits = boost::lexical_cast<int>(v);
@@ -55,21 +54,21 @@ bool UserDbValue::Unpack(const std::string& value) {
 }
 
 template <>
-const std::string UserDbFormat<TextDb>::extension(".userdb.txt");
+const string UserDbFormat<TextDb>::extension(".userdb.txt");
 
 template <>
-const std::string UserDbFormat<TextDb>::snapshot_extension(".userdb.txt");
+const string UserDbFormat<TextDb>::snapshot_extension(".userdb.txt");
 
 // key ::= code <space> <Tab> phrase
 
 static bool userdb_entry_parser(const Tsv& row,
-                                std::string* key,
-                                std::string* value) {
+                                string* key,
+                                string* value) {
   if (row.size() < 2 ||
       row[0].empty() || row[1].empty()) {
     return false;
   }
-  std::string code(row[0]);
+  string code(row[0]);
   // fix invalid keys created by a buggy version
   if (code[code.length() - 1] != ' ')
     code += ' ';
@@ -81,8 +80,8 @@ static bool userdb_entry_parser(const Tsv& row,
   return true;
 }
 
-static bool userdb_entry_formatter(const std::string& key,
-                                   const std::string& value,
+static bool userdb_entry_formatter(const string& key,
+                                   const string& value,
                                    Tsv* tsv) {
   Tsv& row(*tsv);
   boost::algorithm::split(row, key,
@@ -101,7 +100,7 @@ static TextFormat plain_userdb_format = {
 };
 
 template <>
-UserDbWrapper<TextDb>::UserDbWrapper(const std::string& db_name)
+UserDbWrapper<TextDb>::UserDbWrapper(const string& db_name)
     : TextDb(db_name, "userdb", plain_userdb_format) {
 }
 
@@ -110,12 +109,12 @@ bool UserDbHelper::UpdateUserInfo() {
   return db_->MetaUpdate("/user_id", deployer.user_id);
 }
 
-bool UserDbHelper::IsUniformFormat(const std::string& file_name) {
+bool UserDbHelper::IsUniformFormat(const string& file_name) {
   return boost::ends_with(file_name,
                           UserDbFormat<TextDb>::snapshot_extension);
 }
 
-bool UserDbHelper::UniformBackup(const std::string& snapshot_file) {
+bool UserDbHelper::UniformBackup(const string& snapshot_file) {
   LOG(INFO) << "backing up userdb '" << db_->name() << "' to "
             << snapshot_file;
   TsvWriter writer(snapshot_file, plain_userdb_format.formatter);
@@ -131,7 +130,7 @@ bool UserDbHelper::UniformBackup(const std::string& snapshot_file) {
   return true;
 }
 
-bool UserDbHelper::UniformRestore(const std::string& snapshot_file) {
+bool UserDbHelper::UniformRestore(const string& snapshot_file) {
   LOG(INFO) << "restoring userdb '" << db_->name() << "' from "
             << snapshot_file;
   TsvReader reader(snapshot_file, plain_userdb_format.parser);
@@ -147,12 +146,12 @@ bool UserDbHelper::UniformRestore(const std::string& snapshot_file) {
 }
 
 bool UserDbHelper::IsUserDb() {
-  std::string db_type;
+  string db_type;
   return db_->MetaFetch("/db_type", &db_type) && (db_type == "userdb");
 }
 
-std::string UserDbHelper::GetDbName() {
-  std::string name;
+string UserDbHelper::GetDbName() {
+  string name;
   if (!db_->MetaFetch("/db_name", &name))
     return name;
   auto ext = boost::find_last(name, ".userdb");
@@ -163,20 +162,20 @@ std::string UserDbHelper::GetDbName() {
   return name;
 }
 
-std::string UserDbHelper::GetUserId() {
-  std::string user_id("unknown");
+string UserDbHelper::GetUserId() {
+  string user_id("unknown");
   db_->MetaFetch("/user_id", &user_id);
   return user_id;
 }
 
-std::string UserDbHelper::GetRimeVersion() {
-  std::string version;
+string UserDbHelper::GetRimeVersion() {
+  string version;
   db_->MetaFetch("/rime_version", &version);
   return version;
 }
 
 static TickCount get_tick_count(Db* db) {
-  std::string tick;
+  string tick;
   if (db && db->MetaFetch("/tick", &tick)) {
     try {
       return boost::lexical_cast<TickCount>(tick);
@@ -197,7 +196,7 @@ UserDbMerger::~UserDbMerger() {
   CloseMerge();
 }
 
-bool UserDbMerger::MetaPut(const std::string& key, const std::string& value) {
+bool UserDbMerger::MetaPut(const string& key, const string& value) {
   if (key == "/tick") {
     try {
       their_tick_ = boost::lexical_cast<TickCount>(value);
@@ -209,14 +208,14 @@ bool UserDbMerger::MetaPut(const std::string& key, const std::string& value) {
   return true;
 }
 
-bool UserDbMerger::Put(const std::string& key, const std::string& value) {
+bool UserDbMerger::Put(const string& key, const string& value) {
   if (!db_) return false;
   UserDbValue v(value);
   if (v.tick < their_tick_) {
     v.dee = algo::formula_d(0, (double)their_tick_, v.dee, (double)v.tick);
   }
   UserDbValue o;
-  std::string our_value;
+  string our_value;
   if (db_->Fetch(key, &our_value)) {
     o.Unpack(our_value);
   }
@@ -235,7 +234,7 @@ void UserDbMerger::CloseMerge() {
     return;
   Deployer& deployer(Service::instance().deployer());
   try {
-    db_->MetaUpdate("/tick", boost::lexical_cast<std::string>(max_tick_));
+    db_->MetaUpdate("/tick", boost::lexical_cast<string>(max_tick_));
     db_->MetaUpdate("/user_id", deployer.user_id);
   }
   catch (...) {
@@ -251,15 +250,15 @@ UserDbImporter::UserDbImporter(Db* db)
     : db_(db) {
 }
 
-bool UserDbImporter::MetaPut(const std::string& key, const std::string& value) {
+bool UserDbImporter::MetaPut(const string& key, const string& value) {
   return true;
 }
 
-bool UserDbImporter::Put(const std::string& key, const std::string& value) {
+bool UserDbImporter::Put(const string& key, const string& value) {
   if (!db_) return false;
   UserDbValue v(value);
   UserDbValue o;
-  std::string old_value;
+  string old_value;
   if (db_->Fetch(key, &old_value)) {
     o.Unpack(old_value);
   }

--- a/src/dict/user_db_recovery_task.cc
+++ b/src/dict/user_db_recovery_task.cc
@@ -16,7 +16,7 @@ namespace fs = boost::filesystem;
 
 namespace rime {
 
-UserDbRecoveryTask::UserDbRecoveryTask(a<Db> db) : db_(db) {
+UserDbRecoveryTask::UserDbRecoveryTask(an<Db> db) : db_(db) {
   if (db_) {
     db_->disable();
   }
@@ -86,7 +86,7 @@ void UserDbRecoveryTask::RestoreUserDataFromSnapshot(Deployer* deployer) {
 
 UserDbRecoveryTask* UserDbRecoveryTaskComponent::Create(TaskInitializer arg) {
   try {
-    auto db = boost::any_cast<a<Db>>(arg);
+    auto db = boost::any_cast<an<Db>>(arg);
     return new UserDbRecoveryTask(db);
   }
   catch (const boost::bad_any_cast&) {

--- a/src/dict/user_db_recovery_task.cc
+++ b/src/dict/user_db_recovery_task.cc
@@ -16,7 +16,7 @@ namespace fs = boost::filesystem;
 
 namespace rime {
 
-UserDbRecoveryTask::UserDbRecoveryTask(shared_ptr<Db> db) : db_(db) {
+UserDbRecoveryTask::UserDbRecoveryTask(a<Db> db) : db_(db) {
   if (db_) {
     db_->disable();
   }
@@ -62,7 +62,7 @@ void UserDbRecoveryTask::RestoreUserDataFromSnapshot(Deployer* deployer) {
   UserDb::Component* component = UserDb::Require("userdb");
   if (!component || !UserDbHelper(db_).IsUserDb())
     return;
-  std::string dict_name(db_->name());
+  string dict_name(db_->name());
   boost::erase_last(dict_name, component->extension());
   // locate snapshot file
   boost::filesystem::path dir(deployer->user_data_sync_dir());
@@ -71,7 +71,7 @@ void UserDbRecoveryTask::RestoreUserDataFromSnapshot(Deployer* deployer) {
       dir / (dict_name + component->snapshot_extension());
   if (!fs::exists(snapshot_path)) {
     // try *.userdb.*.snapshot
-    std::string legacy_snapshot_file =
+    string legacy_snapshot_file =
         dict_name + component->extension() + ".snapshot";
     snapshot_path = dir / legacy_snapshot_file;
     if (!fs::exists(snapshot_path)) {
@@ -86,7 +86,7 @@ void UserDbRecoveryTask::RestoreUserDataFromSnapshot(Deployer* deployer) {
 
 UserDbRecoveryTask* UserDbRecoveryTaskComponent::Create(TaskInitializer arg) {
   try {
-    auto db = boost::any_cast<shared_ptr<Db>>(arg);
+    auto db = boost::any_cast<a<Db>>(arg);
     return new UserDbRecoveryTask(db);
   }
   catch (const boost::bad_any_cast&) {

--- a/src/dict/user_dictionary.cc
+++ b/src/dict/user_dictionary.cc
@@ -5,7 +5,6 @@
 // 2011-10-30 GONG Chen <chen.sst@gmail.com>
 //
 #include <algorithm>
-#include <map>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/scope_exit.hpp>
@@ -25,16 +24,16 @@ struct DfsState {
   size_t depth_limit;
   TickCount present_tick;
   Code code;
-  std::vector<double> credibility;
-  shared_ptr<UserDictEntryCollector> collector;
-  shared_ptr<DbAccessor> accessor;
-  std::string key;
-  std::string value;
+  vector<double> credibility;
+  a<UserDictEntryCollector> collector;
+  a<DbAccessor> accessor;
+  string key;
+  string value;
 
-  bool IsExactMatch(const std::string& prefix) {
+  bool IsExactMatch(const string& prefix) {
     return boost::starts_with(key, prefix + '\t');
   }
-  bool IsPrefixMatch(const std::string& prefix) {
+  bool IsPrefixMatch(const string& prefix) {
     return boost::starts_with(key, prefix);
   }
   void RecruitEntry(size_t pos);
@@ -46,13 +45,13 @@ struct DfsState {
     }
     return true;
   }
-  bool ForwardScan(const std::string& prefix) {
+  bool ForwardScan(const string& prefix) {
     if (!accessor->Jump(prefix)) {
       return false;
     }
     return NextEntry();
   }
-  bool Backdate(const std::string& prefix) {
+  bool Backdate(const string& prefix) {
     DLOG(INFO) << "backdate; prefix: " << prefix;
     if (!accessor->Reset()) {
       LOG(WARNING) << "backdating failed for '" << prefix << "'.";
@@ -74,7 +73,7 @@ void DfsState::RecruitEntry(size_t pos) {
 
 // UserDictEntryIterator members
 
-void UserDictEntryIterator::Add(const shared_ptr<DictEntry>& entry) {
+void UserDictEntryIterator::Add(const a<DictEntry>& entry) {
   if (!entries_) {
     entries_ = New<DictEntryList>();
   }
@@ -96,8 +95,8 @@ bool UserDictEntryIterator::Release(DictEntryList* receiver) {
   return true;
 }
 
-shared_ptr<DictEntry> UserDictEntryIterator::Peek() {
-  shared_ptr<DictEntry> result;
+a<DictEntry> UserDictEntryIterator::Peek() {
+  a<DictEntry> result;
   while (!result && !exhausted()) {
     result = (*entries_)[index_];
     if (filter_ && !filter_(result)) {
@@ -117,7 +116,7 @@ bool UserDictEntryIterator::Next() {
 
 // UserDictionary members
 
-UserDictionary::UserDictionary(const shared_ptr<Db>& db)
+UserDictionary::UserDictionary(const a<Db>& db)
     : db_(db) {
 }
 
@@ -127,8 +126,8 @@ UserDictionary::~UserDictionary() {
   }
 }
 
-void UserDictionary::Attach(const shared_ptr<Table>& table,
-                            const shared_ptr<Prism>& prism) {
+void UserDictionary::Attach(const a<Table>& table,
+                            const a<Prism>& prism) {
   table_ = table;
   prism_ = prism;
 }
@@ -141,7 +140,7 @@ bool UserDictionary::Load() {
     Deployer& deployer(Service::instance().deployer());
     auto task = DeploymentTask::Require("userdb_recovery_task");
     if (task && Is<Recoverable>(db_) && !deployer.IsWorking()) {
-      deployer.ScheduleTask(shared_ptr<DeploymentTask>(task->Create(db_)));
+      deployer.ScheduleTask(a<DeploymentTask>(task->Create(db_)));
       deployer.StartWork();
     }
     return false;
@@ -184,14 +183,14 @@ bool UserDictionary::readonly() const {
 
 void UserDictionary::DfsLookup(const SyllableGraph& syll_graph,
                                size_t current_pos,
-                               const std::string& current_prefix,
+                               const string& current_prefix,
                                DfsState* state) {
   auto index = syll_graph.indices.find(current_pos);
   if (index == syll_graph.indices.end()) {
     return;
   }
   DLOG(INFO) << "dfs lookup starts from " << current_pos;
-  std::string prefix;
+  string prefix;
   for (const auto& spelling : index->second) {
     DLOG(INFO) << "prefix: '" << current_prefix << "'"
                << ", syll_id: " << spelling.first
@@ -238,7 +237,7 @@ void UserDictionary::DfsLookup(const SyllableGraph& syll_graph,
   }
 }
 
-shared_ptr<UserDictEntryCollector>
+a<UserDictEntryCollector>
 UserDictionary::Lookup(const SyllableGraph& syll_graph,
                        size_t start_pos,
                        size_t depth_limit,
@@ -254,7 +253,7 @@ UserDictionary::Lookup(const SyllableGraph& syll_graph,
   state.collector = New<UserDictEntryCollector>();
   state.accessor = db_->Query("");
   state.accessor->Jump(" ");  // skip metadata
-  std::string prefix;
+  string prefix;
   DfsLookup(syll_graph, start_pos, prefix, &state);
   if (state.collector->empty())
     return nullptr;
@@ -266,19 +265,19 @@ UserDictionary::Lookup(const SyllableGraph& syll_graph,
 }
 
 size_t UserDictionary::LookupWords(UserDictEntryIterator* result,
-                                   const std::string& input,
+                                   const string& input,
                                    bool predictive,
                                    size_t limit,
-                                   std::string* resume_key) {
+                                   string* resume_key) {
   TickCount present_tick = tick_ + 1;
   size_t len = input.length();
   size_t start = result->size();
   size_t count = 0;
   size_t exact_match_count = 0;
-  const std::string kEnd = "\xff";
-  std::string key;
-  std::string value;
-  std::string full_code;
+  const string kEnd = "\xff";
+  string key;
+  string value;
+  string full_code;
   auto accessor = db_->Query(input);
   if (!accessor || accessor->exhausted()) {
     if (resume_key)
@@ -293,7 +292,7 @@ size_t UserDictionary::LookupWords(UserDictEntryIterator* result,
     }
     DLOG(INFO) << "resume lookup after: " << key;
   }
-  std::string last_key(key);
+  string last_key(key);
   while (accessor->GetNextRecord(&key, &value)) {
     DLOG(INFO) << "key : " << key << ", value: " << value;
     bool is_exact_match = (len < key.length() && key[len] == ' ');
@@ -333,12 +332,12 @@ bool UserDictionary::UpdateEntry(const DictEntry& entry, int commits) {
 }
 
 bool UserDictionary::UpdateEntry(const DictEntry& entry, int commits,
-                                 const std::string& new_entry_prefix) {
-  std::string code_str(entry.custom_code);
+                                 const string& new_entry_prefix) {
+  string code_str(entry.custom_code);
   if (code_str.empty() && !TranslateCodeToString(entry.code, &code_str))
     return false;
-  std::string key(code_str + '\t' + entry.text);
-  std::string value;
+  string key(code_str + '\t' + entry.text);
+  string value;
   UserDbValue v;
   if (db_->Fetch(key, &value)) {
     v.Unpack(value);
@@ -371,7 +370,7 @@ bool UserDictionary::UpdateEntry(const DictEntry& entry, int commits,
 bool UserDictionary::UpdateTickCount(TickCount increment) {
   tick_ += increment;
   try {
-    return db_->MetaUpdate("/tick", boost::lexical_cast<std::string>(tick_));
+    return db_->MetaUpdate("/tick", boost::lexical_cast<string>(tick_));
   }
   catch (...) {
     return false;
@@ -383,7 +382,7 @@ bool UserDictionary::Initialize() {
 }
 
 bool UserDictionary::FetchTickCount() {
-  std::string value;
+  string value;
   try {
     // an earlier version mistakenly wrote tick count into an empty key
     if (!db_->MetaFetch("/tick", &value) &&
@@ -425,11 +424,11 @@ bool UserDictionary::CommitPendingTransaction() {
 }
 
 bool UserDictionary::TranslateCodeToString(const Code& code,
-                                           std::string* result) {
+                                           string* result) {
   if (!table_ || !result) return false;
   result->clear();
   for (const SyllableId& syllable_id : code) {
-    std::string spelling = table_->GetSyllableById(syllable_id);
+    string spelling = table_->GetSyllableById(syllable_id);
     if (spelling.empty()) {
       LOG(ERROR) << "Error translating syllable_id '" << syllable_id << "'.";
       result->clear();
@@ -441,14 +440,14 @@ bool UserDictionary::TranslateCodeToString(const Code& code,
   return true;
 }
 
-shared_ptr<DictEntry> UserDictionary::CreateDictEntry(const std::string& key,
-                                                      const std::string& value,
+a<DictEntry> UserDictionary::CreateDictEntry(const string& key,
+                                                      const string& value,
                                                       TickCount present_tick,
                                                       double credibility,
-                                                      std::string* full_code) {
-  shared_ptr<DictEntry> e;
+                                                      string* full_code) {
+  a<DictEntry> e;
   size_t separator_pos = key.find('\t');
-  if (separator_pos == std::string::npos)
+  if (separator_pos == string::npos)
     return e;
   UserDbValue v;
   if (!v.Unpack(value))
@@ -490,14 +489,14 @@ UserDictionary* UserDictionaryComponent::Create(const Ticket& ticket) {
   config->GetBool(ticket.name_space + "/enable_user_dict", &enable_user_dict);
   if (!enable_user_dict)
     return NULL;
-  std::string dict_name;
+  string dict_name;
   if (config->GetString(ticket.name_space + "/user_dict", &dict_name)) {
     // user specified name
   }
   else if (config->GetString(ticket.name_space + "/dictionary", &dict_name)) {
     // {dictionary: lunapinyin.extra} implies {user_dict: luna_pinyin}
     size_t dot = dict_name.find('.');
-    if (dot != std::string::npos && dot != 0)
+    if (dot != string::npos && dot != 0)
       dict_name.resize(dot);
   }
   else {
@@ -505,7 +504,7 @@ UserDictionary* UserDictionaryComponent::Create(const Ticket& ticket) {
                << ticket.schema->schema_id() << "'.";
     return NULL;
   }
-  std::string db_class("userdb");
+  string db_class("userdb");
   if (config->GetString(ticket.name_space + "/db_class", &db_class)) {
     // user specified db class
   }

--- a/src/dict/user_dictionary.cc
+++ b/src/dict/user_dictionary.cc
@@ -25,8 +25,8 @@ struct DfsState {
   TickCount present_tick;
   Code code;
   vector<double> credibility;
-  a<UserDictEntryCollector> collector;
-  a<DbAccessor> accessor;
+  an<UserDictEntryCollector> collector;
+  an<DbAccessor> accessor;
   string key;
   string value;
 
@@ -73,7 +73,7 @@ void DfsState::RecruitEntry(size_t pos) {
 
 // UserDictEntryIterator members
 
-void UserDictEntryIterator::Add(const a<DictEntry>& entry) {
+void UserDictEntryIterator::Add(const an<DictEntry>& entry) {
   if (!entries_) {
     entries_ = New<DictEntryList>();
   }
@@ -95,8 +95,8 @@ bool UserDictEntryIterator::Release(DictEntryList* receiver) {
   return true;
 }
 
-a<DictEntry> UserDictEntryIterator::Peek() {
-  a<DictEntry> result;
+an<DictEntry> UserDictEntryIterator::Peek() {
+  an<DictEntry> result;
   while (!result && !exhausted()) {
     result = (*entries_)[index_];
     if (filter_ && !filter_(result)) {
@@ -116,7 +116,7 @@ bool UserDictEntryIterator::Next() {
 
 // UserDictionary members
 
-UserDictionary::UserDictionary(const a<Db>& db)
+UserDictionary::UserDictionary(const an<Db>& db)
     : db_(db) {
 }
 
@@ -126,8 +126,8 @@ UserDictionary::~UserDictionary() {
   }
 }
 
-void UserDictionary::Attach(const a<Table>& table,
-                            const a<Prism>& prism) {
+void UserDictionary::Attach(const an<Table>& table,
+                            const an<Prism>& prism) {
   table_ = table;
   prism_ = prism;
 }
@@ -140,7 +140,7 @@ bool UserDictionary::Load() {
     Deployer& deployer(Service::instance().deployer());
     auto task = DeploymentTask::Require("userdb_recovery_task");
     if (task && Is<Recoverable>(db_) && !deployer.IsWorking()) {
-      deployer.ScheduleTask(a<DeploymentTask>(task->Create(db_)));
+      deployer.ScheduleTask(an<DeploymentTask>(task->Create(db_)));
       deployer.StartWork();
     }
     return false;
@@ -237,7 +237,7 @@ void UserDictionary::DfsLookup(const SyllableGraph& syll_graph,
   }
 }
 
-a<UserDictEntryCollector>
+an<UserDictEntryCollector>
 UserDictionary::Lookup(const SyllableGraph& syll_graph,
                        size_t start_pos,
                        size_t depth_limit,
@@ -440,12 +440,12 @@ bool UserDictionary::TranslateCodeToString(const Code& code,
   return true;
 }
 
-a<DictEntry> UserDictionary::CreateDictEntry(const string& key,
+an<DictEntry> UserDictionary::CreateDictEntry(const string& key,
                                                       const string& value,
                                                       TickCount present_tick,
                                                       double credibility,
                                                       string* full_code) {
-  a<DictEntry> e;
+  an<DictEntry> e;
   size_t separator_pos = key.find('\t');
   if (separator_pos == string::npos)
     return e;

--- a/src/dict/vocabulary.cc
+++ b/src/dict/vocabulary.cc
@@ -44,7 +44,7 @@ void Code::CreateIndex(Code* index_code) {
             index_code->begin());
 }
 
-std::string Code::ToString() const {
+string Code::ToString() const {
   std::stringstream stream;
   bool first = true;
   for (SyllableId syllable_id : *this) {
@@ -90,7 +90,7 @@ void DictEntryFilterBinder::AddFilter(DictEntryFilter filter) {
   }
   else {
     DictEntryFilter previous_filter(std::move(filter_));
-    filter_ = [previous_filter, filter](shared_ptr<DictEntry> e) {
+    filter_ = [previous_filter, filter](a<DictEntry> e) {
       return previous_filter(e) && filter(e);
     };
   }

--- a/src/dict/vocabulary.cc
+++ b/src/dict/vocabulary.cc
@@ -90,7 +90,7 @@ void DictEntryFilterBinder::AddFilter(DictEntryFilter filter) {
   }
   else {
     DictEntryFilter previous_filter(std::move(filter_));
-    filter_ = [previous_filter, filter](a<DictEntry> e) {
+    filter_ = [previous_filter, filter](an<DictEntry> e) {
       return previous_filter(e) && filter(e);
     };
   }

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -44,12 +44,12 @@ class ConcreteEngine : public Engine {
   void OnContextUpdate(Context* ctx);
   void OnOptionUpdate(Context* ctx, const string& option);
 
-  vector<a<Processor>> processors_;
-  vector<a<Segmentor>> segmentors_;
-  vector<a<Translator>> translators_;
-  vector<a<Filter>> filters_;
-  vector<a<Formatter>> formatters_;
-  vector<a<Processor>> post_processors_;
+  vector<of<Processor>> processors_;
+  vector<of<Segmentor>> segmentors_;
+  vector<of<Translator>> translators_;
+  vector<of<Filter>> filters_;
+  vector<of<Formatter>> formatters_;
+  vector<of<Processor>> post_processors_;
 };
 
 // implementations

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -284,7 +284,7 @@ void ConcreteEngine::InitializeComponents() {
         continue;
       Ticket ticket{this, "processor", prescription->str()};
       if (auto c = Processor::Require(ticket.klass)) {
-        a<Processor> p(c->Create(ticket));
+        an<Processor> p(c->Create(ticket));
         processors_.push_back(p);
       }
       else {
@@ -301,7 +301,7 @@ void ConcreteEngine::InitializeComponents() {
         continue;
       Ticket ticket{this, "segmentor", prescription->str()};
       if (auto c = Segmentor::Require(ticket.klass)) {
-        a<Segmentor> s(c->Create(ticket));
+        an<Segmentor> s(c->Create(ticket));
         segmentors_.push_back(s);
       }
       else {
@@ -318,7 +318,7 @@ void ConcreteEngine::InitializeComponents() {
         continue;
       Ticket ticket{this, "translator", prescription->str()};
       if (auto c = Translator::Require(ticket.klass)) {
-        a<Translator> t(c->Create(ticket));
+        an<Translator> t(c->Create(ticket));
         translators_.push_back(t);
       }
       else {
@@ -335,7 +335,7 @@ void ConcreteEngine::InitializeComponents() {
         continue;
       Ticket ticket{this, "filter", prescription->str()};
       if (auto c = Filter::Require(ticket.klass)) {
-        a<Filter> f(c->Create(ticket));
+        an<Filter> f(c->Create(ticket));
         filters_.push_back(f);
       }
       else {
@@ -345,7 +345,7 @@ void ConcreteEngine::InitializeComponents() {
   }
   // create formatters
   if (auto c = Formatter::Require("shape_formatter")) {
-    a<Formatter> f(c->Create(Ticket(this)));
+    an<Formatter> f(c->Create(Ticket(this)));
     formatters_.push_back(f);
   }
   else {
@@ -353,7 +353,7 @@ void ConcreteEngine::InitializeComponents() {
   }
   // create post-processors
   if (auto c = Processor::Require("shape_processor")) {
-    a<Processor> p(c->Create(Ticket(this)));
+    an<Processor> p(c->Create(Ticket(this)));
     post_processors_.push_back(p);
   }
   else {

--- a/src/gear/abc_segmentor.cc
+++ b/src/gear/abc_segmentor.cc
@@ -37,19 +37,19 @@ AbcSegmentor::AbcSegmentor(const Ticket& ticket)
 }
 
 bool AbcSegmentor::Proceed(Segmentation* segmentation) {
-  const std::string& input(segmentation->input());
+  const string& input(segmentation->input());
   DLOG(INFO) << "abc_segmentor: " << input;
   size_t j = segmentation->GetCurrentStartPosition();
   size_t k = j;
   bool expecting_an_initial = true;
   for (; k < input.length(); ++k) {
-    bool is_letter = alphabet_.find(input[k]) != std::string::npos;
+    bool is_letter = alphabet_.find(input[k]) != string::npos;
     bool is_delimiter =
-        (k != j) && (delimiter_.find(input[k]) != std::string::npos);
+        (k != j) && (delimiter_.find(input[k]) != string::npos);
     if (!is_letter && !is_delimiter)
       break;
-    bool is_initial = initials_.find(input[k]) != std::string::npos;
-    bool is_final = finals_.find(input[k]) != std::string::npos;
+    bool is_initial = initials_.find(input[k]) != string::npos;
+    bool is_final = finals_.find(input[k]) != string::npos;
     if (expecting_an_initial && !is_initial && !is_delimiter) {
       break;  // not a valid seplling.
     }
@@ -60,7 +60,7 @@ bool AbcSegmentor::Proceed(Segmentation* segmentation) {
   if (j < k) {
     Segment segment(j, k);
     segment.tags.insert("abc");
-    for (const std::string& tag : extra_tags_) {
+    for (const string& tag : extra_tags_) {
       segment.tags.insert(tag);
     }
     segmentation->AddSegment(segment);

--- a/src/gear/affix_segmentor.cc
+++ b/src/gear/affix_segmentor.cc
@@ -52,7 +52,7 @@ bool AffixSegmentor::Proceed(Segmentation* segmentation) {
   }
   size_t j = segmentation->GetCurrentStartPosition();
   size_t k = segmentation->GetCurrentEndPosition();
-  std::string active_input(segmentation->input().substr(j, k - j));
+  string active_input(segmentation->input().substr(j, k - j));
   if (prefix_.empty() || !boost::starts_with(active_input, prefix_)) {
     return true;
   }
@@ -81,7 +81,7 @@ bool AffixSegmentor::Proceed(Segmentation* segmentation) {
   j += prefix_.length();
   Segment code_segment(j, k);
   code_segment.tags.insert(tag_);
-  for (const std::string& tag : extra_tags_) {
+  for (const string& tag : extra_tags_) {
     code_segment.tags.insert(tag);
   }
   segmentation->Forward();

--- a/src/gear/ascii_composer.cc
+++ b/src/gear/ascii_composer.cc
@@ -26,7 +26,7 @@ static struct AsciiModeSwitchStyleDefinition {
   { NULL, kAsciiModeSwitchNoop }
 };
 
-static void load_bindings(const ConfigMapPtr& src,
+static void load_bindings(const a<ConfigMap>& src,
                           AsciiModeSwitchKeyBindings* dest) {
   if (!src)
     return;

--- a/src/gear/ascii_composer.cc
+++ b/src/gear/ascii_composer.cc
@@ -26,7 +26,7 @@ static struct AsciiModeSwitchStyleDefinition {
   { NULL, kAsciiModeSwitchNoop }
 };
 
-static void load_bindings(const a<ConfigMap>& src,
+static void load_bindings(const an<ConfigMap>& src,
                           AsciiModeSwitchKeyBindings* dest) {
   if (!src)
     return;

--- a/src/gear/ascii_composer.cc
+++ b/src/gear/ascii_composer.cc
@@ -160,7 +160,7 @@ ProcessResult AsciiComposer::ProcessCapsLock(const KeyEvent& key_event) {
         ch = toupper(ch);
       else if (isupper(ch))
         ch = tolower(ch);
-      engine_->CommitText(std::string(1, ch));
+      engine_->CommitText(string(1, ch));
       return kAccepted;
     }
     else {
@@ -176,7 +176,7 @@ void AsciiComposer::LoadConfig(Schema* schema) {
   good_old_caps_lock_ = false;
   if (!schema)
     return;
-  unique_ptr<Config> preset_config(
+  the<Config> preset_config(
       Config::Require("config")->Create("default"));
   if (preset_config) {
     preset_config->GetBool("ascii_composer/good_old_caps_lock",

--- a/src/gear/ascii_segmentor.cc
+++ b/src/gear/ascii_segmentor.cc
@@ -20,7 +20,7 @@ AsciiSegmentor::AsciiSegmentor(const Ticket& ticket) : Segmentor(ticket) {
 bool AsciiSegmentor::Proceed(Segmentation* segmentation) {
   if (!engine_->context()->get_option("ascii_mode"))
     return true;
-  const std::string& input = segmentation->input();
+  const string& input = segmentation->input();
   size_t j = segmentation->GetCurrentStartPosition();
   if (j < input.length()) {
     Segment segment(j, input.length());

--- a/src/gear/charset_filter.cc
+++ b/src/gear/charset_filter.cc
@@ -28,7 +28,7 @@ bool is_extended_cjk(uint32_t ch)
   return false;
 }
 
-bool contains_extended_cjk(const std::string& text)
+bool contains_extended_cjk(const string& text)
 {
   const char *p = text.c_str();
   uint32_t ch;
@@ -45,7 +45,7 @@ bool contains_extended_cjk(const std::string& text)
 // CharsetFilterTranslation
 
 CharsetFilterTranslation::CharsetFilterTranslation(
-    shared_ptr<Translation> translation)
+    a<Translation> translation)
     : translation_(translation) {
   LocateNextCandidate();
 }
@@ -60,7 +60,7 @@ bool CharsetFilterTranslation::Next() {
   return LocateNextCandidate();
 }
 
-shared_ptr<Candidate> CharsetFilterTranslation::Peek() {
+a<Candidate> CharsetFilterTranslation::Peek() {
   return translation_->Peek();
 }
 
@@ -77,11 +77,11 @@ bool CharsetFilterTranslation::LocateNextCandidate() {
 
 // CharsetFilter
 
-bool CharsetFilter::FilterText(const std::string& text) {
+bool CharsetFilter::FilterText(const string& text) {
   return !contains_extended_cjk(text);
 }
 
-bool CharsetFilter::FilterDictEntry(shared_ptr<DictEntry> entry) {
+bool CharsetFilter::FilterDictEntry(a<DictEntry> entry) {
   return entry && FilterText(entry->text);
 }
 
@@ -89,8 +89,8 @@ CharsetFilter::CharsetFilter(const Ticket& ticket)
     : Filter(ticket), TagMatching(ticket) {
 }
 
-shared_ptr<Translation> CharsetFilter::Apply(
-    shared_ptr<Translation> translation, CandidateList* candidates) {
+a<Translation> CharsetFilter::Apply(
+    a<Translation> translation, CandidateList* candidates) {
   if (engine_->context()->get_option("extended_charset")) {
     return translation;
   }

--- a/src/gear/charset_filter.cc
+++ b/src/gear/charset_filter.cc
@@ -45,7 +45,7 @@ bool contains_extended_cjk(const string& text)
 // CharsetFilterTranslation
 
 CharsetFilterTranslation::CharsetFilterTranslation(
-    a<Translation> translation)
+    an<Translation> translation)
     : translation_(translation) {
   LocateNextCandidate();
 }
@@ -60,7 +60,7 @@ bool CharsetFilterTranslation::Next() {
   return LocateNextCandidate();
 }
 
-a<Candidate> CharsetFilterTranslation::Peek() {
+an<Candidate> CharsetFilterTranslation::Peek() {
   return translation_->Peek();
 }
 
@@ -81,7 +81,7 @@ bool CharsetFilter::FilterText(const string& text) {
   return !contains_extended_cjk(text);
 }
 
-bool CharsetFilter::FilterDictEntry(a<DictEntry> entry) {
+bool CharsetFilter::FilterDictEntry(an<DictEntry> entry) {
   return entry && FilterText(entry->text);
 }
 
@@ -89,8 +89,8 @@ CharsetFilter::CharsetFilter(const Ticket& ticket)
     : Filter(ticket), TagMatching(ticket) {
 }
 
-a<Translation> CharsetFilter::Apply(
-    a<Translation> translation, CandidateList* candidates) {
+an<Translation> CharsetFilter::Apply(
+    an<Translation> translation, CandidateList* candidates) {
   if (engine_->context()->get_option("extended_charset")) {
     return translation;
   }

--- a/src/gear/chord_composer.cc
+++ b/src/gear/chord_composer.cc
@@ -85,7 +85,7 @@ ProcessResult ChordComposer::ProcessKeyEvent(const KeyEvent& key_event) {
       DLOG(INFO) << "update sequence: " << sequence_;
     }
   }
-  if (alphabet_.find(ch) == std::string::npos) {
+  if (alphabet_.find(ch) == string::npos) {
     return chording ? kAccepted : kNoop;
   }
   // in alphabet
@@ -103,8 +103,8 @@ ProcessResult ChordComposer::ProcessKeyEvent(const KeyEvent& key_event) {
   return kAccepted;
 }
 
-std::string ChordComposer::SerializeChord() {
-  std::string code;
+string ChordComposer::SerializeChord() {
+  string code;
   for (char ch : alphabet_) {
     if (chord_.find(ch) != chord_.end())
       code.push_back(ch);
@@ -118,7 +118,7 @@ void ChordComposer::UpdateChord() {
     return;
   Context* ctx = engine_->context();
   Composition& comp = ctx->composition();
-  std::string code = SerializeChord();
+  string code = SerializeChord();
   prompt_format_.Apply(&code);
   if (comp.empty()) {
     // add an invisbile place holder segment
@@ -138,7 +138,7 @@ void ChordComposer::UpdateChord() {
 void ChordComposer::FinishChord() {
   if (!engine_)
     return;
-  std::string code = SerializeChord();
+  string code = SerializeChord();
   output_format_.Apply(&code);
   ClearChord();
 
@@ -148,7 +148,7 @@ void ChordComposer::FinishChord() {
     for (const KeyEvent& key : sequence) {
       if (!engine_->ProcessKey(key)) {
         // direct commit
-        engine_->CommitText(std::string(1, key.keycode()));
+        engine_->CommitText(string(1, key.keycode()));
         // exclude the character (eg. space) from the following sequence
         sequence_.clear();
       }
@@ -181,7 +181,7 @@ bool ChordComposer::DeleteLastSyllable() {
     return false;
   Context* ctx = engine_->context();
   Composition& comp = ctx->composition();
-  const std::string& input(ctx->input());
+  const string& input(ctx->input());
   size_t start = comp.empty() ? 0 : comp.back().start;
   size_t caret_pos = ctx->caret_pos();
   if (input.empty() || caret_pos <= start)
@@ -189,7 +189,7 @@ bool ChordComposer::DeleteLastSyllable() {
   size_t deleted = 0;
   for (; caret_pos > start; --caret_pos, ++deleted) {
     if (deleted > 0 &&
-        delimiter_.find(input[caret_pos - 1]) != std::string::npos)
+        delimiter_.find(input[caret_pos - 1]) != string::npos)
       break;
   }
   ctx->PopInput(deleted);

--- a/src/gear/echo_translator.cc
+++ b/src/gear/echo_translator.cc
@@ -15,10 +15,10 @@ namespace rime {
 
 class EchoTranslation : public UniqueTranslation {
  public:
-  EchoTranslation(const a<Candidate>& candidate)
+  EchoTranslation(const an<Candidate>& candidate)
       : UniqueTranslation(candidate) {
   }
-  virtual int Compare(a<Translation> other,
+  virtual int Compare(an<Translation> other,
                       const CandidateList& candidates) {
     if (!candidates.empty() || (other && other->Peek())) {
       set_exhausted(true);
@@ -32,7 +32,7 @@ EchoTranslator::EchoTranslator(const Ticket& ticket)
     : Translator(ticket) {
 }
 
-a<Translation> EchoTranslator::Query(const string& input,
+an<Translation> EchoTranslator::Query(const string& input,
                                               const Segment& segment) {
   DLOG(INFO) << "input = '" << input
              << "', [" << segment.start << ", " << segment.end << ")";

--- a/src/gear/echo_translator.cc
+++ b/src/gear/echo_translator.cc
@@ -15,10 +15,10 @@ namespace rime {
 
 class EchoTranslation : public UniqueTranslation {
  public:
-  EchoTranslation(const shared_ptr<Candidate>& candidate)
+  EchoTranslation(const a<Candidate>& candidate)
       : UniqueTranslation(candidate) {
   }
-  virtual int Compare(shared_ptr<Translation> other,
+  virtual int Compare(a<Translation> other,
                       const CandidateList& candidates) {
     if (!candidates.empty() || (other && other->Peek())) {
       set_exhausted(true);
@@ -32,7 +32,7 @@ EchoTranslator::EchoTranslator(const Ticket& ticket)
     : Translator(ticket) {
 }
 
-shared_ptr<Translation> EchoTranslator::Query(const std::string& input,
+a<Translation> EchoTranslator::Query(const string& input,
                                               const Segment& segment) {
   DLOG(INFO) << "input = '" << input
              << "', [" << segment.start << ", " << segment.end << ")";

--- a/src/gear/fallback_segmentor.cc
+++ b/src/gear/fallback_segmentor.cc
@@ -20,7 +20,7 @@ bool FallbackSegmentor::Proceed(Segmentation* segmentation) {
   if (len > 0)
     return false;
 
-  const std::string& input(segmentation->input());
+  const string& input(segmentation->input());
   int k = segmentation->GetCurrentStartPosition();
   DLOG(INFO) << "current start pos: " << k;
   if (k == input.length())

--- a/src/gear/filter_commons.cc
+++ b/src/gear/filter_commons.cc
@@ -29,7 +29,7 @@ bool TagMatching::TagsMatch(Segment* segment) {
     return false;
   if (tags_.empty())  // match any
     return true;
-  for (const std::string& tag : tags_) {
+  for (const string& tag : tags_) {
     if (segment->HasTag(tag))
       return true;
   }

--- a/src/gear/key_binder.cc
+++ b/src/gear/key_binder.cc
@@ -5,11 +5,6 @@
 // 2011-11-23 GONG Chen <chen.sst@gmail.com>
 //
 #include <algorithm>
-#include <functional>
-#include <map>
-#include <set>
-#include <string>
-#include <vector>
 #include <rime/common.h>
 #include <rime/composition.h>
 #include <rime/context.h>
@@ -43,7 +38,7 @@ static struct KeyBindingConditionDef {
   { kNever,         NULL        }
 };
 
-static KeyBindingCondition translate_condition(const std::string& str) {
+static KeyBindingCondition translate_condition(const string& str) {
   for (auto* d = condition_definitions; d->name; ++d) {
     if (str == d->name)
       return d->condition;
@@ -54,28 +49,28 @@ static KeyBindingCondition translate_condition(const std::string& str) {
 struct KeyBinding {
   KeyBindingCondition whence;
   KeyEvent target;
-  std::function<void (Engine* engine)> action;
+  function<void (Engine* engine)> action;
 
   bool operator< (const KeyBinding& o) const {
     return whence < o.whence;
   }
 };
 
-class KeyBindings : public std::map<KeyEvent,
-                                    std::vector<KeyBinding>> {
+class KeyBindings : public map<KeyEvent,
+                                    vector<KeyBinding>> {
  public:
   void LoadBindings(const ConfigListPtr& bindings);
   void Bind(const KeyEvent& key, const KeyBinding& binding);
 };
 
-static void toggle_option(Engine* engine, const std::string& option) {
+static void toggle_option(Engine* engine, const string& option) {
   if (!engine)
     return;
   Context* ctx = engine->context();
   ctx->set_option(option, !ctx->get_option(option));
 }
 
-static void select_schema(Engine* engine, const std::string& schema) {
+static void select_schema(Engine* engine, const string& schema) {
   if (!engine)
     return;
   if (schema == ".next") {
@@ -144,7 +139,7 @@ KeyBinder::KeyBinder(const Ticket& ticket) : Processor(ticket),
   LoadConfig();
 }
 
-class KeyBindingConditions : public std::set<KeyBindingCondition> {
+class KeyBindingConditions : public set<KeyBindingCondition> {
  public:
   explicit KeyBindingConditions(Context* ctx);
 };
@@ -199,9 +194,9 @@ void KeyBinder::LoadConfig() {
   if (!engine_)
     return;
   Config* config = engine_->schema()->config();
-  std::string preset;
+  string preset;
   if (config->GetString("key_binder/import_preset", &preset)) {
-    unique_ptr<Config> preset_config(Config::Require("config")->Create(preset));
+    the<Config> preset_config(Config::Require("config")->Create(preset));
     if (!preset_config) {
       LOG(ERROR) << "Error importing preset key bindings '" << preset << "'.";
       return;
@@ -229,7 +224,7 @@ bool KeyBinder::ReinterpretPagingKey(const KeyEvent& key_event) {
   }
   if (last_key_ == '.' && ch >= 'a' && ch <= 'z') {
     Context* ctx = engine_->context();
-    const std::string& input(ctx->input());
+    const string& input(ctx->input());
     if (!input.empty() && input[input.length() - 1] != '.') {
       LOG(INFO) << "reinterpreted key: '" << last_key_
                 << "', successor: '" << (char)ch << "'";

--- a/src/gear/key_binder.cc
+++ b/src/gear/key_binder.cc
@@ -59,7 +59,7 @@ struct KeyBinding {
 class KeyBindings : public map<KeyEvent,
                                     vector<KeyBinding>> {
  public:
-  void LoadBindings(const ConfigListPtr& bindings);
+  void LoadBindings(const a<ConfigList>& bindings);
   void Bind(const KeyEvent& key, const KeyBinding& binding);
 };
 
@@ -82,7 +82,7 @@ static void select_schema(Engine* engine, const string& schema) {
   }
 }
 
-void KeyBindings::LoadBindings(const ConfigListPtr& bindings) {
+void KeyBindings::LoadBindings(const a<ConfigList>& bindings) {
   if (!bindings)
     return;
   for (size_t i = 0; i < bindings->size(); ++i) {

--- a/src/gear/key_binder.cc
+++ b/src/gear/key_binder.cc
@@ -59,7 +59,7 @@ struct KeyBinding {
 class KeyBindings : public map<KeyEvent,
                                     vector<KeyBinding>> {
  public:
-  void LoadBindings(const a<ConfigList>& bindings);
+  void LoadBindings(const an<ConfigList>& bindings);
   void Bind(const KeyEvent& key, const KeyBinding& binding);
 };
 
@@ -82,7 +82,7 @@ static void select_schema(Engine* engine, const string& schema) {
   }
 }
 
-void KeyBindings::LoadBindings(const a<ConfigList>& bindings) {
+void KeyBindings::LoadBindings(const an<ConfigList>& bindings) {
   if (!bindings)
     return;
   for (size_t i = 0; i < bindings->size(); ++i) {

--- a/src/gear/memory.cc
+++ b/src/gear/memory.cc
@@ -24,7 +24,7 @@ void CommitEntry::Clear() {
   elements.clear();
 }
 
-void CommitEntry::AppendPhrase(const a<Phrase>& phrase) {
+void CommitEntry::AppendPhrase(const an<Phrase>& phrase) {
   text += phrase->text();
   code.insert(code.end(),
               phrase->code().begin(), phrase->code().end());

--- a/src/gear/memory.cc
+++ b/src/gear/memory.cc
@@ -24,7 +24,7 @@ void CommitEntry::Clear() {
   elements.clear();
 }
 
-void CommitEntry::AppendPhrase(const shared_ptr<Phrase>& phrase) {
+void CommitEntry::AppendPhrase(const a<Phrase>& phrase) {
   text += phrase->text();
   code.insert(code.end(),
               phrase->code().begin(), phrase->code().end());

--- a/src/gear/poet.cc
+++ b/src/gear/poet.cc
@@ -13,10 +13,10 @@
 
 namespace rime {
 
-a<Sentence> Poet::MakeSentence(const WordGraph& graph,
+an<Sentence> Poet::MakeSentence(const WordGraph& graph,
                                         size_t total_length) {
   const int kMaxHomophonesInMind = 1;
-  map<int, a<Sentence>> sentences;
+  map<int, an<Sentence>> sentences;
   sentences[0] = New<Sentence>(language_);
   // dynamic programming
   for (const auto& w : graph) {

--- a/src/gear/poet.cc
+++ b/src/gear/poet.cc
@@ -6,8 +6,6 @@
 //
 // 2011-10-06 GONG Chen <chen.sst@gmail.com>
 //
-#include <map>
-#include <vector>
 #include <rime/common.h>
 #include <rime/candidate.h>
 #include <rime/dict/vocabulary.h>
@@ -15,10 +13,10 @@
 
 namespace rime {
 
-shared_ptr<Sentence> Poet::MakeSentence(const WordGraph& graph,
+a<Sentence> Poet::MakeSentence(const WordGraph& graph,
                                         size_t total_length) {
   const int kMaxHomophonesInMind = 1;
-  std::map<int, shared_ptr<Sentence>> sentences;
+  map<int, a<Sentence>> sentences;
   sentences[0] = New<Sentence>(language_);
   // dynamic programming
   for (const auto& w : graph) {

--- a/src/gear/punctuator.cc
+++ b/src/gear/punctuator.cc
@@ -22,14 +22,14 @@ namespace rime {
 
 void PunctConfig::LoadConfig(Engine* engine, bool load_symbols) {
   bool full_shape = engine->context()->get_option("full_shape");
-  std::string shape(full_shape ? "full_shape" : "half_shape");
+  string shape(full_shape ? "full_shape" : "half_shape");
   if (shape_ == shape)
     return;
   shape_ = shape;
   Config* config = engine->schema()->config();
-  std::string preset;
+  string preset;
   if (config->GetString("punctuator/import_preset", &preset)) {
-    unique_ptr<Config> preset_config(
+    the<Config> preset_config(
         Config::Require("config")->Create(preset));
     if (!preset_config) {
       LOG(ERROR) << "Error importing preset punctuation '" << preset << "'.";
@@ -52,7 +52,7 @@ void PunctConfig::LoadConfig(Engine* engine, bool load_symbols) {
   }
 }
 
-ConfigItemPtr PunctConfig::GetPunctDefinition(const std::string key) {
+ConfigItemPtr PunctConfig::GetPunctDefinition(const string key) {
   ConfigItemPtr punct_definition;
   if (mapping_)
     punct_definition = mapping_->Get(key);
@@ -115,7 +115,7 @@ ProcessResult Punctuator::ProcessKeyEvent(const KeyEvent& key_event) {
     }
   }
   config_.LoadConfig(engine_);
-  std::string punct_key(1, ch);
+  string punct_key(1, ch);
   auto punct_definition = config_.GetPunctDefinition(punct_key);
   if (!punct_definition)
     return kNoop;
@@ -130,7 +130,7 @@ ProcessResult Punctuator::ProcessKeyEvent(const KeyEvent& key_event) {
   return kAccepted;
 }
 
-bool Punctuator::AlternatePunct(const std::string& key,
+bool Punctuator::AlternatePunct(const string& key,
                                 const ConfigItemPtr& definition) {
   if (!As<ConfigList>(definition))
     return false;
@@ -199,7 +199,7 @@ PunctSegmentor::PunctSegmentor(const Ticket& ticket) : Segmentor(ticket) {
 }
 
 bool PunctSegmentor::Proceed(Segmentation* segmentation) {
-  const std::string& input = segmentation->input();
+  const string& input = segmentation->input();
   int k = segmentation->GetCurrentStartPosition();
   if (k == input.length())
     return false;  // no chance for others too
@@ -207,7 +207,7 @@ bool PunctSegmentor::Proceed(Segmentation* segmentation) {
   if (ch < 0x20 || ch >= 0x7f)
     return true;
   config_.LoadConfig(engine_);
-  std::string punct_key(1, ch);
+  string punct_key(1, ch);
   auto punct_definition = config_.GetPunctDefinition(punct_key);
   if (!punct_definition)
     return true;
@@ -227,8 +227,8 @@ PunctTranslator::PunctTranslator(const Ticket& ticket)
   config_.LoadConfig(engine_, load_symbols);
 }
 
-shared_ptr<Candidate>
-CreatePunctCandidate(const std::string& punct, const Segment& segment) {
+a<Candidate>
+CreatePunctCandidate(const string& punct, const Segment& segment) {
   const char half_shape[] =
       "\xe3\x80\x94\xe5\x8d\x8a\xe8\xa7\x92\xe3\x80\x95";  // 〔半角〕
   const char full_shape[] =
@@ -255,7 +255,7 @@ CreatePunctCandidate(const std::string& punct, const Segment& segment) {
                               one_key ? punct : "");
 }
 
-shared_ptr<Translation> PunctTranslator::Query(const std::string& input,
+a<Translation> PunctTranslator::Query(const string& input,
                                                const Segment& segment) {
   if (!segment.HasTag("punct"))
     return nullptr;
@@ -283,8 +283,8 @@ shared_ptr<Translation> PunctTranslator::Query(const std::string& input,
   return translation;
 }
 
-shared_ptr<Translation>
-PunctTranslator::TranslateUniquePunct(const std::string& key,
+a<Translation>
+PunctTranslator::TranslateUniquePunct(const string& key,
                                       const Segment& segment,
                                       const ConfigValuePtr& definition) {
   if (!definition)
@@ -293,8 +293,8 @@ PunctTranslator::TranslateUniquePunct(const std::string& key,
       CreatePunctCandidate(definition->str(), segment));
 }
 
-shared_ptr<Translation>
-PunctTranslator::TranslateAlternatingPunct(const std::string& key,
+a<Translation>
+PunctTranslator::TranslateAlternatingPunct(const string& key,
                                            const Segment& segment,
                                            const ConfigListPtr& definition) {
   if (!definition)
@@ -317,8 +317,8 @@ PunctTranslator::TranslateAlternatingPunct(const std::string& key,
   return translation;
 }
 
-shared_ptr<Translation>
-PunctTranslator::TranslateAutoCommitPunct(const std::string& key,
+a<Translation>
+PunctTranslator::TranslateAutoCommitPunct(const string& key,
                                           const Segment& segment,
                                           const ConfigMapPtr& definition) {
   if (!definition || !definition->HasKey("commit"))
@@ -331,8 +331,8 @@ PunctTranslator::TranslateAutoCommitPunct(const std::string& key,
   return New<UniqueTranslation>(CreatePunctCandidate(value->str(), segment));
 }
 
-shared_ptr<Translation>
-PunctTranslator::TranslatePairedPunct(const std::string& key,
+a<Translation>
+PunctTranslator::TranslatePairedPunct(const string& key,
                                       const Segment& segment,
                                       const ConfigMapPtr& definition) {
   if (!definition || !definition->HasKey("pair"))

--- a/src/gear/punctuator.cc
+++ b/src/gear/punctuator.cc
@@ -52,8 +52,8 @@ void PunctConfig::LoadConfig(Engine* engine, bool load_symbols) {
   }
 }
 
-a<ConfigItem> PunctConfig::GetPunctDefinition(const string key) {
-  a<ConfigItem> punct_definition;
+an<ConfigItem> PunctConfig::GetPunctDefinition(const string key) {
+  an<ConfigItem> punct_definition;
   if (mapping_)
     punct_definition = mapping_->Get(key);
   if (punct_definition)
@@ -131,7 +131,7 @@ ProcessResult Punctuator::ProcessKeyEvent(const KeyEvent& key_event) {
 }
 
 bool Punctuator::AlternatePunct(const string& key,
-                                const a<ConfigItem>& definition) {
+                                const an<ConfigItem>& definition) {
   if (!As<ConfigList>(definition))
     return false;
   Context* ctx = engine_->context();
@@ -155,14 +155,14 @@ bool Punctuator::AlternatePunct(const string& key,
   return false;
 }
 
-bool Punctuator::ConfirmUniquePunct(const a<ConfigItem>& definition) {
+bool Punctuator::ConfirmUniquePunct(const an<ConfigItem>& definition) {
   if (!As<ConfigValue>(definition))
     return false;
   engine_->context()->ConfirmCurrentSelection();
   return true;
 }
 
-bool Punctuator::AutoCommitPunct(const a<ConfigItem>& definition) {
+bool Punctuator::AutoCommitPunct(const an<ConfigItem>& definition) {
   auto map = As<ConfigMap>(definition);
   if (!map || !map->HasKey("commit"))
     return false;
@@ -170,7 +170,7 @@ bool Punctuator::AutoCommitPunct(const a<ConfigItem>& definition) {
   return true;
 }
 
-bool Punctuator::PairPunct(const a<ConfigItem>& definition) {
+bool Punctuator::PairPunct(const an<ConfigItem>& definition) {
   auto map = As<ConfigMap>(definition);
   if (!map || !map->HasKey("pair"))
     return false;
@@ -227,7 +227,7 @@ PunctTranslator::PunctTranslator(const Ticket& ticket)
   config_.LoadConfig(engine_, load_symbols);
 }
 
-a<Candidate>
+an<Candidate>
 CreatePunctCandidate(const string& punct, const Segment& segment) {
   const char half_shape[] =
       "\xe3\x80\x94\xe5\x8d\x8a\xe8\xa7\x92\xe3\x80\x95";  // 〔半角〕
@@ -255,7 +255,7 @@ CreatePunctCandidate(const string& punct, const Segment& segment) {
                               one_key ? punct : "");
 }
 
-a<Translation> PunctTranslator::Query(const string& input,
+an<Translation> PunctTranslator::Query(const string& input,
                                                const Segment& segment) {
   if (!segment.HasTag("punct"))
     return nullptr;
@@ -283,20 +283,20 @@ a<Translation> PunctTranslator::Query(const string& input,
   return translation;
 }
 
-a<Translation>
+an<Translation>
 PunctTranslator::TranslateUniquePunct(const string& key,
                                       const Segment& segment,
-                                      const a<ConfigValue>& definition) {
+                                      const an<ConfigValue>& definition) {
   if (!definition)
     return nullptr;
   return New<UniqueTranslation>(
       CreatePunctCandidate(definition->str(), segment));
 }
 
-a<Translation>
+an<Translation>
 PunctTranslator::TranslateAlternatingPunct(const string& key,
                                            const Segment& segment,
-                                           const a<ConfigList>& definition) {
+                                           const an<ConfigList>& definition) {
   if (!definition)
     return nullptr;
   auto translation = New<FifoTranslation>();
@@ -317,10 +317,10 @@ PunctTranslator::TranslateAlternatingPunct(const string& key,
   return translation;
 }
 
-a<Translation>
+an<Translation>
 PunctTranslator::TranslateAutoCommitPunct(const string& key,
                                           const Segment& segment,
-                                          const a<ConfigMap>& definition) {
+                                          const an<ConfigMap>& definition) {
   if (!definition || !definition->HasKey("commit"))
     return nullptr;
   auto value = definition->GetValue("commit");
@@ -331,10 +331,10 @@ PunctTranslator::TranslateAutoCommitPunct(const string& key,
   return New<UniqueTranslation>(CreatePunctCandidate(value->str(), segment));
 }
 
-a<Translation>
+an<Translation>
 PunctTranslator::TranslatePairedPunct(const string& key,
                                       const Segment& segment,
-                                      const a<ConfigMap>& definition) {
+                                      const an<ConfigMap>& definition) {
   if (!definition || !definition->HasKey("pair"))
     return nullptr;
   auto list = As<ConfigList>(definition->Get("pair"));

--- a/src/gear/punctuator.cc
+++ b/src/gear/punctuator.cc
@@ -52,8 +52,8 @@ void PunctConfig::LoadConfig(Engine* engine, bool load_symbols) {
   }
 }
 
-ConfigItemPtr PunctConfig::GetPunctDefinition(const string key) {
-  ConfigItemPtr punct_definition;
+a<ConfigItem> PunctConfig::GetPunctDefinition(const string key) {
+  a<ConfigItem> punct_definition;
   if (mapping_)
     punct_definition = mapping_->Get(key);
   if (punct_definition)
@@ -131,7 +131,7 @@ ProcessResult Punctuator::ProcessKeyEvent(const KeyEvent& key_event) {
 }
 
 bool Punctuator::AlternatePunct(const string& key,
-                                const ConfigItemPtr& definition) {
+                                const a<ConfigItem>& definition) {
   if (!As<ConfigList>(definition))
     return false;
   Context* ctx = engine_->context();
@@ -155,14 +155,14 @@ bool Punctuator::AlternatePunct(const string& key,
   return false;
 }
 
-bool Punctuator::ConfirmUniquePunct(const ConfigItemPtr& definition) {
+bool Punctuator::ConfirmUniquePunct(const a<ConfigItem>& definition) {
   if (!As<ConfigValue>(definition))
     return false;
   engine_->context()->ConfirmCurrentSelection();
   return true;
 }
 
-bool Punctuator::AutoCommitPunct(const ConfigItemPtr& definition) {
+bool Punctuator::AutoCommitPunct(const a<ConfigItem>& definition) {
   auto map = As<ConfigMap>(definition);
   if (!map || !map->HasKey("commit"))
     return false;
@@ -170,7 +170,7 @@ bool Punctuator::AutoCommitPunct(const ConfigItemPtr& definition) {
   return true;
 }
 
-bool Punctuator::PairPunct(const ConfigItemPtr& definition) {
+bool Punctuator::PairPunct(const a<ConfigItem>& definition) {
   auto map = As<ConfigMap>(definition);
   if (!map || !map->HasKey("pair"))
     return false;
@@ -286,7 +286,7 @@ a<Translation> PunctTranslator::Query(const string& input,
 a<Translation>
 PunctTranslator::TranslateUniquePunct(const string& key,
                                       const Segment& segment,
-                                      const ConfigValuePtr& definition) {
+                                      const a<ConfigValue>& definition) {
   if (!definition)
     return nullptr;
   return New<UniqueTranslation>(
@@ -296,7 +296,7 @@ PunctTranslator::TranslateUniquePunct(const string& key,
 a<Translation>
 PunctTranslator::TranslateAlternatingPunct(const string& key,
                                            const Segment& segment,
-                                           const ConfigListPtr& definition) {
+                                           const a<ConfigList>& definition) {
   if (!definition)
     return nullptr;
   auto translation = New<FifoTranslation>();
@@ -320,7 +320,7 @@ PunctTranslator::TranslateAlternatingPunct(const string& key,
 a<Translation>
 PunctTranslator::TranslateAutoCommitPunct(const string& key,
                                           const Segment& segment,
-                                          const ConfigMapPtr& definition) {
+                                          const a<ConfigMap>& definition) {
   if (!definition || !definition->HasKey("commit"))
     return nullptr;
   auto value = definition->GetValue("commit");
@@ -334,7 +334,7 @@ PunctTranslator::TranslateAutoCommitPunct(const string& key,
 a<Translation>
 PunctTranslator::TranslatePairedPunct(const string& key,
                                       const Segment& segment,
-                                      const ConfigMapPtr& definition) {
+                                      const a<ConfigMap>& definition) {
   if (!definition || !definition->HasKey("pair"))
     return nullptr;
   auto list = As<ConfigList>(definition->Get("pair"));

--- a/src/gear/recognizer.cc
+++ b/src/gear/recognizer.cc
@@ -15,7 +15,7 @@
 
 namespace rime {
 
-static void load_patterns(RecognizerPatterns* patterns, ConfigMapPtr map) {
+static void load_patterns(RecognizerPatterns* patterns, a<ConfigMap> map) {
   if (!patterns || !map)
     return;
   for (auto it = map->begin(); it != map->end(); ++it) {
@@ -27,7 +27,7 @@ static void load_patterns(RecognizerPatterns* patterns, ConfigMapPtr map) {
 }
 
 void RecognizerPatterns::LoadConfig(Config* config) {
-  ConfigMapPtr pattern_map;
+  a<ConfigMap> pattern_map;
   string preset;
   if (config->GetString("recognizer/import_preset", &preset)) {
     the<Config> preset_config(

--- a/src/gear/recognizer.cc
+++ b/src/gear/recognizer.cc
@@ -15,7 +15,7 @@
 
 namespace rime {
 
-static void load_patterns(RecognizerPatterns* patterns, a<ConfigMap> map) {
+static void load_patterns(RecognizerPatterns* patterns, an<ConfigMap> map) {
   if (!patterns || !map)
     return;
   for (auto it = map->begin(); it != map->end(); ++it) {
@@ -27,7 +27,7 @@ static void load_patterns(RecognizerPatterns* patterns, a<ConfigMap> map) {
 }
 
 void RecognizerPatterns::LoadConfig(Config* config) {
-  a<ConfigMap> pattern_map;
+  an<ConfigMap> pattern_map;
   string preset;
   if (config->GetString("recognizer/import_preset", &preset)) {
     the<Config> preset_config(

--- a/src/gear/recognizer.cc
+++ b/src/gear/recognizer.cc
@@ -28,9 +28,9 @@ static void load_patterns(RecognizerPatterns* patterns, ConfigMapPtr map) {
 
 void RecognizerPatterns::LoadConfig(Config* config) {
   ConfigMapPtr pattern_map;
-  std::string preset;
+  string preset;
   if (config->GetString("recognizer/import_preset", &preset)) {
-    unique_ptr<Config> preset_config(
+    the<Config> preset_config(
         Config::Require("config")->Create(preset));
     if (!preset_config) {
       LOG(ERROR) << "Error importing preset patterns '" << preset << "'.";
@@ -44,11 +44,11 @@ void RecognizerPatterns::LoadConfig(Config* config) {
 }
 
 RecognizerMatch
-RecognizerPatterns::GetMatch(const std::string& input,
+RecognizerPatterns::GetMatch(const string& input,
                              const Segmentation& segmentation) const {
   size_t j = segmentation.GetCurrentEndPosition();
   size_t k = segmentation.GetConfirmedPosition();
-  std::string active_input = input.substr(k);
+  string active_input = input.substr(k);
   DLOG(INFO) << "matching active input '" << active_input << "' at pos " << k;
   for (const auto& v : *this) {
     boost::smatch m;
@@ -95,7 +95,7 @@ ProcessResult Recognizer::ProcessKeyEvent(const KeyEvent& key_event) {
       (ch > 0x20 && ch < 0x80)) {
     // pattern matching against the input string plus the incoming character
     Context* ctx = engine_->context();
-    std::string input = ctx->input();
+    string input = ctx->input();
     input += ch;
     auto match = patterns_.GetMatch(input, ctx->composition());
     if (match.found()) {

--- a/src/gear/reverse_lookup_filter.cc
+++ b/src/gear/reverse_lookup_filter.cc
@@ -16,17 +16,17 @@ namespace rime {
 
 class ReverseLookupFilterTranslation : public CacheTranslation {
  public:
-  ReverseLookupFilterTranslation(a<Translation> translation,
+  ReverseLookupFilterTranslation(an<Translation> translation,
                                  ReverseLookupFilter* filter)
       : CacheTranslation(translation), filter_(filter) {
   }
-  virtual a<Candidate> Peek();
+  virtual an<Candidate> Peek();
 
  protected:
   ReverseLookupFilter* filter_;
 };
 
-a<Candidate> ReverseLookupFilterTranslation::Peek() {
+an<Candidate> ReverseLookupFilterTranslation::Peek() {
   auto cand = CacheTranslation::Peek();
   if (cand) {
     filter_->Process(cand);
@@ -58,8 +58,8 @@ void ReverseLookupFilter::Initialize() {
   }
 }
 
-a<Translation> ReverseLookupFilter::Apply(
-    a<Translation> translation, CandidateList* candidates) {
+an<Translation> ReverseLookupFilter::Apply(
+    an<Translation> translation, CandidateList* candidates) {
   if (!initialized_) {
     Initialize();
   }
@@ -69,7 +69,7 @@ a<Translation> ReverseLookupFilter::Apply(
   return New<ReverseLookupFilterTranslation>(translation, this);
 }
 
-void ReverseLookupFilter::Process(const a<Candidate>& cand) {
+void ReverseLookupFilter::Process(const an<Candidate>& cand) {
   if (!overwrite_comment_ && !cand->comment().empty())
     return;
   auto phrase = As<Phrase>(Candidate::GetGenuineCandidate(cand));

--- a/src/gear/reverse_lookup_filter.cc
+++ b/src/gear/reverse_lookup_filter.cc
@@ -16,17 +16,17 @@ namespace rime {
 
 class ReverseLookupFilterTranslation : public CacheTranslation {
  public:
-  ReverseLookupFilterTranslation(shared_ptr<Translation> translation,
+  ReverseLookupFilterTranslation(a<Translation> translation,
                                  ReverseLookupFilter* filter)
       : CacheTranslation(translation), filter_(filter) {
   }
-  virtual shared_ptr<Candidate> Peek();
+  virtual a<Candidate> Peek();
 
  protected:
   ReverseLookupFilter* filter_;
 };
 
-shared_ptr<Candidate> ReverseLookupFilterTranslation::Peek() {
+a<Candidate> ReverseLookupFilterTranslation::Peek() {
   auto cand = CacheTranslation::Peek();
   if (cand) {
     filter_->Process(cand);
@@ -58,8 +58,8 @@ void ReverseLookupFilter::Initialize() {
   }
 }
 
-shared_ptr<Translation> ReverseLookupFilter::Apply(
-    shared_ptr<Translation> translation, CandidateList* candidates) {
+a<Translation> ReverseLookupFilter::Apply(
+    a<Translation> translation, CandidateList* candidates) {
   if (!initialized_) {
     Initialize();
   }
@@ -69,13 +69,13 @@ shared_ptr<Translation> ReverseLookupFilter::Apply(
   return New<ReverseLookupFilterTranslation>(translation, this);
 }
 
-void ReverseLookupFilter::Process(const shared_ptr<Candidate>& cand) {
+void ReverseLookupFilter::Process(const a<Candidate>& cand) {
   if (!overwrite_comment_ && !cand->comment().empty())
     return;
   auto phrase = As<Phrase>(Candidate::GetGenuineCandidate(cand));
   if (!phrase)
     return;
-  std::string codes;
+  string codes;
   if (rev_dict_->ReverseLookup(phrase->text(), &codes)) {
     comment_formatter_.Apply(&codes);
     if (!codes.empty()) {

--- a/src/gear/reverse_lookup_translator.cc
+++ b/src/gear/reverse_lookup_translator.cc
@@ -29,16 +29,16 @@ class ReverseLookupTranslation : public TableTranslation {
  public:
   ReverseLookupTranslation(ReverseLookupDictionary* dict,
                            TranslatorOptions* options,
-                           const std::string& input,
+                           const string& input,
                            size_t start, size_t end,
-                           const std::string& preedit,
+                           const string& preedit,
                            const DictEntryIterator& iter,
                            bool quality)
       : TableTranslation(options, NULL, input, start, end, preedit, iter),
         dict_(dict), options_(options), quality_(quality) {
   }
-  virtual shared_ptr<Candidate> Peek();
-  virtual int Compare(shared_ptr<Translation> other,
+  virtual a<Candidate> Peek();
+  virtual int Compare(a<Translation> other,
                       const CandidateList& candidates);
  protected:
   ReverseLookupDictionary* dict_;
@@ -46,11 +46,11 @@ class ReverseLookupTranslation : public TableTranslation {
   bool quality_;
 };
 
-shared_ptr<Candidate> ReverseLookupTranslation::Peek() {
+a<Candidate> ReverseLookupTranslation::Peek() {
   if (exhausted())
     return nullptr;
   const auto& entry(iter_.Peek());
-  std::string tips;
+  string tips;
   if (dict_) {
     dict_->ReverseLookup(entry->text, &tips);
     if (options_) {
@@ -60,7 +60,7 @@ shared_ptr<Candidate> ReverseLookupTranslation::Peek() {
     //  boost::algorithm::replace_all(tips, " ", separator);
     //}
   }
-  shared_ptr<Candidate> cand = New<SimpleCandidate>(
+  a<Candidate> cand = New<SimpleCandidate>(
       "reverse_lookup",
       start_,
       end_,
@@ -70,7 +70,7 @@ shared_ptr<Candidate> ReverseLookupTranslation::Peek() {
   return cand;
 }
 
-int ReverseLookupTranslation::Compare(shared_ptr<Translation> other,
+int ReverseLookupTranslation::Compare(a<Translation> other,
                                       const CandidateList& candidates) {
   if (!other || other->exhausted())
     return -1;
@@ -129,7 +129,7 @@ void ReverseLookupTranslator::Initialize() {
   if (!rev_component)
     return;
   // lookup target defaults to "translator/dictionary"
-  std::string rev_target("translator");
+  string rev_target("translator");
   config->GetString(name_space_ + "/target", &rev_target);
   Ticket rev_ticket(engine_, rev_target);
   rev_dict_.reset(rev_component->Create(rev_ticket));
@@ -138,7 +138,7 @@ void ReverseLookupTranslator::Initialize() {
   }
 }
 
-shared_ptr<Translation> ReverseLookupTranslator::Query(const std::string& input,
+a<Translation> ReverseLookupTranslator::Query(const string& input,
                                                        const Segment& segment) {
   if (!segment.HasTag(tag_))
     return nullptr;
@@ -149,13 +149,13 @@ shared_ptr<Translation> ReverseLookupTranslator::Query(const std::string& input,
   DLOG(INFO) << "input = '" << input
              << "', [" << segment.start << ", " << segment.end << ")";
 
-  const std::string& preedit(input);
+  const string& preedit(input);
 
   size_t start = 0;
   if (!prefix_.empty() && boost::starts_with(input, prefix_)) {
     start = prefix_.length();
   }
-  std::string code = input.substr(start);
+  string code = input.substr(start);
   if (!suffix_.empty() && boost::ends_with(code, suffix_)) {
     code.resize(code.length() - suffix_.length());
   }

--- a/src/gear/reverse_lookup_translator.cc
+++ b/src/gear/reverse_lookup_translator.cc
@@ -37,8 +37,8 @@ class ReverseLookupTranslation : public TableTranslation {
       : TableTranslation(options, NULL, input, start, end, preedit, iter),
         dict_(dict), options_(options), quality_(quality) {
   }
-  virtual a<Candidate> Peek();
-  virtual int Compare(a<Translation> other,
+  virtual an<Candidate> Peek();
+  virtual int Compare(an<Translation> other,
                       const CandidateList& candidates);
  protected:
   ReverseLookupDictionary* dict_;
@@ -46,7 +46,7 @@ class ReverseLookupTranslation : public TableTranslation {
   bool quality_;
 };
 
-a<Candidate> ReverseLookupTranslation::Peek() {
+an<Candidate> ReverseLookupTranslation::Peek() {
   if (exhausted())
     return nullptr;
   const auto& entry(iter_.Peek());
@@ -60,7 +60,7 @@ a<Candidate> ReverseLookupTranslation::Peek() {
     //  boost::algorithm::replace_all(tips, " ", separator);
     //}
   }
-  a<Candidate> cand = New<SimpleCandidate>(
+  an<Candidate> cand = New<SimpleCandidate>(
       "reverse_lookup",
       start_,
       end_,
@@ -70,7 +70,7 @@ a<Candidate> ReverseLookupTranslation::Peek() {
   return cand;
 }
 
-int ReverseLookupTranslation::Compare(a<Translation> other,
+int ReverseLookupTranslation::Compare(an<Translation> other,
                                       const CandidateList& candidates) {
   if (!other || other->exhausted())
     return -1;
@@ -138,7 +138,7 @@ void ReverseLookupTranslator::Initialize() {
   }
 }
 
-a<Translation> ReverseLookupTranslator::Query(const string& input,
+an<Translation> ReverseLookupTranslator::Query(const string& input,
                                                        const Segment& segment) {
   if (!segment.HasTag(tag_))
     return nullptr;

--- a/src/gear/schema_list_translator.cc
+++ b/src/gear/schema_list_translator.cc
@@ -40,8 +40,8 @@ void SchemaSelection::Apply(Switcher* switcher) {
 
 class SchemaAction : public ShadowCandidate, public SwitcherCommand {
  public:
-  SchemaAction(a<Candidate> schema,
-               a<Candidate> command)
+  SchemaAction(an<Candidate> schema,
+               an<Candidate> command)
       : ShadowCandidate(schema, command->type()),
         SwitcherCommand(As<SwitcherCommand>(schema)->keyword()),
         command_(As<SwitcherCommand>(command)) {
@@ -49,7 +49,7 @@ class SchemaAction : public ShadowCandidate, public SwitcherCommand {
   virtual void Apply(Switcher* switcher);
 
  private:
-  a<SwitcherCommand> command_;
+  an<SwitcherCommand> command_;
 };
 
 void SchemaAction::Apply(Switcher* switcher) {
@@ -63,14 +63,14 @@ class SchemaListTranslation : public FifoTranslation {
   SchemaListTranslation(Switcher* switcher) {
     LoadSchemaList(switcher);
   }
-  virtual int Compare(a<Translation> other,
+  virtual int Compare(an<Translation> other,
                       const CandidateList& candidates);
 
  protected:
   void LoadSchemaList(Switcher* switcher);
 };
 
-int SchemaListTranslation::Compare(a<Translation> other,
+int SchemaListTranslation::Compare(an<Translation> other,
                                    const CandidateList& candidates) {
   if (!other || other->exhausted())
     return -1;
@@ -138,7 +138,7 @@ void SchemaListTranslation::LoadSchemaList(Switcher* switcher) {
     return;
   // reorder schema list by recency
   std::stable_sort(candies_.begin() + fixed, candies_.end(),
-      [](const a<Candidate>& x, const a<Candidate>& y) {
+      [](const an<Candidate>& x, const an<Candidate>& y) {
         return x->quality() > y->quality();
       });
 }
@@ -147,7 +147,7 @@ SchemaListTranslator::SchemaListTranslator(const Ticket& ticket)
     : Translator(ticket) {
 }
 
-a<Translation> SchemaListTranslator::Query(const string& input,
+an<Translation> SchemaListTranslator::Query(const string& input,
                                                     const Segment& segment) {
   auto switcher = dynamic_cast<Switcher*>(engine_);
   if (!switcher) {

--- a/src/gear/schema_list_translator.cc
+++ b/src/gear/schema_list_translator.cc
@@ -40,8 +40,8 @@ void SchemaSelection::Apply(Switcher* switcher) {
 
 class SchemaAction : public ShadowCandidate, public SwitcherCommand {
  public:
-  SchemaAction(shared_ptr<Candidate> schema,
-               shared_ptr<Candidate> command)
+  SchemaAction(a<Candidate> schema,
+               a<Candidate> command)
       : ShadowCandidate(schema, command->type()),
         SwitcherCommand(As<SwitcherCommand>(schema)->keyword()),
         command_(As<SwitcherCommand>(command)) {
@@ -49,7 +49,7 @@ class SchemaAction : public ShadowCandidate, public SwitcherCommand {
   virtual void Apply(Switcher* switcher);
 
  private:
-  shared_ptr<SwitcherCommand> command_;
+  a<SwitcherCommand> command_;
 };
 
 void SchemaAction::Apply(Switcher* switcher) {
@@ -63,14 +63,14 @@ class SchemaListTranslation : public FifoTranslation {
   SchemaListTranslation(Switcher* switcher) {
     LoadSchemaList(switcher);
   }
-  virtual int Compare(shared_ptr<Translation> other,
+  virtual int Compare(a<Translation> other,
                       const CandidateList& candidates);
 
  protected:
   void LoadSchemaList(Switcher* switcher);
 };
 
-int SchemaListTranslation::Compare(shared_ptr<Translation> other,
+int SchemaListTranslation::Compare(a<Translation> other,
                                    const CandidateList& candidates) {
   if (!other || other->exhausted())
     return -1;
@@ -117,7 +117,7 @@ void SchemaListTranslation::LoadSchemaList(Switcher* switcher) {
     auto schema_property = item->GetValue("schema");
     if (!schema_property)
       continue;
-    const std::string& schema_id(schema_property->str());
+    const string& schema_id(schema_property->str());
     if (current_schema && schema_id == current_schema->schema_id())
       continue;
     Schema schema(schema_id);
@@ -138,8 +138,8 @@ void SchemaListTranslation::LoadSchemaList(Switcher* switcher) {
     return;
   // reorder schema list by recency
   std::stable_sort(candies_.begin() + fixed, candies_.end(),
-      [](const shared_ptr<Candidate>& a, const shared_ptr<Candidate>& b) {
-        return a->quality() > b->quality();
+      [](const a<Candidate>& x, const a<Candidate>& y) {
+        return x->quality() > y->quality();
       });
 }
 
@@ -147,7 +147,7 @@ SchemaListTranslator::SchemaListTranslator(const Ticket& ticket)
     : Translator(ticket) {
 }
 
-shared_ptr<Translation> SchemaListTranslator::Query(const std::string& input,
+a<Translation> SchemaListTranslator::Query(const string& input,
                                                     const Segment& segment) {
   auto switcher = dynamic_cast<Switcher*>(engine_);
   if (!switcher) {

--- a/src/gear/script_translator.cc
+++ b/src/gear/script_translator.cc
@@ -99,21 +99,21 @@ class ScriptTranslation : public Translation {
   }
   bool Evaluate(Dictionary* dict, UserDictionary* user_dict);
   virtual bool Next();
-  virtual a<Candidate> Peek();
+  virtual an<Candidate> Peek();
 
  protected:
   bool CheckEmpty();
   bool IsNormalSpelling() const;
-  a<Sentence> MakeSentence(Dictionary* dict,
+  an<Sentence> MakeSentence(Dictionary* dict,
                                     UserDictionary* user_dict);
 
   ScriptTranslator* translator_;
   size_t start_;
-  a<ScriptSyllabifier> syllabifier_;
+  an<ScriptSyllabifier> syllabifier_;
 
-  a<DictEntryCollector> phrase_;
-  a<UserDictEntryCollector> user_phrase_;
-  a<Sentence> sentence_;
+  an<DictEntryCollector> phrase_;
+  an<UserDictEntryCollector> user_phrase_;
+  an<Sentence> sentence_;
 
   DictEntryCollector::reverse_iterator phrase_iter_;
   UserDictEntryCollector::reverse_iterator user_phrase_iter_;
@@ -133,7 +133,7 @@ ScriptTranslator::ScriptTranslator(const Ticket& ticket)
   }
 }
 
-a<Translation> ScriptTranslator::Query(const string& input,
+an<Translation> ScriptTranslator::Query(const string& input,
                                                 const Segment& segment) {
   if (!dict_ || !dict_->loaded())
     return nullptr;
@@ -336,7 +336,7 @@ bool ScriptTranslation::IsNormalSpelling() const {
       (syllable_graph.vertices.rbegin()->second == kNormalSpelling);
 }
 
-a<Candidate> ScriptTranslation::Peek() {
+an<Candidate> ScriptTranslation::Peek() {
   if (exhausted())
     return nullptr;
   if (sentence_) {
@@ -359,7 +359,7 @@ a<Candidate> ScriptTranslation::Peek() {
   if (phrase_ && phrase_iter_ != phrase_->rend()) {
     phrase_code_length = phrase_iter_->first;
   }
-  a<Phrase> cand;
+  an<Phrase> cand;
   if (user_phrase_code_length > 0 &&
       user_phrase_code_length >= phrase_code_length) {
     DictEntryList& entries(user_phrase_iter_->second);
@@ -408,7 +408,7 @@ bool ScriptTranslation::CheckEmpty() {
   return exhausted();
 }
 
-a<Sentence>
+an<Sentence>
 ScriptTranslation::MakeSentence(Dictionary* dict, UserDictionary* user_dict) {
   const int kMaxSyllablesForUserPhraseQuery = 5;
   const auto& syllable_graph = syllabifier_->syllable_graph();

--- a/src/gear/script_translator.cc
+++ b/src/gear/script_translator.cc
@@ -7,7 +7,6 @@
 // 2011-07-10 GONG Chen <chen.sst@gmail.com>
 //
 #include <algorithm>
-#include <functional>
 #include <stack>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/reversed.hpp>
@@ -36,9 +35,9 @@ struct SyllabifyTask {
   const Code& code;
   const SyllableGraph& graph;
   size_t target_pos;
-  std::function<void (SyllabifyTask* task, size_t depth,
+  function<void (SyllabifyTask* task, size_t depth,
                       size_t current_pos, size_t next_pos)> push;
-  std::function<void (SyllabifyTask* task, size_t depth)> pop;
+  function<void (SyllabifyTask* task, size_t depth)> pop;
 };
 
 static bool syllabify_dfs(SyllabifyTask* task,
@@ -71,21 +70,21 @@ static bool syllabify_dfs(SyllabifyTask* task,
 class ScriptSyllabifier : public PhraseSyllabifier {
  public:
   ScriptSyllabifier(ScriptTranslator* translator,
-                    const std::string& input,
+                    const string& input,
                     size_t start)
       : translator_(translator), input_(input), start_(start) {
   }
 
   virtual Spans Syllabify(const Phrase* phrase);
   size_t BuildSyllableGraph(Prism& prism);
-  std::string GetPreeditString(const Phrase& cand) const;
-  std::string GetOriginalSpelling(const Phrase& cand) const;
+  string GetPreeditString(const Phrase& cand) const;
+  string GetOriginalSpelling(const Phrase& cand) const;
 
   const SyllableGraph& syllable_graph() const { return syllable_graph_; }
 
  protected:
   ScriptTranslator* translator_;
-  std::string input_;
+  string input_;
   size_t start_;
   SyllableGraph syllable_graph_;
 };
@@ -93,28 +92,28 @@ class ScriptSyllabifier : public PhraseSyllabifier {
 class ScriptTranslation : public Translation {
  public:
   ScriptTranslation(ScriptTranslator* translator,
-                    const std::string& input, size_t start)
+                    const string& input, size_t start)
       : translator_(translator), start_(start),
         syllabifier_(New<ScriptSyllabifier>(translator, input, start)) {
     set_exhausted(true);
   }
   bool Evaluate(Dictionary* dict, UserDictionary* user_dict);
   virtual bool Next();
-  virtual shared_ptr<Candidate> Peek();
+  virtual a<Candidate> Peek();
 
  protected:
   bool CheckEmpty();
   bool IsNormalSpelling() const;
-  shared_ptr<Sentence> MakeSentence(Dictionary* dict,
+  a<Sentence> MakeSentence(Dictionary* dict,
                                     UserDictionary* user_dict);
 
   ScriptTranslator* translator_;
   size_t start_;
-  shared_ptr<ScriptSyllabifier> syllabifier_;
+  a<ScriptSyllabifier> syllabifier_;
 
-  shared_ptr<DictEntryCollector> phrase_;
-  shared_ptr<UserDictEntryCollector> user_phrase_;
-  shared_ptr<Sentence> sentence_;
+  a<DictEntryCollector> phrase_;
+  a<UserDictEntryCollector> user_phrase_;
+  a<Sentence> sentence_;
 
   DictEntryCollector::reverse_iterator phrase_iter_;
   UserDictEntryCollector::reverse_iterator user_phrase_iter_;
@@ -134,7 +133,7 @@ ScriptTranslator::ScriptTranslator(const Ticket& ticket)
   }
 }
 
-shared_ptr<Translation> ScriptTranslator::Query(const std::string& input,
+a<Translation> ScriptTranslator::Query(const string& input,
                                                 const Segment& segment) {
   if (!dict_ || !dict_->loaded())
     return nullptr;
@@ -158,19 +157,19 @@ shared_ptr<Translation> ScriptTranslator::Query(const std::string& input,
   return New<DistinctTranslation>(result);
 }
 
-std::string ScriptTranslator::FormatPreedit(const std::string& preedit) {
-  std::string result = preedit;
+string ScriptTranslator::FormatPreedit(const string& preedit) {
+  string result = preedit;
   preedit_formatter_.Apply(&result);
   return result;
 }
 
-std::string ScriptTranslator::Spell(const Code& code) {
-  std::string result;
-  std::vector<std::string> syllables;
+string ScriptTranslator::Spell(const Code& code) {
+  string result;
+  vector<string> syllables;
   if (!dict_ || !dict_->Decode(code, &syllables) || syllables.empty())
     return result;
   result =  boost::algorithm::join(syllables,
-                                   std::string(1, delimiters_.at(0)));
+                                   string(1, delimiters_.at(0)));
   comment_formatter_.Apply(&result);
   return result;
 }
@@ -200,7 +199,7 @@ bool ScriptTranslator::Memorize(const CommitEntry& commit_entry) {
 
 Spans ScriptSyllabifier::Syllabify(const Phrase* phrase) {
   Spans result;
-  std::vector<size_t> vertices;
+  vector<size_t> vertices;
   vertices.push_back(start_);
   SyllabifyTask task{
     phrase->code(),
@@ -230,10 +229,10 @@ size_t ScriptSyllabifier::BuildSyllableGraph(Prism& prism) {
   return consumed;
 }
 
-std::string ScriptSyllabifier::GetPreeditString(const Phrase& cand) const {
+string ScriptSyllabifier::GetPreeditString(const Phrase& cand) const {
   const auto& delimiters = translator_->delimiters();
   std::stack<size_t> lengths;
-  std::string output;
+  string output;
   SyllabifyTask task{
     cand.code(),
     syllable_graph_,
@@ -242,7 +241,7 @@ std::string ScriptSyllabifier::GetPreeditString(const Phrase& cand) const {
         size_t current_pos, size_t next_pos) {
       size_t len = output.length();
       if (depth > 0 && len > 0 &&
-          delimiters.find(output[len - 1]) == std::string::npos) {
+          delimiters.find(output[len - 1]) == string::npos) {
         output += delimiters.at(0);
       }
       output += input_.substr(current_pos, next_pos - current_pos);
@@ -257,16 +256,16 @@ std::string ScriptSyllabifier::GetPreeditString(const Phrase& cand) const {
     return translator_->FormatPreedit(output);
   }
   else {
-    return std::string();
+    return string();
   }
 }
 
-std::string ScriptSyllabifier::GetOriginalSpelling(const Phrase& cand) const {
+string ScriptSyllabifier::GetOriginalSpelling(const Phrase& cand) const {
   if (translator_ &&
       static_cast<int>(cand.code().size()) <= translator_->spelling_hints()) {
     return translator_->Spell(cand.code());
   }
-  return std::string();
+  return string();
 }
 
 // ScriptTranslation implementation
@@ -337,7 +336,7 @@ bool ScriptTranslation::IsNormalSpelling() const {
       (syllable_graph.vertices.rbegin()->second == kNormalSpelling);
 }
 
-shared_ptr<Candidate> ScriptTranslation::Peek() {
+a<Candidate> ScriptTranslation::Peek() {
   if (exhausted())
     return nullptr;
   if (sentence_) {
@@ -360,7 +359,7 @@ shared_ptr<Candidate> ScriptTranslation::Peek() {
   if (phrase_ && phrase_iter_ != phrase_->rend()) {
     phrase_code_length = phrase_iter_->first;
   }
-  shared_ptr<Phrase> cand;
+  a<Phrase> cand;
   if (user_phrase_code_length > 0 &&
       user_phrase_code_length >= phrase_code_length) {
     DictEntryList& entries(user_phrase_iter_->second);
@@ -409,7 +408,7 @@ bool ScriptTranslation::CheckEmpty() {
   return exhausted();
 }
 
-shared_ptr<Sentence>
+a<Sentence>
 ScriptTranslation::MakeSentence(Dictionary* dict, UserDictionary* user_dict) {
   const int kMaxSyllablesForUserPhraseQuery = 5;
   const auto& syllable_graph = syllabifier_->syllable_graph();

--- a/src/gear/selector.cc
+++ b/src/gear/selector.cc
@@ -54,12 +54,12 @@ ProcessResult Selector::ProcessKeyEvent(const KeyEvent& key_event) {
       return kAccepted;
   }
   int index = -1;
-  const std::string& select_keys(engine_->schema()->select_keys());
+  const string& select_keys(engine_->schema()->select_keys());
   if (!select_keys.empty() &&
       !key_event.ctrl() &&
       ch >= 0x20 && ch < 0x7f) {
     size_t pos = select_keys.find((char)ch);
-    if (pos != std::string::npos) {
+    if (pos != string::npos) {
       index = static_cast<int>(pos);
     }
   }

--- a/src/gear/shape.cc
+++ b/src/gear/shape.cc
@@ -13,7 +13,7 @@
 
 namespace rime {
 
-void ShapeFormatter::Format(std::string* text) {
+void ShapeFormatter::Format(string* text) {
   if (!engine_->context()->get_option("full_shape")) {
     return;
   }
@@ -48,7 +48,7 @@ ProcessResult ShapeProcessor::ProcessKeyEvent(const KeyEvent& key_event) {
   if (ch < 0x20 || ch > 0x7e) {
     return kNoop;
   }
-  std::string wide(1, ch);
+  string wide(1, ch);
   formatter_.Format(&wide);
   engine_->sink()(wide);
   return kAccepted;

--- a/src/gear/simplifier.cc
+++ b/src/gear/simplifier.cc
@@ -4,8 +4,6 @@
 //
 // 2011-12-12 GONG Chen <chen.sst@gmail.com>
 //
-#include <string>
-#include <vector>
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include <opencc/Config.hpp>
@@ -33,17 +31,17 @@ namespace rime {
 
 class Opencc {
  public:
-  Opencc(const std::string& config_path) {
+  Opencc(const string& config_path) {
     LOG(INFO) << "initilizing opencc: " << config_path;
     opencc::Config config;
     converter_ = config.NewFromFile(config_path);
-    const std::list<opencc::ConversionPtr> conversions =
+    const list<opencc::ConversionPtr> conversions =
       converter_->GetConversionChain()->GetConversions();
     dict_ = conversions.front()->GetDict();
   }
 
-  bool ConvertSingleCharacter(const std::string& text,
-                              std::vector<std::string>* forms) {
+  bool ConvertSingleCharacter(const string& text,
+                              vector<string>* forms) {
     opencc::Optional<const opencc::DictEntry*> item = dict_->Match(text);
     if (item.IsNull()) {
       // Match not found
@@ -57,8 +55,8 @@ class Opencc {
     }
   }
 
-  bool ConvertText(const std::string& text,
-                   std::string* simplified) {
+  bool ConvertText(const string& text,
+                   string* simplified) {
     *simplified = converter_->Convert(text);
     return true;
   }
@@ -76,7 +74,7 @@ Simplifier::Simplifier(const Ticket& ticket) : Filter(ticket),
     name_space_ = "simplifier";
   }
   if (Config* config = engine_->schema()->config()) {
-    std::string tips;
+    string tips;
     if (config->GetString(name_space_ + "/tips", &tips) ||
         config->GetString(name_space_ + "/tip", &tips)) {
       tips_level_ = (tips == "all") ? kTipsAll :
@@ -130,7 +128,7 @@ void Simplifier::Initialize() {
 
 class SimplifiedTranslation : public PrefetchTranslation {
  public:
-  SimplifiedTranslation(shared_ptr<Translation> translation,
+  SimplifiedTranslation(a<Translation> translation,
                         Simplifier* simplifier)
       : PrefetchTranslation(translation), simplifier_(simplifier) {
   }
@@ -151,7 +149,7 @@ bool SimplifiedTranslation::Replenish() {
   return !cache_.empty();
 }
 
-shared_ptr<Translation> Simplifier::Apply(shared_ptr<Translation> translation,
+a<Translation> Simplifier::Apply(a<Translation> translation,
                                           CandidateList* candidates) {
   if (!engine_->context()->get_option(option_name_)) {  // off
     return translation;
@@ -165,7 +163,7 @@ shared_ptr<Translation> Simplifier::Apply(shared_ptr<Translation> translation,
   return New<SimplifiedTranslation>(translation, this);
 }
 
-bool Simplifier::Convert(const shared_ptr<Candidate>& original,
+bool Simplifier::Convert(const a<Candidate>& original,
                          CandidateQueue* result) {
   if (excluded_types_.find(original->type()) != excluded_types_.end()) {
     return false;
@@ -175,7 +173,7 @@ bool Simplifier::Convert(const shared_ptr<Candidate>& original,
                                             + original->text().length());
   bool success;
   if (length == 1) {
-    std::vector<std::string> forms;
+    vector<string> forms;
     success = opencc_->ConvertSingleCharacter(original->text(), &forms);
     if (!success || forms.size() == 0) {
       return false;
@@ -185,7 +183,7 @@ bool Simplifier::Convert(const shared_ptr<Candidate>& original,
         result->push_back(original);
       }
       else {
-        std::string tips;
+        string tips;
         if (tips_level_ >= kTipsChar) {
           tips = quote_left + original->text() + quote_right;
         }
@@ -198,12 +196,12 @@ bool Simplifier::Convert(const shared_ptr<Candidate>& original,
       }
     }
   } else {
-    std::string simplified;
+    string simplified;
     success = opencc_->ConvertText(original->text(), &simplified);
     if (!success || simplified == original->text()) {
       return false;
     }
-    std::string tips;
+    string tips;
     if (tips_level_ == kTipsAll) {
       tips = quote_left + original->text() + quote_right;
     }

--- a/src/gear/simplifier.cc
+++ b/src/gear/simplifier.cc
@@ -128,7 +128,7 @@ void Simplifier::Initialize() {
 
 class SimplifiedTranslation : public PrefetchTranslation {
  public:
-  SimplifiedTranslation(a<Translation> translation,
+  SimplifiedTranslation(an<Translation> translation,
                         Simplifier* simplifier)
       : PrefetchTranslation(translation), simplifier_(simplifier) {
   }
@@ -149,7 +149,7 @@ bool SimplifiedTranslation::Replenish() {
   return !cache_.empty();
 }
 
-a<Translation> Simplifier::Apply(a<Translation> translation,
+an<Translation> Simplifier::Apply(an<Translation> translation,
                                           CandidateList* candidates) {
   if (!engine_->context()->get_option(option_name_)) {  // off
     return translation;
@@ -163,7 +163,7 @@ a<Translation> Simplifier::Apply(a<Translation> translation,
   return New<SimplifiedTranslation>(translation, this);
 }
 
-bool Simplifier::Convert(const a<Candidate>& original,
+bool Simplifier::Convert(const an<Candidate>& original,
                          CandidateQueue* result) {
   if (excluded_types_.find(original->type()) != excluded_types_.end()) {
     return false;

--- a/src/gear/single_char_filter.cc
+++ b/src/gear/single_char_filter.cc
@@ -19,14 +19,14 @@ static inline size_t unistrlen(const string& text) {
 
 class SingleCharFirstTranslation : public PrefetchTranslation {
  public:
-  SingleCharFirstTranslation(a<Translation> translation);
+  SingleCharFirstTranslation(an<Translation> translation);
 
  private:
   bool Rearrange();
 };
 
 SingleCharFirstTranslation::SingleCharFirstTranslation(
-    a<Translation> translation)
+    an<Translation> translation)
     : PrefetchTranslation(translation) {
   Rearrange();
 }
@@ -60,8 +60,8 @@ SingleCharFilter::SingleCharFilter(const Ticket& ticket)
     : Filter(ticket) {
 }
 
-a<Translation> SingleCharFilter::Apply(
-    a<Translation> translation, CandidateList* candidates) {
+an<Translation> SingleCharFilter::Apply(
+    an<Translation> translation, CandidateList* candidates) {
   return New<SingleCharFirstTranslation>(translation);
 }
 

--- a/src/gear/single_char_filter.cc
+++ b/src/gear/single_char_filter.cc
@@ -12,21 +12,21 @@
 
 namespace rime {
 
-static inline size_t unistrlen(const std::string& text) {
+static inline size_t unistrlen(const string& text) {
   return utf8::unchecked::distance(
       text.c_str(), text.c_str() + text.length());
 }
 
 class SingleCharFirstTranslation : public PrefetchTranslation {
  public:
-  SingleCharFirstTranslation(shared_ptr<Translation> translation);
+  SingleCharFirstTranslation(a<Translation> translation);
 
  private:
   bool Rearrange();
 };
 
 SingleCharFirstTranslation::SingleCharFirstTranslation(
-    shared_ptr<Translation> translation)
+    a<Translation> translation)
     : PrefetchTranslation(translation) {
   Rearrange();
 }
@@ -60,8 +60,8 @@ SingleCharFilter::SingleCharFilter(const Ticket& ticket)
     : Filter(ticket) {
 }
 
-shared_ptr<Translation> SingleCharFilter::Apply(
-    shared_ptr<Translation> translation, CandidateList* candidates) {
+a<Translation> SingleCharFilter::Apply(
+    a<Translation> translation, CandidateList* candidates) {
   return New<SingleCharFirstTranslation>(translation);
 }
 

--- a/src/gear/speller.cc
+++ b/src/gear/speller.cc
@@ -25,7 +25,7 @@ static inline bool belongs_to(char ch, const string& charset) {
   return charset.find(ch) != string::npos;
 }
 
-static bool reached_max_code_length(const a<Candidate>& cand,
+static bool reached_max_code_length(const an<Candidate>& cand,
                                     int max_code_length) {
   if (!cand)
     return false;
@@ -33,7 +33,7 @@ static bool reached_max_code_length(const a<Candidate>& cand,
   return code_length >= max_code_length;
 }
 
-static bool is_auto_selectable(const a<Candidate>& cand,
+static bool is_auto_selectable(const an<Candidate>& cand,
                                const string& input,
                                const string& delimiters) {
   return

--- a/src/gear/speller.cc
+++ b/src/gear/speller.cc
@@ -21,11 +21,11 @@ static const char kRimeAlphabet[] = "zyxwvutsrqponmlkjihgfedcba";
 
 namespace rime {
 
-static inline bool belongs_to(char ch, const std::string& charset) {
-  return charset.find(ch) != std::string::npos;
+static inline bool belongs_to(char ch, const string& charset) {
+  return charset.find(ch) != string::npos;
 }
 
-static bool reached_max_code_length(const shared_ptr<Candidate>& cand,
+static bool reached_max_code_length(const a<Candidate>& cand,
                                     int max_code_length) {
   if (!cand)
     return false;
@@ -33,27 +33,27 @@ static bool reached_max_code_length(const shared_ptr<Candidate>& cand,
   return code_length >= max_code_length;
 }
 
-static bool is_auto_selectable(const shared_ptr<Candidate>& cand,
-                               const std::string& input,
-                               const std::string& delimiters) {
+static bool is_auto_selectable(const a<Candidate>& cand,
+                               const string& input,
+                               const string& delimiters) {
   return
       // reaches end of input
       cand->end() == input.length() &&
       // is table entry
       Candidate::GetGenuineCandidate(cand)->type() == "table" &&
       // no delimiters
-      input.find_first_of(delimiters, cand->start()) == std::string::npos;
+      input.find_first_of(delimiters, cand->start()) == string::npos;
 }
 
 static bool expecting_an_initial(Context* ctx,
-                                 const std::string& alphabet,
-                                 const std::string& finals) {
+                                 const string& alphabet,
+                                 const string& finals) {
   size_t caret_pos = ctx->caret_pos();
   if (caret_pos == 0 ||
       caret_pos == ctx->composition().GetCurrentStartPosition()) {
     return true;
   }
-  const std::string& input(ctx->input());
+  const string& input(ctx->input());
   char previous_char = input[caret_pos - 1];
   return belongs_to(previous_char, finals) ||
          !belongs_to(previous_char, alphabet);
@@ -69,7 +69,7 @@ Speller::Speller(const Ticket& ticket) : Processor(ticket),
     config->GetInt("speller/max_code_length", &max_code_length_);
     config->GetBool("speller/auto_select", &auto_select_);
     config->GetBool("speller/use_space", &use_space_);
-    std::string pattern;
+    string pattern;
     if (config->GetString("speller/auto_select_pattern", &pattern)) {
       auto_select_pattern_ = pattern;
     }
@@ -147,7 +147,7 @@ bool Speller::AutoSelectUniqueCandidate(Context* ctx) {
   bool unique_candidate = seg.menu->Prepare(2) == 1;
   if (!unique_candidate)
     return false;
-  const std::string& input(ctx->input());
+  const string& input(ctx->input());
   auto cand = seg.GetSelectedCandidate();
   bool matches_input_pattern = false;
   if (auto_select_pattern_.empty()) {
@@ -156,7 +156,7 @@ bool Speller::AutoSelectUniqueCandidate(Context* ctx) {
         reached_max_code_length(cand, max_code_length_);
   }
   else {
-    std::string code(input.substr(cand->start(), cand->end()));
+    string code(input.substr(cand->start(), cand->end()));
     matches_input_pattern = boost::regex_match(code, auto_select_pattern_);
   }
   if (matches_input_pattern &&
@@ -177,8 +177,8 @@ bool Speller::AutoSelectPreviousMatch(Context* ctx,
     return false;
   size_t start = previous_segment->start;
   size_t end = previous_segment->end;
-  std::string input = ctx->input();
-  std::string converted = input.substr(0, end);
+  string input = ctx->input();
+  string converted = input.substr(0, end);
   if (is_auto_selectable(previous_segment->GetSelectedCandidate(),
                          converted, delimiters_)) {
     // reuse previous match
@@ -188,7 +188,7 @@ bool Speller::AutoSelectPreviousMatch(Context* ctx,
     if (ctx->get_option("_auto_commit")) {
       ctx->set_input(converted);
       ctx->Commit();
-      std::string rest = input.substr(end);
+      string rest = input.substr(end);
       ctx->set_input(rest);
     }
     return true;
@@ -199,8 +199,8 @@ bool Speller::AutoSelectPreviousMatch(Context* ctx,
 bool Speller::FindEarlierMatch(Context* ctx, size_t start, size_t end) {
   if (end <= start + 1)
     return false;
-  std::string input = ctx->input();
-  std::string converted = input;
+  string input = ctx->input();
+  string converted = input;
   while (--end > start) {
     converted.resize(end);
     ctx->set_input(converted);
@@ -212,7 +212,7 @@ bool Speller::FindEarlierMatch(Context* ctx, size_t start, size_t end) {
       // select previous match
       if (ctx->get_option("_auto_commit")) {
         ctx->Commit();
-        std::string rest = input.substr(end);
+        string rest = input.substr(end);
         ctx->set_input(rest);
         end = 0;
       }

--- a/src/gear/switch_translator.cc
+++ b/src/gear/switch_translator.cc
@@ -59,7 +59,7 @@ class RadioGroup : public std::enable_shared_from_this<RadioGroup> {
   RadioGroup(Context* context, Switcher* switcher)
       : context_(context), switcher_(switcher) {
   }
-  a<RadioOption> CreateOption(const string& state_label,
+  an<RadioOption> CreateOption(const string& state_label,
                                        const string& option_name);
   void SelectOption(RadioOption* option);
   RadioOption* GetSelectedOption() const;
@@ -72,7 +72,7 @@ class RadioGroup : public std::enable_shared_from_this<RadioGroup> {
 
 class RadioOption : public SimpleCandidate, public SwitcherCommand {
  public:
-  RadioOption(a<RadioGroup> group,
+  RadioOption(an<RadioGroup> group,
               const string& state_label,
               const string& option_name)
       : SimpleCandidate("switch", 0, 0, state_label),
@@ -84,7 +84,7 @@ class RadioOption : public SimpleCandidate, public SwitcherCommand {
   bool selected() const { return selected_; }
 
  protected:
-  a<RadioGroup> group_;
+  an<RadioGroup> group_;
   bool selected_ = false;
 };
 
@@ -98,7 +98,7 @@ void RadioOption::UpdateState(bool selected) {
   set_comment(selected ? kRadioSelected : "");
 }
 
-a<RadioOption>
+an<RadioOption>
 RadioGroup::CreateOption(const string& state_label,
                          const string& option_name) {
   auto option = New<RadioOption>(shared_from_this(),
@@ -281,7 +281,7 @@ SwitchTranslator::SwitchTranslator(const Ticket& ticket)
     : Translator(ticket) {
 }
 
-a<Translation> SwitchTranslator::Query(const string& input,
+an<Translation> SwitchTranslator::Query(const string& input,
                                                 const Segment& segment) {
   auto switcher = dynamic_cast<Switcher*>(engine_);
   if (!switcher) {

--- a/src/gear/switch_translator.cc
+++ b/src/gear/switch_translator.cc
@@ -4,7 +4,6 @@
 //
 // 2013-05-26 GONG Chen <chen.sst@gmail.com>
 //
-#include <vector>
 #include <utf8.h>
 #include <rime/candidate.h>
 #include <rime/common.h>
@@ -23,9 +22,9 @@ namespace rime {
 
 class Switch : public SimpleCandidate, public SwitcherCommand {
  public:
-  Switch(const std::string& current_state_label,
-         const std::string& next_state_label,
-         const std::string& option_name,
+  Switch(const string& current_state_label,
+         const string& next_state_label,
+         const string& option_name,
          bool current_state,
          bool auto_save)
       : SimpleCandidate("switch", 0, 0,
@@ -60,22 +59,22 @@ class RadioGroup : public std::enable_shared_from_this<RadioGroup> {
   RadioGroup(Context* context, Switcher* switcher)
       : context_(context), switcher_(switcher) {
   }
-  shared_ptr<RadioOption> CreateOption(const std::string& state_label,
-                                       const std::string& option_name);
+  a<RadioOption> CreateOption(const string& state_label,
+                                       const string& option_name);
   void SelectOption(RadioOption* option);
   RadioOption* GetSelectedOption() const;
 
  private:
   Context* context_;
   Switcher* switcher_;
-  std::vector<RadioOption*> options_;
+  vector<RadioOption*> options_;
 };
 
 class RadioOption : public SimpleCandidate, public SwitcherCommand {
  public:
-  RadioOption(shared_ptr<RadioGroup> group,
-              const std::string& state_label,
-              const std::string& option_name)
+  RadioOption(a<RadioGroup> group,
+              const string& state_label,
+              const string& option_name)
       : SimpleCandidate("switch", 0, 0, state_label),
         SwitcherCommand(option_name),
         group_(group) {
@@ -85,7 +84,7 @@ class RadioOption : public SimpleCandidate, public SwitcherCommand {
   bool selected() const { return selected_; }
 
  protected:
-  shared_ptr<RadioGroup> group_;
+  a<RadioGroup> group_;
   bool selected_ = false;
 };
 
@@ -99,9 +98,9 @@ void RadioOption::UpdateState(bool selected) {
   set_comment(selected ? kRadioSelected : "");
 }
 
-shared_ptr<RadioOption>
-RadioGroup::CreateOption(const std::string& state_label,
-                         const std::string& option_name) {
+a<RadioOption>
+RadioGroup::CreateOption(const string& state_label,
+                         const string& option_name) {
   auto option = New<RadioOption>(shared_from_this(),
                                  state_label,
                                  option_name);
@@ -116,7 +115,7 @@ void RadioGroup::SelectOption(RadioOption* option) {
   for (auto it = options_.begin(); it != options_.end(); ++it) {
     bool selected = (*it == option);
     (*it)->UpdateState(selected);
-    const std::string& option_name((*it)->keyword());
+    const string& option_name((*it)->keyword());
     if (context_->get_option(option_name) != selected) {
       context_->set_option(option_name, selected);
       if (user_config && switcher_->IsAutoSave(option_name)) {
@@ -144,7 +143,7 @@ class FoldedOptions : public SimpleCandidate, public SwitcherCommand {
     LoadConfig(config);
   }
   virtual void Apply(Switcher* switcher);
-  void Append(const std::string& label) {
+  void Append(const string& label) {
     labels_.push_back(label);
   }
   size_t size() const {
@@ -155,12 +154,12 @@ class FoldedOptions : public SimpleCandidate, public SwitcherCommand {
  private:
   void LoadConfig(Config* config);
 
-  std::string prefix_;
-  std::string suffix_;
-  std::string separator_ = " ";
+  string prefix_;
+  string suffix_;
+  string separator_ = " ";
   bool abbreviate_options_ = false;
 
-  std::vector<std::string> labels_;
+  vector<string> labels_;
 };
 
 void FoldedOptions::LoadConfig(Config* config) {
@@ -179,15 +178,15 @@ void FoldedOptions::Apply(Switcher* switcher) {
   switcher->RefreshMenu();
 }
 
-static std::string FirstCharOf(const std::string& str) {
+static string FirstCharOf(const string& str) {
   if (str.empty()) {
     return str;
   }
-  std::string first_char;
+  string first_char;
   const char* start = str.c_str();
   const char* end = start;
   utf8::unchecked::next(end);
-  return std::string(start, end - start);
+  return string(start, end - start);
 }
 
 void FoldedOptions::Finish() {
@@ -282,7 +281,7 @@ SwitchTranslator::SwitchTranslator(const Ticket& ticket)
     : Translator(ticket) {
 }
 
-shared_ptr<Translation> SwitchTranslator::Query(const std::string& input,
+a<Translation> SwitchTranslator::Query(const string& input,
                                                 const Segment& segment) {
   auto switcher = dynamic_cast<Switcher*>(engine_);
   if (!switcher) {

--- a/src/gear/table_translator.cc
+++ b/src/gear/table_translator.cc
@@ -74,7 +74,7 @@ static bool is_constructed(const DictEntry* e) {
   return UnityTableEncoder::HasPrefix(e->custom_code);
 }
 
-a<Candidate> TableTranslation::Peek() {
+an<Candidate> TableTranslation::Peek() {
   if (exhausted())
     return nullptr;
   bool is_user_phrase = PreferUserPhrase();
@@ -234,14 +234,14 @@ TableTranslator::TableTranslator(const Ticket& ticket)
   }
 }
 
-static bool starts_with_completion(a<Translation> translation) {
+static bool starts_with_completion(an<Translation> translation) {
   if (!translation)
     return false;
   auto cand = translation->Peek();
   return cand && cand->type() == "completion";
 }
 
-a<Translation> TableTranslator::Query(const string& input,
+an<Translation> TableTranslator::Query(const string& input,
                                                const Segment& segment) {
   if (!segment.HasTag(tag_))
     return nullptr;
@@ -257,7 +257,7 @@ a<Translation> TableTranslator::Query(const string& input,
   string code = input;
   boost::trim_right_if(code, boost::is_any_of(delimiters_));
 
-  a<Translation> translation;
+  an<Translation> translation;
   if (enable_completion_) {
     translation = Cached<LazyTableTranslation>(
         this,
@@ -391,13 +391,13 @@ Spans SentenceSyllabifier::Syllabify(const Phrase* phrase) {
 class SentenceTranslation : public Translation {
  public:
   SentenceTranslation(TableTranslator* translator,
-                      a<Sentence> sentence,
+                      an<Sentence> sentence,
                       DictEntryCollector* collector,
                       UserDictEntryCollector* ucollector,
                       const string& input,
                       size_t start);
   virtual bool Next();
-  virtual a<Candidate> Peek();
+  virtual an<Candidate> Peek();
 
  protected:
   void PrepareSentence();
@@ -405,7 +405,7 @@ class SentenceTranslation : public Translation {
   bool PreferUserPhrase() const;
 
   TableTranslator* translator_;
-  a<Sentence> sentence_;
+  an<Sentence> sentence_;
   DictEntryCollector collector_;
   UserDictEntryCollector user_phrase_collector_;
   size_t user_phrase_index_ = 0;
@@ -414,7 +414,7 @@ class SentenceTranslation : public Translation {
 };
 
 SentenceTranslation::SentenceTranslation(TableTranslator* translator,
-                                         a<Sentence> sentence,
+                                         an<Sentence> sentence,
                                          DictEntryCollector* collector,
                                          UserDictEntryCollector* ucollector,
                                          const string& input,
@@ -450,14 +450,14 @@ bool SentenceTranslation::Next() {
   return !CheckEmpty();
 }
 
-a<Candidate> SentenceTranslation::Peek() {
+an<Candidate> SentenceTranslation::Peek() {
   if (exhausted())
     return nullptr;
   if (sentence_) {
     return sentence_;
   }
   size_t code_length = 0;
-  a<DictEntry> entry;
+  an<DictEntry> entry;
   if (PreferUserPhrase()) {
     auto r = user_phrase_collector_.rbegin();
     code_length = r->first;
@@ -540,14 +540,14 @@ static size_t consume_trailing_delimiters(size_t pos,
   return pos;
 }
 
-a<Translation>
+an<Translation>
 TableTranslator::MakeSentence(const string& input, size_t start,
                               bool include_prefix_phrases) {
   bool filter_by_charset = enable_charset_filter_ &&
       !engine_->context()->get_option("extended_charset");
   DictEntryCollector collector;
   UserDictEntryCollector user_phrase_collector;
-  map<int, a<Sentence>> sentences;
+  map<int, an<Sentence>> sentences;
   sentences[0] = New<Sentence>(language());
   for (size_t start_pos = 0; start_pos < input.length(); ++start_pos) {
     if (sentences.find(start_pos) == sentences.end())
@@ -649,7 +649,7 @@ TableTranslator::MakeSentence(const string& input, size_t start,
       }
     }
   }
-  a<Translation> result;
+  an<Translation> result;
   if (sentences.find(input.length()) != sentences.end()) {
     result = Cached<SentenceTranslation>(
         this,

--- a/src/gear/table_translator.cc
+++ b/src/gear/table_translator.cc
@@ -554,7 +554,7 @@ TableTranslator::MakeSentence(const string& input, size_t start,
       continue;
     string active_input = input.substr(start_pos);
     string active_key = active_input + ' ';
-    vector<a<DictEntry>> entries(active_input.length() + 1);
+    vector<of<DictEntry>> entries(active_input.length() + 1);
     // lookup dictionaries
     if (user_dict_ && user_dict_->loaded()) {
       for (size_t len = 1; len <= active_input.length(); ++len) {

--- a/src/gear/table_translator.cc
+++ b/src/gear/table_translator.cc
@@ -29,9 +29,9 @@ static const char* kUnitySymbol = " \xe2\x98\xaf ";
 
 TableTranslation::TableTranslation(TranslatorOptions* options,
                                    Language* language,
-                                   const std::string& input,
+                                   const string& input,
                                    size_t start, size_t end,
-                                   const std::string& preedit)
+                                   const string& preedit)
     : options_(options), language_(language),
       input_(input), start_(start), end_(end), preedit_(preedit) {
   if (options_)
@@ -41,9 +41,9 @@ TableTranslation::TableTranslation(TranslatorOptions* options,
 
 TableTranslation::TableTranslation(TranslatorOptions* options,
                                    Language* language,
-                                   const std::string& input,
+                                   const string& input,
                                    size_t start, size_t end,
-                                   const std::string& preedit,
+                                   const string& preedit,
                                    const DictEntryIterator& iter,
                                    const UserDictEntryIterator& uter)
     : options_(options), language_(language),
@@ -74,12 +74,12 @@ static bool is_constructed(const DictEntry* e) {
   return UnityTableEncoder::HasPrefix(e->custom_code);
 }
 
-shared_ptr<Candidate> TableTranslation::Peek() {
+a<Candidate> TableTranslation::Peek() {
   if (exhausted())
     return nullptr;
   bool is_user_phrase = PreferUserPhrase();
   auto e = PreferedEntry(is_user_phrase);
-  std::string comment(is_constructed(e.get()) ? kUnitySymbol : e->comment);
+  string comment(is_constructed(e.get()) ? kUnitySymbol : e->comment);
   if (options_) {
     options_->comment_formatter().Apply(&comment);
   }
@@ -126,9 +126,9 @@ class LazyTableTranslation : public TableTranslation {
   static const size_t kExpandingFactor = 10;
 
   LazyTableTranslation(TableTranslator* translator,
-                       const std::string& input,
+                       const string& input,
                        size_t start, size_t end,
-                       const std::string& preedit,
+                       const string& preedit,
                        bool enable_user_dict);
   bool FetchUserPhrases(TableTranslator* translator);
   virtual bool FetchMoreUserPhrases();
@@ -139,13 +139,13 @@ class LazyTableTranslation : public TableTranslation {
   UserDictionary* user_dict_;
   size_t limit_;
   size_t user_dict_limit_;
-  std::string user_dict_key_;
+  string user_dict_key_;
 };
 
 LazyTableTranslation::LazyTableTranslation(TableTranslator* translator,
-                                           const std::string& input,
+                                           const string& input,
                                            size_t start, size_t end,
-                                           const std::string& preedit,
+                                           const string& preedit,
                                            bool enable_user_dict)
     : TableTranslation(translator, translator->language(),
                        input, start, end, preedit),
@@ -234,14 +234,14 @@ TableTranslator::TableTranslator(const Ticket& ticket)
   }
 }
 
-static bool starts_with_completion(shared_ptr<Translation> translation) {
+static bool starts_with_completion(a<Translation> translation) {
   if (!translation)
     return false;
   auto cand = translation->Peek();
   return cand && cand->type() == "completion";
 }
 
-shared_ptr<Translation> TableTranslator::Query(const std::string& input,
+a<Translation> TableTranslator::Query(const string& input,
                                                const Segment& segment) {
   if (!segment.HasTag(tag_))
     return nullptr;
@@ -253,11 +253,11 @@ shared_ptr<Translation> TableTranslator::Query(const std::string& input,
   bool enable_user_dict = user_dict_ && user_dict_->loaded() &&
       !IsUserDictDisabledFor(input);
 
-  const std::string& preedit(input);
-  std::string code = input;
+  const string& preedit(input);
+  string code = input;
   boost::trim_right_if(code, boost::is_any_of(delimiters_));
 
-  shared_ptr<Translation> translation;
+  a<Translation> translation;
   if (enable_completion_) {
     translation = Cached<LazyTableTranslation>(
         this,
@@ -344,7 +344,7 @@ bool TableTranslator::Memorize(const CommitEntry& commit_entry) {
         if (it->type == "punct") {  // ending with punctuation
             ++it;
         }
-        std::string phrase;
+        string phrase;
         for (; it != history.rend(); ++it) {
           if (it->type != "table" && it->type != "sentence")
             break;
@@ -391,13 +391,13 @@ Spans SentenceSyllabifier::Syllabify(const Phrase* phrase) {
 class SentenceTranslation : public Translation {
  public:
   SentenceTranslation(TableTranslator* translator,
-                      shared_ptr<Sentence> sentence,
+                      a<Sentence> sentence,
                       DictEntryCollector* collector,
                       UserDictEntryCollector* ucollector,
-                      const std::string& input,
+                      const string& input,
                       size_t start);
   virtual bool Next();
-  virtual shared_ptr<Candidate> Peek();
+  virtual a<Candidate> Peek();
 
  protected:
   void PrepareSentence();
@@ -405,19 +405,19 @@ class SentenceTranslation : public Translation {
   bool PreferUserPhrase() const;
 
   TableTranslator* translator_;
-  shared_ptr<Sentence> sentence_;
+  a<Sentence> sentence_;
   DictEntryCollector collector_;
   UserDictEntryCollector user_phrase_collector_;
   size_t user_phrase_index_ = 0;
-  std::string input_;
+  string input_;
   size_t start_;
 };
 
 SentenceTranslation::SentenceTranslation(TableTranslator* translator,
-                                         shared_ptr<Sentence> sentence,
+                                         a<Sentence> sentence,
                                          DictEntryCollector* collector,
                                          UserDictEntryCollector* ucollector,
-                                         const std::string& input,
+                                         const string& input,
                                          size_t start)
     : translator_(translator), input_(input), start_(start) {
   sentence_.swap(sentence);
@@ -450,14 +450,14 @@ bool SentenceTranslation::Next() {
   return !CheckEmpty();
 }
 
-shared_ptr<Candidate> SentenceTranslation::Peek() {
+a<Candidate> SentenceTranslation::Peek() {
   if (exhausted())
     return nullptr;
   if (sentence_) {
     return sentence_;
   }
   size_t code_length = 0;
-  shared_ptr<DictEntry> entry;
+  a<DictEntry> entry;
   if (PreferUserPhrase()) {
     auto r = user_phrase_collector_.rbegin();
     code_length = r->first;
@@ -475,7 +475,7 @@ shared_ptr<Candidate> SentenceTranslation::Peek() {
       start_ + code_length,
       entry);
   if (translator_) {
-    std::string preedit = input_.substr(0, code_length);
+    string preedit = input_.substr(0, code_length);
     translator_->preedit_formatter().Apply(&preedit);
     result->set_preedit(preedit);
   }
@@ -491,12 +491,12 @@ void SentenceTranslation::PrepareSentence() {
 
   if (!translator_)
     return;
-  std::string preedit = input_;
-  const std::string& delimiters(translator_->delimiters());
+  string preedit = input_;
+  const string& delimiters(translator_->delimiters());
   // split syllables
   size_t pos = 0;
   for (int len : sentence_->syllable_lengths()) {
-    if (pos > 0 && delimiters.find(input_[pos - 1]) == std::string::npos) {
+    if (pos > 0 && delimiters.find(input_[pos - 1]) == string::npos) {
       preedit.insert(pos, 1, ' ');
       ++pos;
     }
@@ -531,30 +531,30 @@ bool SentenceTranslation::PreferUserPhrase() const {
 }
 
 static size_t consume_trailing_delimiters(size_t pos,
-                                          const std::string& input,
-                                          const std::string& delimiters) {
+                                          const string& input,
+                                          const string& delimiters) {
   while (pos < input.length() &&
-         delimiters.find(input[pos]) != std::string::npos) {
+         delimiters.find(input[pos]) != string::npos) {
     ++pos;
   }
   return pos;
 }
 
-shared_ptr<Translation>
-TableTranslator::MakeSentence(const std::string& input, size_t start,
+a<Translation>
+TableTranslator::MakeSentence(const string& input, size_t start,
                               bool include_prefix_phrases) {
   bool filter_by_charset = enable_charset_filter_ &&
       !engine_->context()->get_option("extended_charset");
   DictEntryCollector collector;
   UserDictEntryCollector user_phrase_collector;
-  std::map<int, shared_ptr<Sentence>> sentences;
+  map<int, a<Sentence>> sentences;
   sentences[0] = New<Sentence>(language());
   for (size_t start_pos = 0; start_pos < input.length(); ++start_pos) {
     if (sentences.find(start_pos) == sentences.end())
       continue;
-    std::string active_input = input.substr(start_pos);
-    std::string active_key = active_input + ' ';
-    std::vector<shared_ptr<DictEntry>> entries(active_input.length() + 1);
+    string active_input = input.substr(start_pos);
+    string active_key = active_input + ' ';
+    vector<a<DictEntry>> entries(active_input.length() + 1);
     // lookup dictionaries
     if (user_dict_ && user_dict_->loaded()) {
       for (size_t len = 1; len <= active_input.length(); ++len) {
@@ -564,8 +564,8 @@ TableTranslator::MakeSentence(const std::string& input, size_t start,
           continue;
         DLOG(INFO) << "active input: " << active_input << "[0, " << len << ")";
         UserDictEntryIterator uter;
-        std::string resume_key;
-        std::string key = active_input.substr(0, len);
+        string resume_key;
+        string key = active_input.substr(0, len);
         user_dict_->LookupWords(&uter, key, false, 0, &resume_key);
         if (filter_by_charset) {
           uter.AddFilter(CharsetFilter::FilterDictEntry);
@@ -591,8 +591,8 @@ TableTranslator::MakeSentence(const std::string& input, size_t start,
           continue;
         DLOG(INFO) << "active input: " << active_input << "[0, " << len << ")";
         UserDictEntryIterator uter;
-        std::string resume_key;
-        std::string key = active_input.substr(0, len);
+        string resume_key;
+        string key = active_input.substr(0, len);
         encoder_->LookupPhrases(&uter, key, false, 0, &resume_key);
         if (filter_by_charset) {
           uter.AddFilter(CharsetFilter::FilterDictEntry);
@@ -610,7 +610,7 @@ TableTranslator::MakeSentence(const std::string& input, size_t start,
       }
     }
     if (dict_ && dict_->loaded()) {
-      std::vector<Prism::Match> matches;
+      vector<Prism::Match> matches;
       dict_->prism()->CommonPrefixSearch(input.substr(start_pos), &matches);
       if (matches.empty())
         continue;
@@ -649,7 +649,7 @@ TableTranslator::MakeSentence(const std::string& input, size_t start,
       }
     }
   }
-  shared_ptr<Translation> result;
+  a<Translation> result;
   if (sentences.find(input.length()) != sentences.end()) {
     result = Cached<SentenceTranslation>(
         this,

--- a/src/gear/translator_commons.cc
+++ b/src/gear/translator_commons.cc
@@ -129,7 +129,7 @@ TranslatorOptions::TranslatorOptions(const Ticket& ticket) {
   }
 }
 
-bool TranslatorOptions::IsUserDictDisabledFor(const std::string& input) const {
+bool TranslatorOptions::IsUserDictDisabledFor(const string& input) const {
   if (user_dict_disabling_patterns_.empty())
     return false;
   for (const auto& pattern : user_dict_disabling_patterns_) {

--- a/src/gear/translator_commons.cc
+++ b/src/gear/translator_commons.cc
@@ -14,7 +14,7 @@ namespace rime {
 
 // Patterns
 
-bool Patterns::Load(ConfigListPtr patterns) {
+bool Patterns::Load(a<ConfigList> patterns) {
   clear();
   if (!patterns)
     return false;

--- a/src/gear/translator_commons.cc
+++ b/src/gear/translator_commons.cc
@@ -14,7 +14,7 @@ namespace rime {
 
 // Patterns
 
-bool Patterns::Load(a<ConfigList> patterns) {
+bool Patterns::Load(an<ConfigList> patterns) {
   clear();
   if (!patterns)
     return false;

--- a/src/gear/uniquifier.cc
+++ b/src/gear/uniquifier.cc
@@ -13,7 +13,7 @@ namespace rime {
 
 class UniquifiedTranslation : public CacheTranslation {
  public:
-  UniquifiedTranslation(a<Translation> translation,
+  UniquifiedTranslation(an<Translation> translation,
                         CandidateList* candidates)
       : CacheTranslation(translation), candidates_(candidates) {
     Uniquify();
@@ -23,7 +23,7 @@ class UniquifiedTranslation : public CacheTranslation {
  protected:
   bool Uniquify();
 
-  a<Translation> translation_;
+  an<Translation> translation_;
   CandidateList* candidates_;
 };
 
@@ -55,7 +55,7 @@ bool UniquifiedTranslation::Uniquify() {
 Uniquifier::Uniquifier(const Ticket& ticket) : Filter(ticket) {
 }
 
-a<Translation> Uniquifier::Apply(a<Translation> translation,
+an<Translation> Uniquifier::Apply(an<Translation> translation,
                                           CandidateList* candidates) {
   return New<UniquifiedTranslation>(translation, candidates);
 }

--- a/src/gear/uniquifier.cc
+++ b/src/gear/uniquifier.cc
@@ -13,7 +13,7 @@ namespace rime {
 
 class UniquifiedTranslation : public CacheTranslation {
  public:
-  UniquifiedTranslation(shared_ptr<Translation> translation,
+  UniquifiedTranslation(a<Translation> translation,
                         CandidateList* candidates)
       : CacheTranslation(translation), candidates_(candidates) {
     Uniquify();
@@ -23,7 +23,7 @@ class UniquifiedTranslation : public CacheTranslation {
  protected:
   bool Uniquify();
 
-  shared_ptr<Translation> translation_;
+  a<Translation> translation_;
   CandidateList* candidates_;
 };
 
@@ -55,7 +55,7 @@ bool UniquifiedTranslation::Uniquify() {
 Uniquifier::Uniquifier(const Ticket& ticket) : Filter(ticket) {
 }
 
-shared_ptr<Translation> Uniquifier::Apply(shared_ptr<Translation> translation,
+a<Translation> Uniquifier::Apply(a<Translation> translation,
                                           CandidateList* candidates) {
   return New<UniquifiedTranslation>(translation, candidates);
 }

--- a/src/gear/unity_table_encoder.cc
+++ b/src/gear/unity_table_encoder.cc
@@ -41,9 +41,9 @@ bool UnityTableEncoder::Load(const Ticket& ticket) {
   return LoadSettings(settings.get());
 }
 
-void UnityTableEncoder::CreateEntry(const std::string& word,
-                                    const std::string& code_str,
-                                    const std::string& weight_str) {
+void UnityTableEncoder::CreateEntry(const string& word,
+                                    const string& code_str,
+                                    const string& weight_str) {
   if (!user_dict_)
     return;
   DictEntry entry;
@@ -53,12 +53,12 @@ void UnityTableEncoder::CreateEntry(const std::string& word,
   user_dict_->UpdateEntry(entry, commits, kEncodedPrefix);
 }
 
-bool UnityTableEncoder::TranslateWord(const std::string& word,
-                                      std::vector<std::string>* code) {
+bool UnityTableEncoder::TranslateWord(const string& word,
+                                      vector<string>* code) {
   if (!rev_dict_) {
     return false;
   }
-  std::string str_list;
+  string str_list;
   if (rev_dict_->LookupStems(word, &str_list) ||
       rev_dict_->ReverseLookup(word, &str_list)) {
     boost::split(*code, str_list, boost::is_any_of(" "));
@@ -68,10 +68,10 @@ bool UnityTableEncoder::TranslateWord(const std::string& word,
 }
 
 size_t UnityTableEncoder::LookupPhrases(UserDictEntryIterator* result,
-                                        const std::string& input,
+                                        const string& input,
                                         bool predictive,
                                         size_t limit,
-                                        std::string* resume_key) {
+                                        string* resume_key) {
   if (!user_dict_)
     return 0;
   return user_dict_->LookupWords(result,
@@ -79,16 +79,16 @@ size_t UnityTableEncoder::LookupPhrases(UserDictEntryIterator* result,
                                  predictive, limit, resume_key);
 }
 
-bool UnityTableEncoder::HasPrefix(const std::string& key) {
+bool UnityTableEncoder::HasPrefix(const string& key) {
   return boost::starts_with(key, kEncodedPrefix);
 }
 
-bool UnityTableEncoder::AddPrefix(std::string* key) {
+bool UnityTableEncoder::AddPrefix(string* key) {
   key->insert(0, kEncodedPrefix);
   return true;
 }
 
-bool UnityTableEncoder::RemovePrefix(std::string* key) {
+bool UnityTableEncoder::RemovePrefix(string* key) {
   if (!HasPrefix(*key))
     return false;
   key->erase(0, strlen(kEncodedPrefix));

--- a/src/key_event.cc
+++ b/src/key_event.cc
@@ -4,7 +4,6 @@
 //
 // 2011-04-20 GONG Chen <chen.sst@gmail.com>
 //
-#include <string>
 #include <sstream>
 #include <boost/format.hpp>
 #include <rime/key_event.h>
@@ -12,12 +11,12 @@
 
 namespace rime {
 
-KeyEvent::KeyEvent(const std::string& repr) {
+KeyEvent::KeyEvent(const string& repr) {
   if (!Parse(repr))
     keycode_ = modifier_ = 0;
 }
 
-std::string KeyEvent::repr() const {
+string KeyEvent::repr() const {
   // stringify modifiers
   std::ostringstream modifiers;
   if (modifier_) {
@@ -37,7 +36,7 @@ std::string KeyEvent::repr() const {
     return modifiers.str() + name;
   }
   // no name :-| return its hex value
-  std::string value;
+  string value;
   if (keycode_ <= 0xffff) {
     value = boost::str(boost::format("0x%4x") % keycode_);
   }
@@ -50,7 +49,7 @@ std::string KeyEvent::repr() const {
   return modifiers.str() + value;
 }
 
-bool KeyEvent::Parse(const std::string& repr) {
+bool KeyEvent::Parse(const string& repr) {
   keycode_ = modifier_ = 0;
   if (repr.empty()) {
     return false;
@@ -61,9 +60,9 @@ bool KeyEvent::Parse(const std::string& repr) {
   else {
     size_t start = 0;
     size_t found = 0;
-    std::string token;
+    string token;
     int mask = 0;
-    while ((found = repr.find('+', start)) != std::string::npos) {
+    while ((found = repr.find('+', start)) != string::npos) {
       token = repr.substr(start, found - start);
       mask = RimeGetModifierByName(token.c_str());
       if (mask) {
@@ -85,14 +84,14 @@ bool KeyEvent::Parse(const std::string& repr) {
   return true;
 }
 
-KeySequence::KeySequence(const std::string& repr) {
+KeySequence::KeySequence(const string& repr) {
   if (!Parse(repr))
     clear();
 }
 
-std::string KeySequence::repr() const {
+string KeySequence::repr() const {
   std::ostringstream result;
-  std::string k;
+  string k;
   for (auto it = cbegin(); it != cend(); ++it) {
     k = it->repr();
     if (k.size() == 1) {
@@ -105,7 +104,7 @@ std::string KeySequence::repr() const {
   return result.str();
 }
 
-bool KeySequence::Parse(const std::string& repr) {
+bool KeySequence::Parse(const string& repr) {
   clear();
   size_t n = repr.size();
   size_t start = 0;
@@ -115,7 +114,7 @@ bool KeySequence::Parse(const std::string& repr) {
     if (repr[i] == '{' && i + 1 < n) {
       start = i + 1;
       size_t j = repr.find('}', start);
-      if (j == std::string::npos) {
+      if (j == string::npos) {
         LOG(ERROR) << "parse error: unparalleled brace in '" << repr << "'";
         return false;
       }

--- a/src/lever/custom_settings.cc
+++ b/src/lever/custom_settings.cc
@@ -52,20 +52,20 @@ bool CustomSettings::Save() {
   return true;
 }
 
-a<ConfigValue> CustomSettings::GetValue(const string& key) {
+an<ConfigValue> CustomSettings::GetValue(const string& key) {
   return config_.GetValue(key);
 }
 
-a<ConfigList> CustomSettings::GetList(const string& key) {
+an<ConfigList> CustomSettings::GetList(const string& key) {
   return config_.GetList(key);
 }
 
-a<ConfigMap> CustomSettings::GetMap(const string& key) {
+an<ConfigMap> CustomSettings::GetMap(const string& key) {
   return config_.GetMap(key);
 }
 
 bool CustomSettings::Customize(const string& key,
-                               const a<ConfigItem>& item) {
+                               const an<ConfigItem>& item) {
   auto patch = custom_config_.GetMap("patch");
   if (!patch) {
     patch = New<ConfigMap>();

--- a/src/lever/custom_settings.cc
+++ b/src/lever/custom_settings.cc
@@ -52,20 +52,20 @@ bool CustomSettings::Save() {
   return true;
 }
 
-ConfigValuePtr CustomSettings::GetValue(const string& key) {
+a<ConfigValue> CustomSettings::GetValue(const string& key) {
   return config_.GetValue(key);
 }
 
-ConfigListPtr CustomSettings::GetList(const string& key) {
+a<ConfigList> CustomSettings::GetList(const string& key) {
   return config_.GetList(key);
 }
 
-ConfigMapPtr CustomSettings::GetMap(const string& key) {
+a<ConfigMap> CustomSettings::GetMap(const string& key) {
   return config_.GetMap(key);
 }
 
 bool CustomSettings::Customize(const string& key,
-                               const ConfigItemPtr& item) {
+                               const a<ConfigItem>& item) {
   auto patch = custom_config_.GetMap("patch");
   if (!patch) {
     patch = New<ConfigMap>();

--- a/src/lever/custom_settings.cc
+++ b/src/lever/custom_settings.cc
@@ -16,8 +16,8 @@ namespace fs = boost::filesystem;
 namespace rime {
 
 CustomSettings::CustomSettings(Deployer* deployer,
-                               const std::string& config_id,
-                               const std::string& generator_id)
+                               const string& config_id,
+                               const string& generator_id)
     : deployer_(deployer),
       config_id_(config_id),
       generator_id_(generator_id) {
@@ -52,19 +52,19 @@ bool CustomSettings::Save() {
   return true;
 }
 
-ConfigValuePtr CustomSettings::GetValue(const std::string& key) {
+ConfigValuePtr CustomSettings::GetValue(const string& key) {
   return config_.GetValue(key);
 }
 
-ConfigListPtr CustomSettings::GetList(const std::string& key) {
+ConfigListPtr CustomSettings::GetList(const string& key) {
   return config_.GetList(key);
 }
 
-ConfigMapPtr CustomSettings::GetMap(const std::string& key) {
+ConfigMapPtr CustomSettings::GetMap(const string& key) {
   return config_.GetMap(key);
 }
 
-bool CustomSettings::Customize(const std::string& key,
+bool CustomSettings::Customize(const string& key,
                                const ConfigItemPtr& item) {
   auto patch = custom_config_.GetMap("patch");
   if (!patch) {

--- a/src/lever/customizer.cc
+++ b/src/lever/customizer.cc
@@ -32,9 +32,9 @@ bool Customizer::UpdateConfigFile() {
   bool need_update = false;
   bool redistribute = false;
   bool missing_original_copy = false;
-  std::string source_version;
-  std::string dest_version;
-  std::string applied_customization;
+  string source_version;
+  string dest_version;
+  string applied_customization;
 
   Config dest_config;
   if (dest_config.LoadFromFile(dest_path_.string())) {
@@ -74,9 +74,9 @@ bool Customizer::UpdateConfigFile() {
     }
     custom_path = custom_path.string() + ".custom.yaml";
   }
-  std::string customization;
+  string customization;
   if (!custom_path.empty() && fs::exists(custom_path)) {
-    customization = boost::lexical_cast<std::string>(
+    customization = boost::lexical_cast<string>(
         Checksum(custom_path.string()));
   }
   if (applied_customization != customization) {
@@ -131,7 +131,7 @@ bool Customizer::UpdateConfigFile() {
     // update config version
     dest_config.GetString(version_key_, &dest_version);
     size_t custom_part = dest_version.find(".custom.");
-    if (custom_part != std::string::npos) {
+    if (custom_part != string::npos) {
       dest_version.erase(custom_part);
     }
     dest_version.append(".custom.").append(customization);

--- a/src/lever/deployment_tasks.cc
+++ b/src/lever/deployment_tasks.cc
@@ -307,7 +307,7 @@ bool SchemaUpdate::Run(Deployer* deployer) {
 
 ConfigFileUpdate::ConfigFileUpdate(TaskInitializer arg) {
   try {
-    auto p = boost::any_cast< std::pair<string, string>>(arg);
+    auto p = boost::any_cast<pair<string, string>>(arg);
     file_name_ = p.first;
     version_key_ = p.second;
   }

--- a/src/lever/deployment_tasks.cc
+++ b/src/lever/deployment_tasks.cc
@@ -41,7 +41,7 @@ bool InstallationUpdate::Run(Deployer* deployer) {
     }
   }
   fs::path installation_info(user_data_path / "installation.yaml");
-  rime::Config config;
+  Config config;
   string installation_id;
   string last_distro_code_name;
   string last_distro_version;
@@ -413,7 +413,7 @@ bool UserDictUpgrade::Run(Deployer* deployer) {
 }
 
 bool UserDictSync::Run(Deployer* deployer) {
-  rime::UserDictManager mgr(deployer);
+  UserDictManager mgr(deployer);
   return mgr.SynchronizeAll();
 }
 

--- a/src/lever/levers_module.cc
+++ b/src/lever/levers_module.cc
@@ -151,7 +151,7 @@ rime_levers_get_selected_schema_list(RimeSwitcherSettings* settings,
     return False;
   }
   list->list = new RimeSchemaListItem[ss->selection().size()];
-  for (const std::string& schema_id : ss->selection()) {
+  for (const rime::string& schema_id : ss->selection()) {
     auto& item(list->list[list->size]);
     item.schema_id = const_cast<char*>(schema_id.c_str());
     ++list->size;

--- a/src/lever/levers_module.cc
+++ b/src/lever/levers_module.cc
@@ -63,35 +63,35 @@ static Bool rime_levers_save_settings(RimeCustomSettings* settings) {
 
 static Bool rime_levers_customize_bool(RimeCustomSettings* settings,
                                        const char* key, bool value) {
-  a<ConfigItem> item = New<ConfigValue>(value);
+  an<ConfigItem> item = New<ConfigValue>(value);
   auto custom_settings = reinterpret_cast<CustomSettings*>(settings);
   return custom_settings->Customize(key, item);
 }
 
 static Bool rime_levers_customize_int(RimeCustomSettings* settings,
                                       const char* key, int value) {
-  a<ConfigItem> item = New<ConfigValue>(value);
+  an<ConfigItem> item = New<ConfigValue>(value);
   auto custom_settings = reinterpret_cast<CustomSettings*>(settings);
   return custom_settings->Customize(key, item);
 }
 
 static Bool rime_levers_customize_double(RimeCustomSettings* settings,
                                          const char* key, double value) {
-  a<ConfigItem> item = New<ConfigValue>(value);
+  an<ConfigItem> item = New<ConfigValue>(value);
   auto custom_settings = reinterpret_cast<CustomSettings*>(settings);
   return custom_settings->Customize(key, item);
 }
 
 static Bool rime_levers_customize_string(RimeCustomSettings* settings,
                                          const char* key, const char* value) {
-  a<ConfigItem> item = New<ConfigValue>(value);
+  an<ConfigItem> item = New<ConfigValue>(value);
   auto custom_settings = reinterpret_cast<CustomSettings*>(settings);
   return custom_settings->Customize(key, item);
 }
 
 static Bool rime_levers_customize_item(RimeCustomSettings* settings,
                                        const char* key, RimeConfig* value) {
-  a<ConfigItem> item;
+  an<ConfigItem> item;
   if (value) {
     if (Config* v = reinterpret_cast<Config*>(value->ptr)) {
       item = v->GetItem("");

--- a/src/lever/levers_module.cc
+++ b/src/lever/levers_module.cc
@@ -16,8 +16,9 @@
 #include <rime/lever/switcher_settings.h>
 #include <rime/lever/user_dict_manager.h>
 
+using namespace rime;
+
 static void rime_levers_initialize() {
-  using namespace rime;
 
   LOG(INFO) << "registering components from module 'levers'.";
   Registry& r = Registry::instance();
@@ -44,87 +45,87 @@ static RimeCustomSettings*
 rime_levers_custom_settings_init(const char* config_id,
                                  const char* generator_id) {
   return reinterpret_cast<RimeCustomSettings*>(
-      new rime::CustomSettings(&rime::Service::instance().deployer(),
-                               config_id, generator_id));
+      new CustomSettings(&Service::instance().deployer(),
+                         config_id, generator_id));
 }
 
 static void rime_levers_custom_settings_destroy(RimeCustomSettings* settings) {
-  delete reinterpret_cast<rime::CustomSettings*>(settings);
+  delete reinterpret_cast<CustomSettings*>(settings);
 }
 
 static Bool rime_levers_load_settings(RimeCustomSettings* settings) {
-  return Bool(reinterpret_cast<rime::CustomSettings*>(settings)->Load());
+  return Bool(reinterpret_cast<CustomSettings*>(settings)->Load());
 }
 
 static Bool rime_levers_save_settings(RimeCustomSettings* settings) {
-  return Bool(reinterpret_cast<rime::CustomSettings*>(settings)->Save());
+  return Bool(reinterpret_cast<CustomSettings*>(settings)->Save());
 }
 
 static Bool rime_levers_customize_bool(RimeCustomSettings* settings,
                                        const char* key, bool value) {
-  rime::ConfigItemPtr item = rime::New<rime::ConfigValue>(value);
-  auto custom_settings = reinterpret_cast<rime::CustomSettings*>(settings);
+  a<ConfigItem> item = New<ConfigValue>(value);
+  auto custom_settings = reinterpret_cast<CustomSettings*>(settings);
   return custom_settings->Customize(key, item);
 }
 
 static Bool rime_levers_customize_int(RimeCustomSettings* settings,
                                       const char* key, int value) {
-  rime::ConfigItemPtr item = rime::New<rime::ConfigValue>(value);
-  auto custom_settings = reinterpret_cast<rime::CustomSettings*>(settings);
+  a<ConfigItem> item = New<ConfigValue>(value);
+  auto custom_settings = reinterpret_cast<CustomSettings*>(settings);
   return custom_settings->Customize(key, item);
 }
 
 static Bool rime_levers_customize_double(RimeCustomSettings* settings,
                                          const char* key, double value) {
-  rime::ConfigItemPtr item = rime::New<rime::ConfigValue>(value);
-  auto custom_settings = reinterpret_cast<rime::CustomSettings*>(settings);
+  a<ConfigItem> item = New<ConfigValue>(value);
+  auto custom_settings = reinterpret_cast<CustomSettings*>(settings);
   return custom_settings->Customize(key, item);
 }
 
 static Bool rime_levers_customize_string(RimeCustomSettings* settings,
                                          const char* key, const char* value) {
-  rime::ConfigItemPtr item = rime::New<rime::ConfigValue>(value);
-  auto custom_settings = reinterpret_cast<rime::CustomSettings*>(settings);
+  a<ConfigItem> item = New<ConfigValue>(value);
+  auto custom_settings = reinterpret_cast<CustomSettings*>(settings);
   return custom_settings->Customize(key, item);
 }
 
 static Bool rime_levers_customize_item(RimeCustomSettings* settings,
                                        const char* key, RimeConfig* value) {
-  rime::ConfigItemPtr item;
+  a<ConfigItem> item;
   if (value) {
-    if (rime::Config* v = reinterpret_cast<rime::Config*>(value->ptr)) {
+    if (Config* v = reinterpret_cast<Config*>(value->ptr)) {
       item = v->GetItem("");
     }
   }
-  auto custom_settings = reinterpret_cast<rime::CustomSettings*>(settings);
+  auto custom_settings = reinterpret_cast<CustomSettings*>(settings);
   return custom_settings->Customize(key, item);
 }
 
 static Bool rime_levers_is_first_run(RimeCustomSettings* settings) {
-  return reinterpret_cast<rime::CustomSettings*>(settings)->IsFirstRun();
+  return reinterpret_cast<CustomSettings*>(settings)->IsFirstRun();
 }
 
 static Bool rime_levers_settings_is_modified(RimeCustomSettings* settings) {
-  return reinterpret_cast<rime::CustomSettings*>(settings)->modified();
+  return reinterpret_cast<CustomSettings*>(settings)->modified();
 }
 
 static Bool rime_levers_settings_get_config(RimeCustomSettings* settings,
                                             RimeConfig* config) {
   if (!config)
     return False;
-  config->ptr = reinterpret_cast<rime::CustomSettings*>(settings)->config();
+  config->ptr = reinterpret_cast<CustomSettings*>(settings)->config();
   return Bool(!!config->ptr);
 }
 
 static RimeSwitcherSettings* rime_levers_switcher_settings_init() {
   return reinterpret_cast<RimeSwitcherSettings*>(
-      new rime::SwitcherSettings(&rime::Service::instance().deployer()));
+      new SwitcherSettings(&Service::instance().deployer()));
 }
 
 static Bool
 rime_levers_get_available_schema_list(RimeSwitcherSettings* settings,
                                       RimeSchemaList* list) {
-  auto ss = reinterpret_cast<rime::SwitcherSettings*>(settings);
+  auto ss = reinterpret_cast<SwitcherSettings*>(settings);
   list->size = 0;
   list->list = NULL;
   if (ss->available().empty()) {
@@ -135,7 +136,7 @@ rime_levers_get_available_schema_list(RimeSwitcherSettings* settings,
     auto& item(list->list[list->size]);
     item.schema_id = const_cast<char*>(info.schema_id.c_str());
     item.name = const_cast<char*>(info.name.c_str());
-    item.reserved = const_cast<rime::SchemaInfo*>(&info);
+    item.reserved = const_cast<SchemaInfo*>(&info);
     ++list->size;
   }
   return True;
@@ -144,14 +145,14 @@ rime_levers_get_available_schema_list(RimeSwitcherSettings* settings,
 static Bool
 rime_levers_get_selected_schema_list(RimeSwitcherSettings* settings,
                                      RimeSchemaList* list) {
-  auto ss = reinterpret_cast<rime::SwitcherSettings*>(settings);
+  auto ss = reinterpret_cast<SwitcherSettings*>(settings);
   list->size = 0;
   list->list = NULL;
   if (ss->selection().empty()) {
     return False;
   }
   list->list = new RimeSchemaListItem[ss->selection().size()];
-  for (const rime::string& schema_id : ss->selection()) {
+  for (const string& schema_id : ss->selection()) {
     auto& item(list->list[list->size]);
     item.schema_id = const_cast<char*>(schema_id.c_str());
     ++list->size;
@@ -166,39 +167,39 @@ static void rime_levers_schema_list_destroy(RimeSchemaList* list) {
 }
 
 static const char* rime_levers_get_schema_id(RimeSchemaInfo* info) {
-  auto si = reinterpret_cast<rime::SchemaInfo*>(info);
+  auto si = reinterpret_cast<SchemaInfo*>(info);
   return si && !si->schema_id.empty() ? si->schema_id.c_str() : NULL;
 }
 
 static const char* rime_levers_get_schema_name(RimeSchemaInfo* info) {
-  auto si = reinterpret_cast<rime::SchemaInfo*>(info);
+  auto si = reinterpret_cast<SchemaInfo*>(info);
   return si && !si->name.empty() ? si->name.c_str() : NULL;
 }
 
 static const char* rime_levers_get_schema_version(RimeSchemaInfo* info) {
-  auto si = reinterpret_cast<rime::SchemaInfo*>(info);
+  auto si = reinterpret_cast<SchemaInfo*>(info);
   return si && !si->version.empty() ? si->version.c_str() : NULL;
 }
 static const char* rime_levers_get_schema_author(RimeSchemaInfo* info) {
-  auto si = reinterpret_cast<rime::SchemaInfo*>(info);
+  auto si = reinterpret_cast<SchemaInfo*>(info);
   return si && !si->author.empty() ? si->author.c_str() : NULL;
 }
 
 static const char* rime_levers_get_schema_description(RimeSchemaInfo* info) {
-  auto si = reinterpret_cast<rime::SchemaInfo*>(info);
+  auto si = reinterpret_cast<SchemaInfo*>(info);
   return si && !si->description.empty() ? si->description.c_str() : NULL;
 }
 
 static const char* rime_levers_get_schema_file_path(RimeSchemaInfo* info) {
-  auto si = reinterpret_cast<rime::SchemaInfo*>(info);
+  auto si = reinterpret_cast<SchemaInfo*>(info);
   return si && !si->file_path.empty() ? si->file_path.c_str() : NULL;
 }
 
 static Bool rime_levers_select_schemas(RimeSwitcherSettings* settings,
                                        const char* schema_id_list[],
                                        int count) {
-  auto ss = reinterpret_cast<rime::SwitcherSettings*>(settings);
-  rime::SwitcherSettings::Selection selection;
+  auto ss = reinterpret_cast<SwitcherSettings*>(settings);
+  SwitcherSettings::Selection selection;
   for (int i = 0; i < count; ++i) {
     selection.push_back(schema_id_list[i]);
   }
@@ -206,19 +207,19 @@ static Bool rime_levers_select_schemas(RimeSwitcherSettings* settings,
 }
 
 static const char* rime_levers_get_hotkeys(RimeSwitcherSettings* settings) {
-  auto ss = reinterpret_cast<rime::SwitcherSettings*>(settings);
+  auto ss = reinterpret_cast<SwitcherSettings*>(settings);
   return !ss->hotkeys().empty() ? ss->hotkeys().c_str() : NULL;
 }
 
 static Bool rime_levers_set_hotkeys(RimeSwitcherSettings* settings,
                                     const char* hotkeys) {
-  auto ss = reinterpret_cast<rime::SwitcherSettings*>(settings);
+  auto ss = reinterpret_cast<SwitcherSettings*>(settings);
   return Bool(ss->SetHotkeys(hotkeys));
 }
 
 static Bool rime_levers_user_dict_iterator_init(RimeUserDictIterator* iter) {
-  rime::UserDictManager mgr(&rime::Service::instance().deployer());
-  rime::UserDictList* list = new rime::UserDictList;
+  UserDictManager mgr(&Service::instance().deployer());
+  UserDictList* list = new UserDictList;
   mgr.GetUserDictList(list);
   if (list->empty()) {
     delete list;
@@ -230,13 +231,13 @@ static Bool rime_levers_user_dict_iterator_init(RimeUserDictIterator* iter) {
 }
 
 static void rime_levers_user_dict_iterator_destroy(RimeUserDictIterator* iter) {
-  delete (rime::UserDictList*)iter->ptr;
+  delete (UserDictList*)iter->ptr;
   iter->ptr = NULL;
   iter->i = 0;
 }
 
 static const char* rime_levers_next_user_dict(RimeUserDictIterator* iter) {
-  auto list = reinterpret_cast<rime::UserDictList*>(iter->ptr);
+  auto list = reinterpret_cast<UserDictList*>(iter->ptr);
   if (!list || iter->i >= list->size()) {
     return NULL;
   }
@@ -244,24 +245,24 @@ static const char* rime_levers_next_user_dict(RimeUserDictIterator* iter) {
 }
 
 static Bool rime_levers_backup_user_dict(const char* dict_name) {
-  rime::UserDictManager mgr(&rime::Service::instance().deployer());
+  UserDictManager mgr(&Service::instance().deployer());
   return Bool(mgr.Backup(dict_name));
 }
 
 static Bool rime_levers_restore_user_dict(const char* snapshot_file) {
-  rime::UserDictManager mgr(&rime::Service::instance().deployer());
+  UserDictManager mgr(&Service::instance().deployer());
   return Bool(mgr.Restore(snapshot_file));
 }
 
 static int rime_levers_export_user_dict(const char* dict_name,
                                         const char* text_file) {
-  rime::UserDictManager mgr(&rime::Service::instance().deployer());
+  UserDictManager mgr(&Service::instance().deployer());
   return mgr.Export(dict_name, text_file);
 }
 
 static int rime_levers_import_user_dict(const char* dict_name,
                                         const char* text_file) {
-  rime::UserDictManager mgr(&rime::Service::instance().deployer());
+  UserDictManager mgr(&Service::instance().deployer());
   return mgr.Import(dict_name, text_file);
 }
 

--- a/src/lever/switcher_settings.cc
+++ b/src/lever/switcher_settings.cc
@@ -37,7 +37,7 @@ bool SwitcherSettings::Load() {
 bool SwitcherSettings::Select(Selection selection) {
   selection_ = std::move(selection);
   auto schema_list = New<ConfigList>();
-  for (const std::string& schema_id : selection_) {
+  for (const string& schema_id : selection_) {
     auto item = New<ConfigMap>();
     item->Set("schema", New<ConfigValue>(schema_id));
     schema_list->Append(item);
@@ -45,7 +45,7 @@ bool SwitcherSettings::Select(Selection selection) {
   return Customize("schema_list", schema_list);
 }
 
-bool SwitcherSettings::SetHotkeys(const std::string& hotkeys) {
+bool SwitcherSettings::SetHotkeys(const string& hotkeys) {
   // TODO: not implemented; validation required
   return false;
 }
@@ -57,7 +57,7 @@ void SwitcherSettings::GetAvailableSchemasFromDirectory(const fs::path& dir) {
   }
   for (fs::directory_iterator it(dir), end;
        it != end; ++it) {
-    std::string file_path(it->path().string());
+    string file_path(it->path().string());
     if (boost::ends_with(file_path, ".schema.yaml")) {
       Config config;
       if (config.LoadFromFile(file_path)) {
@@ -110,7 +110,7 @@ void SwitcherSettings::GetSelectedSchemasFromConfig() {
     auto schema_property = item->GetValue("schema");
     if (!schema_property)
       continue;
-    const std::string& schema_id(schema_property->str());
+    const string& schema_id(schema_property->str());
     selection_.push_back(schema_id);
   }
 }
@@ -125,7 +125,7 @@ void SwitcherSettings::GetHotkeysFromConfig() {
     auto item = As<ConfigValue>(*it);
     if (!item)
       continue;
-    const std::string& hotkey(item->str());
+    const string& hotkey(item->str());
     if (hotkey.empty())
       continue;
     if (!hotkeys_.empty())

--- a/src/menu.cc
+++ b/src/menu.cc
@@ -17,7 +17,7 @@ Menu::Menu()
       result_(merged_) {
 }
 
-void Menu::AddTranslation(a<Translation> translation) {
+void Menu::AddTranslation(an<Translation> translation) {
   *merged_ += translation;
   DLOG(INFO) << merged_->size() << " translations added.";
 }
@@ -59,7 +59,7 @@ Page* Menu::CreatePage(size_t page_size, size_t page_no) {
   return page;
 }
 
-a<Candidate> Menu::GetCandidateAt(size_t index) {
+an<Candidate> Menu::GetCandidateAt(size_t index) {
   if (index >= candidates_.size() &&
       index >= Prepare(index + 1)) {
     return nullptr;

--- a/src/menu.cc
+++ b/src/menu.cc
@@ -17,7 +17,7 @@ Menu::Menu()
       result_(merged_) {
 }
 
-void Menu::AddTranslation(shared_ptr<Translation> translation) {
+void Menu::AddTranslation(a<Translation> translation) {
   *merged_ += translation;
   DLOG(INFO) << merged_->size() << " translations added.";
 }
@@ -59,10 +59,10 @@ Page* Menu::CreatePage(size_t page_size, size_t page_no) {
   return page;
 }
 
-shared_ptr<Candidate> Menu::GetCandidateAt(size_t index) {
+a<Candidate> Menu::GetCandidateAt(size_t index) {
   if (index >= candidates_.size() &&
       index >= Prepare(index + 1)) {
-    return shared_ptr<Candidate>();
+    return a<Candidate>();
   }
   return candidates_[index];
 }

--- a/src/menu.cc
+++ b/src/menu.cc
@@ -62,7 +62,7 @@ Page* Menu::CreatePage(size_t page_size, size_t page_no) {
 a<Candidate> Menu::GetCandidateAt(size_t index) {
   if (index >= candidates_.size() &&
       index >= Prepare(index + 1)) {
-    return a<Candidate>();
+    return nullptr;
   }
   return candidates_[index];
 }

--- a/src/module.cc
+++ b/src/module.cc
@@ -10,12 +10,12 @@
 
 namespace rime {
 
-void ModuleManager::Register(const std::string& name,
+void ModuleManager::Register(const string& name,
                               RimeModule* module) {
   map_[name] = module;
 }
 
-RimeModule* ModuleManager::Find(const std::string& name) {
+RimeModule* ModuleManager::Find(const string& name) {
   ModuleMap::const_iterator it = map_.find(name);
   if (it != map_.end()) {
     return it->second;
@@ -48,7 +48,7 @@ void ModuleManager::UnloadModules() {
 }
 
 ModuleManager& ModuleManager::instance() {
-  static unique_ptr<ModuleManager> s_instance;
+  static the<ModuleManager> s_instance;
   if (!s_instance) {
     s_instance.reset(new ModuleManager);
   }

--- a/src/registry.cc
+++ b/src/registry.cc
@@ -10,7 +10,7 @@
 
 namespace rime {
 
-void Registry::Register(const std::string &name, ComponentBase *component) {
+void Registry::Register(const string &name, ComponentBase *component) {
   LOG(INFO) << "registering component: " << name;
   if (ComponentBase* existing = Find(name)) {
     LOG(WARNING) << "replacing previously registered component: " << name;
@@ -19,7 +19,7 @@ void Registry::Register(const std::string &name, ComponentBase *component) {
   map_[name] = component;
 }
 
-void Registry::Unregister(const std::string &name) {
+void Registry::Unregister(const string &name) {
   LOG(INFO) << "unregistering component: " << name;
   ComponentMap::iterator it = map_.find(name);
   if (it == map_.end())
@@ -36,7 +36,7 @@ void Registry::Clear() {
   }
 }
 
-ComponentBase* Registry::Find(const std::string &name) {
+ComponentBase* Registry::Find(const string &name) {
   ComponentMap::const_iterator it = map_.find(name);
   if (it != map_.end()) {
     return it->second;
@@ -45,7 +45,7 @@ ComponentBase* Registry::Find(const std::string &name) {
 }
 
 Registry& Registry::instance() {
-  static unique_ptr<Registry> s_instance;
+  static the<Registry> s_instance;
   if (!s_instance) {
     s_instance.reset(new Registry);
   }

--- a/src/rime_api.cc
+++ b/src/rime_api.cc
@@ -103,7 +103,8 @@ RIME_API Bool RimeStartMaintenance(Bool full_check) {
     return False;
   }
   if (!full_check) {
-    TaskInitializer args(std::make_pair("default.yaml", "config_version"));
+    TaskInitializer args{
+        make_pair<string, string>("default.yaml", "config_version")};
     if (!deployer.RunTask("config_file_update", args)) {
       return False;
     }
@@ -158,7 +159,7 @@ RIME_API Bool RimeDeploySchema(const char *schema_file) {
 RIME_API Bool RimeDeployConfigFile(const char *file_name,
                                    const char *version_key) {
   Deployer& deployer(Service::instance().deployer());
-  TaskInitializer args(std::make_pair(file_name, version_key));
+  TaskInitializer args(make_pair<string, string>(file_name, version_key));
   return Bool(deployer.RunTask("config_file_update", args));
 }
 

--- a/src/rime_api.cc
+++ b/src/rime_api.cc
@@ -197,21 +197,21 @@ RIME_API void RimeCleanupAllSessions() {
 // input
 
 RIME_API Bool RimeProcessKey(RimeSessionId session_id, int keycode, int mask) {
-  a<Session> session(Service::instance().GetSession(session_id));
+  an<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return False;
   return Bool(session->ProcessKey(KeyEvent(keycode, mask)));
 }
 
 RIME_API Bool RimeCommitComposition(RimeSessionId session_id) {
-  a<Session> session(Service::instance().GetSession(session_id));
+  an<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return False;
   return Bool(session->CommitComposition());
 }
 
 RIME_API void RimeClearComposition(RimeSessionId session_id) {
-  a<Session> session(Service::instance().GetSession(session_id));
+  an<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return;
   session->ClearComposition();
@@ -223,7 +223,7 @@ RIME_API Bool RimeGetContext(RimeSessionId session_id, RimeContext* context) {
   if (!context || context->data_size <= 0)
     return False;
   RIME_STRUCT_CLEAR(*context);
-  a<Session> session(Service::instance().GetSession(session_id));
+  an<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return False;
   Context *ctx = session->context();
@@ -262,7 +262,7 @@ RIME_API Bool RimeGetContext(RimeSessionId session_id, RimeContext* context) {
       int i = 0;
       context->menu.num_candidates = page->candidates.size();
       context->menu.candidates = new RimeCandidate[page->candidates.size()];
-      for (const a<Candidate> &cand : page->candidates) {
+      for (const an<Candidate> &cand : page->candidates) {
         RimeCandidate* dest = &context->menu.candidates[i++];
         dest->text = new char[cand->text().length() + 1];
         std::strcpy(dest->text, cand->text().c_str());
@@ -308,7 +308,7 @@ RIME_API Bool RimeGetCommit(RimeSessionId session_id, RimeCommit* commit) {
   if (!commit)
     return False;
   RIME_STRUCT_CLEAR(*commit);
-  a<Session> session(Service::instance().GetSession(session_id));
+  an<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return False;
   const string& commit_text(session->commit_text());
@@ -333,7 +333,7 @@ RIME_API Bool RimeGetStatus(RimeSessionId session_id, RimeStatus* status) {
   if (!status || status->data_size <= 0)
     return False;
   RIME_STRUCT_CLEAR(*status);
-  a<Session> session(Service::instance().GetSession(session_id));
+  an<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return False;
   Schema *schema = session->schema();
@@ -366,7 +366,7 @@ RIME_API Bool RimeFreeStatus(RimeStatus* status) {
 // runtime options
 
 RIME_API void RimeSetOption(RimeSessionId session_id, const char* option, Bool value) {
-  a<Session> session(Service::instance().GetSession(session_id));
+  an<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return;
   Context *ctx = session->context();
@@ -376,7 +376,7 @@ RIME_API void RimeSetOption(RimeSessionId session_id, const char* option, Bool v
 }
 
 RIME_API Bool RimeGetOption(RimeSessionId session_id, const char* option) {
-  a<Session> session(Service::instance().GetSession(session_id));
+  an<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return False;
   Context *ctx = session->context();
@@ -386,7 +386,7 @@ RIME_API Bool RimeGetOption(RimeSessionId session_id, const char* option) {
 }
 
 RIME_API void RimeSetProperty(RimeSessionId session_id, const char* prop, const char* value) {
-  a<Session> session(Service::instance().GetSession(session_id));
+  an<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return;
   Context *ctx = session->context();
@@ -397,7 +397,7 @@ RIME_API void RimeSetProperty(RimeSessionId session_id, const char* prop, const 
 
 RIME_API Bool RimeGetProperty(RimeSessionId session_id, const char* prop,
                               char* value, size_t buffer_size) {
-  a<Session> session(Service::instance().GetSession(session_id));
+  an<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return False;
   Context *ctx = session->context();
@@ -417,14 +417,14 @@ RIME_API Bool RimeGetSchemaList(RimeSchemaList* output) {
   Schema default_schema;
   Config* config = default_schema.config();
   if (!config) return False;
-  a<ConfigList> schema_list = config->GetList("schema_list");
+  an<ConfigList> schema_list = config->GetList("schema_list");
   if (!schema_list || schema_list->size() == 0)
     return False;
   output->list = new RimeSchemaListItem[schema_list->size()];
   for (size_t i = 0; i < schema_list->size(); ++i) {
-    a<ConfigMap> item = As<ConfigMap>(schema_list->GetAt(i));
+    an<ConfigMap> item = As<ConfigMap>(schema_list->GetAt(i));
     if (!item) continue;
-    a<ConfigValue> schema_property = item->GetValue("schema");
+    an<ConfigValue> schema_property = item->GetValue("schema");
     if (!schema_property) continue;
     const string &schema_id(schema_property->str());
     RimeSchemaListItem& x(output->list[output->size]);
@@ -458,7 +458,7 @@ RIME_API void RimeFreeSchemaList(RimeSchemaList* schema_list) {
 }
 
 RIME_API Bool RimeGetCurrentSchema(RimeSessionId session_id, char* schema_id, size_t buffer_size) {
-  a<Session> session(Service::instance().GetSession(session_id));
+  an<Session> session(Service::instance().GetSession(session_id));
   if (!session) return False;
   Schema* schema = session->schema();
   if (!schema) return False;
@@ -468,7 +468,7 @@ RIME_API Bool RimeGetCurrentSchema(RimeSessionId session_id, char* schema_id, si
 
 RIME_API Bool RimeSelectSchema(RimeSessionId session_id, const char* schema_id) {
   if (!schema_id) return False;
-  a<Session> session(Service::instance().GetSession(session_id));
+  an<Session> session(Service::instance().GetSession(session_id));
   if (!session) return False;
   session->ApplySchema(new Schema(schema_id));
   return True;
@@ -544,7 +544,7 @@ RIME_API const char* RimeConfigGetCString(RimeConfig *config, const char *key) {
   if (!config || !key) return NULL;
   Config *c = reinterpret_cast<Config*>(config->ptr);
   if (!c) return NULL;
-  if (a<ConfigValue> v = c->GetValue(key)) {
+  if (an<ConfigValue> v = c->GetValue(key)) {
     return v->str().c_str();
   }
   return NULL;
@@ -589,7 +589,7 @@ RIME_API Bool RimeConfigBeginList(RimeConfigIterator* iterator,
   Config *c = reinterpret_cast<Config*>(config->ptr);
   if (!c)
     return False;
-  a<ConfigList> list = c->GetList(key);
+  an<ConfigList> list = c->GetList(key);
   if (!list)
     return False;
   iterator->list = new RimeConfigIteratorImpl<ConfigList>(*list, key);
@@ -607,7 +607,7 @@ RIME_API Bool RimeConfigBeginMap(RimeConfigIterator* iterator,
   iterator->path = NULL;
   Config *c = reinterpret_cast<Config*>(config->ptr);
   if (!c) return False;
-  a<ConfigMap> m = c->GetMap(key);
+  an<ConfigMap> m = c->GetMap(key);
   if (!m) return False;
   iterator->map = new RimeConfigIteratorImpl<ConfigMap>(*m, key);
   return True;
@@ -659,7 +659,7 @@ RIME_API void RimeConfigEnd(RimeConfigIterator* iterator) {
 
 RIME_API Bool RimeSimulateKeySequence(RimeSessionId session_id, const char *key_sequence) {
   LOG(INFO) << "simulate key sequence: " << key_sequence;
-  a<Session> session(Service::instance().GetSession(session_id));
+  an<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return False;
   KeySequence keys;
@@ -755,7 +755,7 @@ RIME_API Bool RimeConfigSetItem(RimeConfig* config, const char* key, RimeConfig*
   Config* c = reinterpret_cast<Config*>(config->ptr);
   if (!c)
     return False;
-  a<ConfigItem> item;
+  an<ConfigItem> item;
   if (value) {
     if (Config* v = reinterpret_cast<Config*>(value->ptr)) {
       item = v->GetItem("");
@@ -833,14 +833,14 @@ RIME_API size_t RimeConfigListSize(RimeConfig* config, const char* key) {
   Config* c = reinterpret_cast<Config*>(config->ptr);
   if (!c)
     return 0;
-  if (a<ConfigList> list = c->GetList(key)) {
+  if (an<ConfigList> list = c->GetList(key)) {
     return list->size();
   }
   return 0;
 }
 
 const char* RimeGetInput(RimeSessionId session_id) {
-  a<Session> session(Service::instance().GetSession(session_id));
+  an<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return NULL;
   Context *ctx = session->context();
@@ -850,7 +850,7 @@ const char* RimeGetInput(RimeSessionId session_id) {
 }
 
 size_t RimeGetCaretPos(RimeSessionId session_id) {
-  a<Session> session(Service::instance().GetSession(session_id));
+  an<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return 0;
   Context *ctx = session->context();
@@ -860,7 +860,7 @@ size_t RimeGetCaretPos(RimeSessionId session_id) {
 }
 
 Bool RimeSelectCandidate(RimeSessionId session_id, size_t index) {
-  a<Session> session(Service::instance().GetSession(session_id));
+  an<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return False;
   Context *ctx = session->context();
@@ -874,7 +874,7 @@ const char* RimeGetVersion() {
 }
 
 void RimeSetCaretPos(RimeSessionId session_id, size_t caret_pos) {
-  a<Session> session(Service::instance().GetSession(session_id));
+  an<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return;
   Context *ctx = session->context();

--- a/src/rime_api.cc
+++ b/src/rime_api.cc
@@ -21,15 +21,15 @@
 #include <rime/signature.h>
 #include <rime_api.h>
 
+using namespace rime;
 using namespace std::placeholders;
-using rime::string;
 
 // assuming member is a pointer in struct *p
 #define PROVIDED(p, member) ((p) && RIME_STRUCT_HAS_MEMBER(*(p), (p)->member) && (p)->member)
 
 static void setup_deployer(RimeTraits *traits) {
   if (!traits) return;
-  rime::Deployer &deployer(rime::Service::instance().deployer());
+  Deployer &deployer(Service::instance().deployer());
   if (PROVIDED(traits, shared_data_dir))
     deployer.shared_data_dir = traits->shared_data_dir;
   if (PROVIDED(traits, user_data_dir))
@@ -43,7 +43,7 @@ static void setup_deployer(RimeTraits *traits) {
 }
 
 RIME_API void RimeSetupLogging(const char* app_name) {
-  rime::SetupLogging(app_name);
+  SetupLogging(app_name);
 }
 
 #if RIME_BUILD_SHARED_LIBS
@@ -67,46 +67,43 @@ RIME_API void RimeSetup(RimeTraits *traits) {
 
   setup_deployer(traits);
   if (PROVIDED(traits, app_name)) {
-    rime::SetupLogging(traits->app_name);
+    SetupLogging(traits->app_name);
   }
 }
 
 RIME_API void RimeSetNotificationHandler(RimeNotificationHandler handler,
                                          void* context_object) {
   if (handler) {
-    rime::Service::instance().SetNotificationHandler(
+    Service::instance().SetNotificationHandler(
         std::bind(handler, context_object, _1, _2, _3));
   }
   else {
-    rime::Service::instance().ClearNotificationHandler();
+    Service::instance().ClearNotificationHandler();
   }
 }
 
 RIME_API void RimeInitialize(RimeTraits *traits) {
   setup_deployer(traits);
-  rime::LoadModules(
-      PROVIDED(traits, modules) ? traits->modules : rime::kDefaultModules);
-  rime::Service::instance().StartService();
+  LoadModules(PROVIDED(traits, modules) ? traits->modules : kDefaultModules);
+  Service::instance().StartService();
 }
 
 RIME_API void RimeFinalize() {
   RimeJoinMaintenanceThread();
-  rime::Service::instance().StopService();
-  rime::Registry::instance().Clear();
-  rime::ModuleManager::instance().UnloadModules();
+  Service::instance().StopService();
+  Registry::instance().Clear();
+  ModuleManager::instance().UnloadModules();
 }
 
 RIME_API Bool RimeStartMaintenance(Bool full_check) {
-  rime::LoadModules(rime::kDeployerModules);
-  rime::Deployer &deployer(rime::Service::instance().deployer());
+  LoadModules(kDeployerModules);
+  Deployer &deployer(Service::instance().deployer());
   deployer.RunTask("clean_old_log_files");
   if (!deployer.RunTask("installation_update")) {
     return False;
   }
   if (!full_check) {
-    rime::TaskInitializer args(
-        std::make_pair<string, string>(
-            "default.yaml", "config_version"));
+    TaskInitializer args(std::make_pair("default.yaml", "config_version"));
     if (!deployer.RunTask("config_file_update", args)) {
       return False;
     }
@@ -124,12 +121,12 @@ RIME_API Bool RimeStartMaintenanceOnWorkspaceChange() {
 }
 
 RIME_API Bool RimeIsMaintenancing() {
-  rime::Deployer &deployer(rime::Service::instance().deployer());
+  Deployer &deployer(Service::instance().deployer());
   return Bool(deployer.IsMaintenanceMode());
 }
 
 RIME_API void RimeJoinMaintenanceThread() {
-  rime::Deployer &deployer(rime::Service::instance().deployer());
+  Deployer &deployer(Service::instance().deployer());
   deployer.JoinMaintenanceThread();
 }
 
@@ -137,17 +134,16 @@ RIME_API void RimeJoinMaintenanceThread() {
 
 RIME_API void RimeDeployerInitialize(RimeTraits *traits) {
   setup_deployer(traits);
-  rime::LoadModules(
-      PROVIDED(traits, modules) ? traits->modules : rime::kDeployerModules);
+  LoadModules(PROVIDED(traits, modules) ? traits->modules : kDeployerModules);
 }
 
 RIME_API Bool RimePrebuildAllSchemas() {
-  rime::Deployer &deployer(rime::Service::instance().deployer());
+  Deployer &deployer(Service::instance().deployer());
   return Bool(deployer.RunTask("prebuild_all_schemas"));
 }
 
 RIME_API Bool RimeDeployWorkspace() {
-  rime::Deployer &deployer(rime::Service::instance().deployer());
+  Deployer &deployer(Service::instance().deployer());
   return Bool(deployer.RunTask("installation_update") &&
               deployer.RunTask("workspace_update") &&
               deployer.RunTask("user_dict_upgrade") &&
@@ -155,22 +151,20 @@ RIME_API Bool RimeDeployWorkspace() {
 }
 
 RIME_API Bool RimeDeploySchema(const char *schema_file) {
-  rime::Deployer &deployer(rime::Service::instance().deployer());
+  Deployer &deployer(Service::instance().deployer());
   return Bool(deployer.RunTask("schema_update", string(schema_file)));
 }
 
 RIME_API Bool RimeDeployConfigFile(const char *file_name,
                                    const char *version_key) {
-  rime::Deployer& deployer(rime::Service::instance().deployer());
-  rime::TaskInitializer args(
-      std::make_pair<string, string>(
-          file_name, version_key));
+  Deployer& deployer(Service::instance().deployer());
+  TaskInitializer args(std::make_pair(file_name, version_key));
   return Bool(deployer.RunTask("config_file_update", args));
 }
 
 RIME_API Bool RimeSyncUserData() {
   RimeCleanupAllSessions();
-  rime::Deployer& deployer(rime::Service::instance().deployer());
+  Deployer& deployer(Service::instance().deployer());
   deployer.ScheduleTask("installation_update");
   deployer.ScheduleTask("backup_config_files");
   deployer.ScheduleTask("user_dict_sync");
@@ -180,43 +174,43 @@ RIME_API Bool RimeSyncUserData() {
 // session management
 
 RIME_API RimeSessionId RimeCreateSession() {
-  return rime::Service::instance().CreateSession();
+  return Service::instance().CreateSession();
 }
 
 RIME_API Bool RimeFindSession(RimeSessionId session_id) {
-  return Bool(session_id && rime::Service::instance().GetSession(session_id));
+  return Bool(session_id && Service::instance().GetSession(session_id));
 }
 
 RIME_API Bool RimeDestroySession(RimeSessionId session_id) {
-  return Bool(rime::Service::instance().DestroySession(session_id));
+  return Bool(Service::instance().DestroySession(session_id));
 }
 
 RIME_API void RimeCleanupStaleSessions() {
-  rime::Service::instance().CleanupStaleSessions();
+  Service::instance().CleanupStaleSessions();
 }
 
 RIME_API void RimeCleanupAllSessions() {
-  rime::Service::instance().CleanupAllSessions();
+  Service::instance().CleanupAllSessions();
 }
 
 // input
 
 RIME_API Bool RimeProcessKey(RimeSessionId session_id, int keycode, int mask) {
-  rime::a<rime::Session> session(rime::Service::instance().GetSession(session_id));
+  a<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return False;
-  return Bool(session->ProcessKey(rime::KeyEvent(keycode, mask)));
+  return Bool(session->ProcessKey(KeyEvent(keycode, mask)));
 }
 
 RIME_API Bool RimeCommitComposition(RimeSessionId session_id) {
-  rime::a<rime::Session> session(rime::Service::instance().GetSession(session_id));
+  a<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return False;
   return Bool(session->CommitComposition());
 }
 
 RIME_API void RimeClearComposition(RimeSessionId session_id) {
-  rime::a<rime::Session> session(rime::Service::instance().GetSession(session_id));
+  a<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return;
   session->ClearComposition();
@@ -228,14 +222,14 @@ RIME_API Bool RimeGetContext(RimeSessionId session_id, RimeContext* context) {
   if (!context || context->data_size <= 0)
     return False;
   RIME_STRUCT_CLEAR(*context);
-  rime::a<rime::Session> session(rime::Service::instance().GetSession(session_id));
+  a<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return False;
-  rime::Context *ctx = session->context();
+  Context *ctx = session->context();
   if (!ctx)
     return False;
   if (ctx->IsComposing()) {
-    rime::Preedit preedit = ctx->GetPreedit();
+    Preedit preedit = ctx->GetPreedit();
     context->composition.length = preedit.text.length();
     context->composition.preedit = new char[preedit.text.length() + 1];
     std::strcpy(context->composition.preedit, preedit.text.c_str());
@@ -251,14 +245,14 @@ RIME_API Bool RimeGetContext(RimeSessionId session_id, RimeContext* context) {
     }
   }
   if (ctx->HasMenu()) {
-    rime::Segment &seg(ctx->composition().back());
+    Segment &seg(ctx->composition().back());
     int page_size = 5;
-    rime::Schema *schema = session->schema();
+    Schema *schema = session->schema();
     if (schema)
       page_size = schema->page_size();
     int selected_index = seg.selected_index;
     int page_no = selected_index / page_size;
-    rime::the<rime::Page> page(seg.menu->CreatePage(page_size, page_no));
+    the<Page> page(seg.menu->CreatePage(page_size, page_no));
     if (page) {
       context->menu.page_size = page_size;
       context->menu.page_no = page_no;
@@ -267,7 +261,7 @@ RIME_API Bool RimeGetContext(RimeSessionId session_id, RimeContext* context) {
       int i = 0;
       context->menu.num_candidates = page->candidates.size();
       context->menu.candidates = new RimeCandidate[page->candidates.size()];
-      for (const rime::a<rime::Candidate> &cand : page->candidates) {
+      for (const a<Candidate> &cand : page->candidates) {
         RimeCandidate* dest = &context->menu.candidates[i++];
         dest->text = new char[cand->text().length() + 1];
         std::strcpy(dest->text, cand->text().c_str());
@@ -313,7 +307,7 @@ RIME_API Bool RimeGetCommit(RimeSessionId session_id, RimeCommit* commit) {
   if (!commit)
     return False;
   RIME_STRUCT_CLEAR(*commit);
-  rime::a<rime::Session> session(rime::Service::instance().GetSession(session_id));
+  a<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return False;
   const string& commit_text(session->commit_text());
@@ -338,18 +332,18 @@ RIME_API Bool RimeGetStatus(RimeSessionId session_id, RimeStatus* status) {
   if (!status || status->data_size <= 0)
     return False;
   RIME_STRUCT_CLEAR(*status);
-  rime::a<rime::Session> session(rime::Service::instance().GetSession(session_id));
+  a<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return False;
-  rime::Schema *schema = session->schema();
-  rime::Context *ctx = session->context();
+  Schema *schema = session->schema();
+  Context *ctx = session->context();
   if (!schema || !ctx)
     return False;
   status->schema_id = new char[schema->schema_id().length() + 1];
   std::strcpy(status->schema_id, schema->schema_id().c_str());
   status->schema_name = new char[schema->schema_name().length() + 1];
   std::strcpy(status->schema_name, schema->schema_name().c_str());
-  status->is_disabled = rime::Service::instance().disabled();
+  status->is_disabled = Service::instance().disabled();
   status->is_composing = Bool(ctx->IsComposing());
   status->is_ascii_mode = Bool(ctx->get_option("ascii_mode"));
   status->is_full_shape = Bool(ctx->get_option("full_shape"));
@@ -371,30 +365,30 @@ RIME_API Bool RimeFreeStatus(RimeStatus* status) {
 // runtime options
 
 RIME_API void RimeSetOption(RimeSessionId session_id, const char* option, Bool value) {
-  rime::a<rime::Session> session(rime::Service::instance().GetSession(session_id));
+  a<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return;
-  rime::Context *ctx = session->context();
+  Context *ctx = session->context();
   if (!ctx)
     return;
   ctx->set_option(option, !!value);
 }
 
 RIME_API Bool RimeGetOption(RimeSessionId session_id, const char* option) {
-  rime::a<rime::Session> session(rime::Service::instance().GetSession(session_id));
+  a<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return False;
-  rime::Context *ctx = session->context();
+  Context *ctx = session->context();
   if (!ctx)
     return False;
   return Bool(ctx->get_option(option));
 }
 
 RIME_API void RimeSetProperty(RimeSessionId session_id, const char* prop, const char* value) {
-  rime::a<rime::Session> session(rime::Service::instance().GetSession(session_id));
+  a<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return;
-  rime::Context *ctx = session->context();
+  Context *ctx = session->context();
   if (!ctx)
     return;
   ctx->set_property(prop, value);
@@ -402,10 +396,10 @@ RIME_API void RimeSetProperty(RimeSessionId session_id, const char* prop, const 
 
 RIME_API Bool RimeGetProperty(RimeSessionId session_id, const char* prop,
                               char* value, size_t buffer_size) {
-  rime::a<rime::Session> session(rime::Service::instance().GetSession(session_id));
+  a<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return False;
-  rime::Context *ctx = session->context();
+  Context *ctx = session->context();
   if (!ctx)
     return False;
   string str_value(ctx->get_property(prop));
@@ -419,23 +413,23 @@ RIME_API Bool RimeGetSchemaList(RimeSchemaList* output) {
   if (!output) return False;
   output->size = 0;
   output->list = NULL;
-  rime::Schema default_schema;
-  rime::Config* config = default_schema.config();
+  Schema default_schema;
+  Config* config = default_schema.config();
   if (!config) return False;
-  rime::ConfigListPtr schema_list = config->GetList("schema_list");
+  a<ConfigList> schema_list = config->GetList("schema_list");
   if (!schema_list || schema_list->size() == 0)
     return False;
   output->list = new RimeSchemaListItem[schema_list->size()];
   for (size_t i = 0; i < schema_list->size(); ++i) {
-    rime::ConfigMapPtr item = rime::As<rime::ConfigMap>(schema_list->GetAt(i));
+    a<ConfigMap> item = As<ConfigMap>(schema_list->GetAt(i));
     if (!item) continue;
-    rime::ConfigValuePtr schema_property = item->GetValue("schema");
+    a<ConfigValue> schema_property = item->GetValue("schema");
     if (!schema_property) continue;
     const string &schema_id(schema_property->str());
     RimeSchemaListItem& x(output->list[output->size]);
     x.schema_id = new char[schema_id.length() + 1];
     strcpy(x.schema_id, schema_id.c_str());
-    rime::Schema schema(schema_id);
+    Schema schema(schema_id);
     x.name = new char[schema.schema_name().length() + 1];
     strcpy(x.name, schema.schema_name().c_str());
     x.reserved = NULL;
@@ -463,9 +457,9 @@ RIME_API void RimeFreeSchemaList(RimeSchemaList* schema_list) {
 }
 
 RIME_API Bool RimeGetCurrentSchema(RimeSessionId session_id, char* schema_id, size_t buffer_size) {
-  rime::a<rime::Session> session(rime::Service::instance().GetSession(session_id));
+  a<Session> session(Service::instance().GetSession(session_id));
   if (!session) return False;
-  rime::Schema* schema = session->schema();
+  Schema* schema = session->schema();
   if (!schema) return False;
   strncpy(schema_id, schema->schema_id().c_str(), buffer_size);
   return True;
@@ -473,9 +467,9 @@ RIME_API Bool RimeGetCurrentSchema(RimeSessionId session_id, char* schema_id, si
 
 RIME_API Bool RimeSelectSchema(RimeSessionId session_id, const char* schema_id) {
   if (!schema_id) return False;
-  rime::a<rime::Session> session(rime::Service::instance().GetSession(session_id));
+  a<Session> session(Service::instance().GetSession(session_id));
   if (!session) return False;
-  session->ApplySchema(new rime::Schema(schema_id));
+  session->ApplySchema(new Schema(schema_id));
   return True;
 }
 
@@ -483,9 +477,9 @@ RIME_API Bool RimeSelectSchema(RimeSessionId session_id, const char* schema_id) 
 
 RIME_API Bool RimeSchemaOpen(const char *schema_id, RimeConfig* config) {
   if (!schema_id || !config) return False;
-  rime::Config::Component* cc = rime::Config::Require("schema_config");
+  Config::Component* cc = Config::Require("schema_config");
   if (!cc) return False;
-  rime::Config* c = cc->Create(schema_id);
+  Config* c = cc->Create(schema_id);
   if (!c) return False;
   config->ptr = (void*)c;
   return True;
@@ -493,9 +487,9 @@ RIME_API Bool RimeSchemaOpen(const char *schema_id, RimeConfig* config) {
 
 RIME_API Bool RimeConfigOpen(const char *config_id, RimeConfig* config) {
   if (!config_id || !config) return False;
-  rime::Config::Component* cc = rime::Config::Require("config");
+  Config::Component* cc = Config::Require("config");
   if (!cc) return False;
-  rime::Config* c = cc->Create(config_id);
+  Config* c = cc->Create(config_id);
   if (!c) return False;
   config->ptr = (void*)c;
   return True;
@@ -503,7 +497,7 @@ RIME_API Bool RimeConfigOpen(const char *config_id, RimeConfig* config) {
 
 RIME_API Bool RimeConfigClose(RimeConfig *config) {
   if (!config || !config->ptr) return False;
-  rime::Config *c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config *c = reinterpret_cast<Config*>(config->ptr);
   delete c;
   config->ptr = NULL;
   return True;
@@ -511,7 +505,7 @@ RIME_API Bool RimeConfigClose(RimeConfig *config) {
 
 RIME_API Bool RimeConfigGetBool(RimeConfig *config, const char *key, Bool *value) {
   if (!config || !key || !value) return False;
-  rime::Config *c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config *c = reinterpret_cast<Config*>(config->ptr);
   bool bool_value = false;
   if (c->GetBool(key, &bool_value)) {
     *value = Bool(bool_value);
@@ -522,20 +516,20 @@ RIME_API Bool RimeConfigGetBool(RimeConfig *config, const char *key, Bool *value
 
 RIME_API Bool RimeConfigGetInt(RimeConfig *config, const char *key, int *value) {
   if (!config || !key || !value) return False;
-  rime::Config *c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config *c = reinterpret_cast<Config*>(config->ptr);
   return Bool(c->GetInt(key, value));
 }
 
 RIME_API Bool RimeConfigGetDouble(RimeConfig *config, const char *key, double *value) {
   if (!config || !key || !value) return False;
-  rime::Config *c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config *c = reinterpret_cast<Config*>(config->ptr);
   return Bool(c->GetDouble(key, value));
 }
 
 RIME_API Bool RimeConfigGetString(RimeConfig *config, const char *key,
                                   char *value, size_t buffer_size) {
   if (!config || !key || !value) return False;
-  rime::Config *c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config *c = reinterpret_cast<Config*>(config->ptr);
   if (!c) return False;
   string str_value;
   if (c->GetString(key, &str_value)) {
@@ -547,9 +541,9 @@ RIME_API Bool RimeConfigGetString(RimeConfig *config, const char *key,
 
 RIME_API const char* RimeConfigGetCString(RimeConfig *config, const char *key) {
   if (!config || !key) return NULL;
-  rime::Config *c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config *c = reinterpret_cast<Config*>(config->ptr);
   if (!c) return NULL;
-  if (rime::ConfigValuePtr v = c->GetValue(key)) {
+  if (a<ConfigValue> v = c->GetValue(key)) {
     return v->str().c_str();
   }
   return NULL;
@@ -557,9 +551,9 @@ RIME_API const char* RimeConfigGetCString(RimeConfig *config, const char *key) {
 
 RIME_API Bool RimeConfigUpdateSignature(RimeConfig *config, const char* signer) {
   if (!config || !signer) return False;
-  rime::Config *c = reinterpret_cast<rime::Config*>(config->ptr);
-  rime::Deployer &deployer(rime::Service::instance().deployer());
-  rime::Signature sig(signer);
+  Config *c = reinterpret_cast<Config*>(config->ptr);
+  Deployer &deployer(Service::instance().deployer());
+  Signature sig(signer);
   return Bool(sig.Sign(c, &deployer));
 }
 
@@ -591,13 +585,13 @@ RIME_API Bool RimeConfigBeginList(RimeConfigIterator* iterator,
   iterator->index = -1;
   iterator->key = NULL;
   iterator->path = NULL;
-  rime::Config *c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config *c = reinterpret_cast<Config*>(config->ptr);
   if (!c)
     return False;
-  rime::ConfigListPtr list = c->GetList(key);
+  a<ConfigList> list = c->GetList(key);
   if (!list)
     return False;
-  iterator->list = new RimeConfigIteratorImpl<rime::ConfigList>(*list, key);
+  iterator->list = new RimeConfigIteratorImpl<ConfigList>(*list, key);
   return True;
 }
 
@@ -610,11 +604,11 @@ RIME_API Bool RimeConfigBeginMap(RimeConfigIterator* iterator,
   iterator->index = -1;
   iterator->key = NULL;
   iterator->path = NULL;
-  rime::Config *c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config *c = reinterpret_cast<Config*>(config->ptr);
   if (!c) return False;
-  rime::ConfigMapPtr m = c->GetMap(key);
+  a<ConfigMap> m = c->GetMap(key);
   if (!m) return False;
-  iterator->map = new RimeConfigIteratorImpl<rime::ConfigMap>(*m, key);
+  iterator->map = new RimeConfigIteratorImpl<ConfigMap>(*m, key);
   return True;
 }
 
@@ -622,8 +616,8 @@ RIME_API Bool RimeConfigNext(RimeConfigIterator* iterator) {
   if (!iterator->list && !iterator->map)
     return False;
   if (iterator->list) {
-    RimeConfigIteratorImpl<rime::ConfigList>* p =
-        reinterpret_cast<RimeConfigIteratorImpl<rime::ConfigList>*>(iterator->list);
+    RimeConfigIteratorImpl<ConfigList>* p =
+        reinterpret_cast<RimeConfigIteratorImpl<ConfigList>*>(iterator->list);
     if (!p) return False;
     if (++iterator->index > 0)
       ++p->iter;
@@ -636,8 +630,8 @@ RIME_API Bool RimeConfigNext(RimeConfigIterator* iterator) {
     return True;
   }
   if (iterator->map) {
-    RimeConfigIteratorImpl<rime::ConfigMap>* p =
-        reinterpret_cast<RimeConfigIteratorImpl<rime::ConfigMap>*>(iterator->map);
+    RimeConfigIteratorImpl<ConfigMap>* p =
+        reinterpret_cast<RimeConfigIteratorImpl<ConfigMap>*>(iterator->map);
     if (!p) return False;
     if (++iterator->index > 0)
       ++p->iter;
@@ -655,24 +649,24 @@ RIME_API Bool RimeConfigNext(RimeConfigIterator* iterator) {
 RIME_API void RimeConfigEnd(RimeConfigIterator* iterator) {
   if (!iterator) return;
   if (iterator->list)
-    delete reinterpret_cast<RimeConfigIteratorImpl<rime::ConfigList>*>(iterator->list);
+    delete reinterpret_cast<RimeConfigIteratorImpl<ConfigList>*>(iterator->list);
   if (iterator->map)
-    delete reinterpret_cast<RimeConfigIteratorImpl<rime::ConfigMap>*>(iterator->map);
+    delete reinterpret_cast<RimeConfigIteratorImpl<ConfigMap>*>(iterator->map);
   memset(iterator, 0, sizeof(RimeConfigIterator));
 }
 
 
 RIME_API Bool RimeSimulateKeySequence(RimeSessionId session_id, const char *key_sequence) {
   LOG(INFO) << "simulate key sequence: " << key_sequence;
-  rime::a<rime::Session> session(rime::Service::instance().GetSession(session_id));
+  a<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return False;
-  rime::KeySequence keys;
+  KeySequence keys;
   if (!keys.Parse(key_sequence)) {
     LOG(ERROR) << "error parsing input: '" << key_sequence << "'";
     return False;
   }
-  for (const rime::KeyEvent& key : keys) {
+  for (const KeyEvent& key : keys) {
     session->ProcessKey(key);
   }
   return True;
@@ -681,50 +675,50 @@ RIME_API Bool RimeSimulateKeySequence(RimeSessionId session_id, const char *key_
 RIME_API Bool RimeRegisterModule(RimeModule* module) {
   if (!module || !module->module_name)
     return False;
-  rime::ModuleManager::instance().Register(module->module_name, module);
+  ModuleManager::instance().Register(module->module_name, module);
   return True;
 }
 
 RIME_API RimeModule* RimeFindModule(const char* module_name) {
-  return rime::ModuleManager::instance().Find(module_name);
+  return ModuleManager::instance().Find(module_name);
 }
 
 RIME_API Bool RimeRunTask(const char* task_name) {
   if (!task_name)
     return False;
-  rime::Deployer &deployer(rime::Service::instance().deployer());
+  Deployer &deployer(Service::instance().deployer());
   return Bool(deployer.RunTask(task_name));
 }
 
 RIME_API const char* RimeGetSharedDataDir() {
-  rime::Deployer &deployer(rime::Service::instance().deployer());
+  Deployer &deployer(Service::instance().deployer());
   return deployer.shared_data_dir.c_str();
 }
 
 RIME_API const char* RimeGetUserDataDir() {
-  rime::Deployer &deployer(rime::Service::instance().deployer());
+  Deployer &deployer(Service::instance().deployer());
   return deployer.user_data_dir.c_str();
 }
 
 RIME_API const char* RimeGetSyncDir() {
-  rime::Deployer &deployer(rime::Service::instance().deployer());
+  Deployer &deployer(Service::instance().deployer());
   return deployer.sync_dir.c_str();
 }
 
 RIME_API const char* RimeGetUserId() {
-  rime::Deployer &deployer(rime::Service::instance().deployer());
+  Deployer &deployer(Service::instance().deployer());
   return deployer.user_id.c_str();
 }
 
 RIME_API void RimeGetUserDataSyncDir(char* dir, size_t buffer_size) {
-  rime::Deployer &deployer(rime::Service::instance().deployer());
+  Deployer &deployer(Service::instance().deployer());
   strncpy(dir, deployer.user_data_sync_dir().c_str(), buffer_size);
 }
 
 RIME_API Bool RimeConfigInit(RimeConfig* config) {
   if (!config || config->ptr)
     return False;
-  config->ptr = (void*)new rime::Config;
+  config->ptr = (void*)new Config;
   return True;
 }
 
@@ -735,7 +729,7 @@ RIME_API Bool RimeConfigLoadString(RimeConfig* config, const char* yaml) {
   if (!config->ptr) {
     RimeConfigInit(config);
   }
-  rime::Config* c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config* c = reinterpret_cast<Config*>(config->ptr);
   std::istringstream iss(yaml);
   return Bool(c->LoadFromStream(iss));
 }
@@ -743,13 +737,13 @@ RIME_API Bool RimeConfigLoadString(RimeConfig* config, const char* yaml) {
 RIME_API Bool RimeConfigGetItem(RimeConfig* config, const char* key, RimeConfig* value) {
   if (!config || !key || !value)
     return False;
-  rime::Config* c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config* c = reinterpret_cast<Config*>(config->ptr);
   if (!c)
     return False;
   if (!value->ptr) {
     RimeConfigInit(value);
   }
-  rime::Config* v = reinterpret_cast<rime::Config*>(value->ptr);
+  Config* v = reinterpret_cast<Config*>(value->ptr);
   *v = c->GetItem(key);
   return True;
 }
@@ -757,12 +751,12 @@ RIME_API Bool RimeConfigGetItem(RimeConfig* config, const char* key, RimeConfig*
 RIME_API Bool RimeConfigSetItem(RimeConfig* config, const char* key, RimeConfig* value) {
   if (!config || !key)
     return False;
-  rime::Config* c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config* c = reinterpret_cast<Config*>(config->ptr);
   if (!c)
     return False;
-  rime::ConfigItemPtr item;
+  a<ConfigItem> item;
   if (value) {
-    if (rime::Config* v = reinterpret_cast<rime::Config*>(value->ptr)) {
+    if (Config* v = reinterpret_cast<Config*>(value->ptr)) {
       item = v->GetItem("");
     }
   }
@@ -772,7 +766,7 @@ RIME_API Bool RimeConfigSetItem(RimeConfig* config, const char* key, RimeConfig*
 RIME_API Bool RimeConfigSetBool(RimeConfig* config, const char* key, Bool value) {
   if (!config || !key)
     return False;
-  rime::Config* c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config* c = reinterpret_cast<Config*>(config->ptr);
   if (!c)
     return False;
   return Bool(c->SetBool(key, value));
@@ -781,7 +775,7 @@ RIME_API Bool RimeConfigSetBool(RimeConfig* config, const char* key, Bool value)
 RIME_API Bool RimeConfigSetInt(RimeConfig* config, const char* key, int value) {
   if (!config || !key)
     return False;
-  rime::Config* c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config* c = reinterpret_cast<Config*>(config->ptr);
   if (!c)
     return False;
   return Bool(c->SetInt(key, value));
@@ -790,7 +784,7 @@ RIME_API Bool RimeConfigSetInt(RimeConfig* config, const char* key, int value) {
 RIME_API Bool RimeConfigSetDouble(RimeConfig* config, const char* key, double value) {
   if (!config || !key)
     return False;
-  rime::Config* c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config* c = reinterpret_cast<Config*>(config->ptr);
   if (!c)
     return False;
   return Bool(c->SetDouble(key, value));
@@ -799,7 +793,7 @@ RIME_API Bool RimeConfigSetDouble(RimeConfig* config, const char* key, double va
 RIME_API Bool RimeConfigSetString(RimeConfig* config, const char* key, const char* value) {
   if (!config || !key || !value)
     return False;
-  rime::Config* c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config* c = reinterpret_cast<Config*>(config->ptr);
   if (!c)
     return False;
   return Bool(c->SetString(key, value));
@@ -808,7 +802,7 @@ RIME_API Bool RimeConfigSetString(RimeConfig* config, const char* key, const cha
 RIME_API Bool RimeConfigClear(RimeConfig* config, const char* key) {
   if (!config || !key)
     return False;
-  rime::Config* c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config* c = reinterpret_cast<Config*>(config->ptr);
   if (!c)
     return False;
   return Bool(c->SetItem(key, nullptr));
@@ -817,58 +811,58 @@ RIME_API Bool RimeConfigClear(RimeConfig* config, const char* key) {
 RIME_API Bool RimeConfigCreateList(RimeConfig* config, const char* key) {
   if (!config || !key)
     return False;
-  rime::Config* c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config* c = reinterpret_cast<Config*>(config->ptr);
   if (!c)
     return False;
-  return Bool(c->SetItem(key, rime::New<rime::ConfigList>()));
+  return Bool(c->SetItem(key, New<ConfigList>()));
 }
 
 RIME_API Bool RimeConfigCreateMap(RimeConfig* config, const char* key) {
   if (!config || !key)
     return False;
-  rime::Config* c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config* c = reinterpret_cast<Config*>(config->ptr);
   if (!c)
     return False;
-  return Bool(c->SetItem(key, rime::New<rime::ConfigMap>()));
+  return Bool(c->SetItem(key, New<ConfigMap>()));
 }
 
 RIME_API size_t RimeConfigListSize(RimeConfig* config, const char* key) {
   if (!config || !key)
     return 0;
-  rime::Config* c = reinterpret_cast<rime::Config*>(config->ptr);
+  Config* c = reinterpret_cast<Config*>(config->ptr);
   if (!c)
     return 0;
-  if (rime::ConfigListPtr list = c->GetList(key)) {
+  if (a<ConfigList> list = c->GetList(key)) {
     return list->size();
   }
   return 0;
 }
 
 const char* RimeGetInput(RimeSessionId session_id) {
-  rime::a<rime::Session> session(rime::Service::instance().GetSession(session_id));
+  a<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return NULL;
-  rime::Context *ctx = session->context();
+  Context *ctx = session->context();
   if (!ctx)
     return NULL;
   return ctx->input().c_str();
 }
 
 size_t RimeGetCaretPos(RimeSessionId session_id) {
-  rime::a<rime::Session> session(rime::Service::instance().GetSession(session_id));
+  a<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return 0;
-  rime::Context *ctx = session->context();
+  Context *ctx = session->context();
   if (!ctx)
     return 0;
   return ctx->caret_pos();
 }
 
 Bool RimeSelectCandidate(RimeSessionId session_id, size_t index) {
-  rime::a<rime::Session> session(rime::Service::instance().GetSession(session_id));
+  a<Session> session(Service::instance().GetSession(session_id));
   if (!session)
     return False;
-  rime::Context *ctx = session->context();
+  Context *ctx = session->context();
   if (!ctx)
     return False;
   return Bool(ctx->Select(index));

--- a/src/schema.cc
+++ b/src/schema.cc
@@ -15,7 +15,7 @@ Schema::Schema()
   FetchUsefulConfigItems();
 }
 
-Schema::Schema(const std::string& schema_id)
+Schema::Schema(const string& schema_id)
     : schema_id_(schema_id) {
   if (boost::starts_with(schema_id_, L".")) {
     config_.reset(Config::Require("config")->Create(schema_id.substr(1)));
@@ -37,7 +37,7 @@ void Schema::FetchUsefulConfigItems() {
   if (!config_->GetInt("menu/page_size", &page_size_) &&
       schema_id_ != ".default") {
     // not defined in schema, use default setting
-    unique_ptr<Config> default_config(
+    the<Config> default_config(
         Config::Require("config")->Create("default"));
     if (default_config) {
       default_config->GetInt("menu/page_size", &page_size_);

--- a/src/segmentation.cc
+++ b/src/segmentation.cc
@@ -43,20 +43,20 @@ bool Segment::Reopen(size_t caret_pos) {
   return true;
 }
 
-shared_ptr<Candidate> Segment::GetCandidateAt(size_t index) const {
+a<Candidate> Segment::GetCandidateAt(size_t index) const {
   if (!menu)
     return nullptr;
   return menu->GetCandidateAt(index);
 }
 
-shared_ptr<Candidate> Segment::GetSelectedCandidate() const {
+a<Candidate> Segment::GetSelectedCandidate() const {
   return GetCandidateAt(selected_index);
 }
 
 Segmentation::Segmentation() {
 }
 
-void Segmentation::Reset(const std::string& new_input) {
+void Segmentation::Reset(const string& new_input) {
   DLOG(INFO) << "reset to " << size() << " segments.";
   // mark redo segmentation, while keeping user confirmed segments
   size_t diff_pos = 0;
@@ -107,8 +107,8 @@ bool Segmentation::AddSegment(const Segment& segment) {
   }
   else {
     // rule three: with segments equal in length, merge their tags
-    std::set<std::string> result;
-    std::set_union(last.tags.begin(), last.tags.end(),
+    set<string> result;
+    set_union(last.tags.begin(), last.tags.end(),
                    segment.tags.begin(), segment.tags.end(),
                    std::inserter(result, result.begin()));
     last.tags.swap(result);
@@ -167,7 +167,7 @@ std::ostream& operator<< (std::ostream& out,
     if (!segment.tags.empty()) {
       out << "{";
       bool first = true;
-      for (const std::string& tag : segment.tags) {
+      for (const string& tag : segment.tags) {
         if (first)
           first = false;
         else

--- a/src/segmentation.cc
+++ b/src/segmentation.cc
@@ -43,13 +43,13 @@ bool Segment::Reopen(size_t caret_pos) {
   return true;
 }
 
-a<Candidate> Segment::GetCandidateAt(size_t index) const {
+an<Candidate> Segment::GetCandidateAt(size_t index) const {
   if (!menu)
     return nullptr;
   return menu->GetCandidateAt(index);
 }
 
-a<Candidate> Segment::GetSelectedCandidate() const {
+an<Candidate> Segment::GetSelectedCandidate() const {
   return GetCandidateAt(selected_index);
 }
 

--- a/src/service.cc
+++ b/src/service.cc
@@ -107,7 +107,7 @@ SessionId Service::CreateSession() {
   return id;
 }
 
-a<Session> Service::GetSession(SessionId session_id) {
+an<Session> Service::GetSession(SessionId session_id) {
   if (disabled())
     return nullptr;
   SessionMap::iterator it = sessions_.find(session_id);

--- a/src/service.cc
+++ b/src/service.cc
@@ -50,7 +50,7 @@ void Session::ApplySchema(Schema* schema) {
   engine_->ApplySchema(schema);
 }
 
-void Session::OnCommit(const std::string& commit_text) {
+void Session::OnCommit(const string& commit_text) {
   commit_text_ += commit_text;
 }
 
@@ -92,7 +92,7 @@ SessionId Service::CreateSession() {
   catch (const std::exception& ex) {
     LOG(ERROR) << "Error creating session: " << ex.what();
   }
-  catch (const std::string& ex) {
+  catch (const string& ex) {
     LOG(ERROR) << "Error creating session: " << ex;
   }
   catch (const char* ex) {
@@ -107,7 +107,7 @@ SessionId Service::CreateSession() {
   return id;
 }
 
-shared_ptr<Session> Service::GetSession(SessionId session_id) {
+a<Session> Service::GetSession(SessionId session_id) {
   if (disabled())
     return nullptr;
   SessionMap::iterator it = sessions_.find(session_id);
@@ -158,8 +158,8 @@ void Service::ClearNotificationHandler() {
 }
 
 void Service::Notify(SessionId session_id,
-                     const std::string& message_type,
-                     const std::string& message_value) {
+                     const string& message_type,
+                     const string& message_value) {
   if (notification_handler_) {
     std::lock_guard<std::mutex> lock(mutex_);
     notification_handler_(session_id,
@@ -169,7 +169,7 @@ void Service::Notify(SessionId session_id,
 }
 
 Service& Service::instance() {
-  static unique_ptr<Service> s_instance;
+  static the<Service> s_instance;
   if (!s_instance) {
     s_instance.reset(new Service);
   }

--- a/src/signature.cc
+++ b/src/signature.cc
@@ -16,7 +16,7 @@ bool Signature::Sign(Config* config, Deployer* deployer) {
   if (!config) return false;
   config->SetString(key_ + "/generator", generator_);
   time_t now = time(NULL);
-  std::string time_str(ctime(&now));
+  string time_str(ctime(&now));
   boost::trim(time_str);
   config->SetString(key_ + "/modified_time", time_str);
   config->SetString(key_ + "/distribution_code_name",

--- a/src/switcher.cc
+++ b/src/switcher.cc
@@ -4,7 +4,6 @@
 //
 // 2011-12-07 GONG Chen <chen.sst@gmail.com>
 //
-#include <string>
 #include <rime/candidate.h>
 #include <rime/common.h>
 #include <rime/composition.h>
@@ -42,7 +41,7 @@ Switcher::~Switcher() {
 
 void Switcher::RestoreSavedOptions() {
   if (user_config_) {
-    for (const std::string& option_name : save_options_) {
+    for (const string& option_name : save_options_) {
       bool value = false;
       if (user_config_->GetBool("var/option/" + option_name, &value)) {
         engine_->context()->set_option(option_name, value);
@@ -91,7 +90,7 @@ void Switcher::HighlightNextSchema() {
     return;
   Segment& seg(comp.back());
   int index = seg.selected_index;
-  shared_ptr<Candidate> option;
+  a<Candidate> option;
   do {
     ++index;  // next
     int candidate_count = seg.menu->Prepare(index + 1);
@@ -116,11 +115,11 @@ Schema* Switcher::CreateSchema() {
   auto schema_list = config->GetList("schema_list");
   if (!schema_list)
     return NULL;
-  std::string previous;
+  string previous;
   if (user_config_) {
     user_config_->GetString("var/previously_selected_schema", &previous);
   }
-  std::string recent;
+  string recent;
   for (size_t i = 0; i < schema_list->size(); ++i) {
     auto item = As<ConfigMap>(schema_list->GetAt(i));
     if (!item)
@@ -128,7 +127,7 @@ Schema* Switcher::CreateSchema() {
     auto schema_property = item->GetValue("schema");
     if (!schema_property)
       continue;
-    const std::string& schema_id(schema_property->str());
+    const string& schema_id(schema_property->str());
     if (previous.empty() || previous == schema_id) {
       recent = schema_id;
       break;
@@ -158,7 +157,7 @@ void Switcher::SelectNextSchema() {
   command->Apply(this);
 }
 
-bool Switcher::IsAutoSave(const std::string& option) const {
+bool Switcher::IsAutoSave(const string& option) const {
   return save_options_.find(option) != save_options_.end();
 }
 
@@ -232,14 +231,14 @@ void Switcher::InitializeComponents() {
   processors_.clear();
   translators_.clear();
   if (auto c = Processor::Require("key_binder")) {
-    shared_ptr<Processor> p(c->Create(Ticket(this)));
+    a<Processor> p(c->Create(Ticket(this)));
     processors_.push_back(p);
   }
   else {
     LOG(WARNING) << "key_binder not available.";
   }
   if (auto c = Processor::Require("selector")) {
-    shared_ptr<Processor> p(c->Create(Ticket(this)));
+    a<Processor> p(c->Create(Ticket(this)));
     processors_.push_back(p);
   }
   else {
@@ -247,14 +246,14 @@ void Switcher::InitializeComponents() {
   }
   DLOG(INFO) << "num processors: " << processors_.size();
   if (auto c = Translator::Require("schema_list_translator")) {
-    shared_ptr<Translator> t(c->Create(Ticket(this)));
+    a<Translator> t(c->Create(Ticket(this)));
     translators_.push_back(t);
   }
   else {
     LOG(WARNING) << "schema_list_translator not available.";
   }
   if (auto c = Translator::Require("switch_translator")) {
-    shared_ptr<Translator> t(c->Create(Ticket(this)));
+    a<Translator> t(c->Create(Ticket(this)));
     translators_.push_back(t);
   }
   else {

--- a/src/switcher.cc
+++ b/src/switcher.cc
@@ -90,7 +90,7 @@ void Switcher::HighlightNextSchema() {
     return;
   Segment& seg(comp.back());
   int index = seg.selected_index;
-  a<Candidate> option;
+  an<Candidate> option;
   do {
     ++index;  // next
     int candidate_count = seg.menu->Prepare(index + 1);
@@ -231,14 +231,14 @@ void Switcher::InitializeComponents() {
   processors_.clear();
   translators_.clear();
   if (auto c = Processor::Require("key_binder")) {
-    a<Processor> p(c->Create(Ticket(this)));
+    an<Processor> p(c->Create(Ticket(this)));
     processors_.push_back(p);
   }
   else {
     LOG(WARNING) << "key_binder not available.";
   }
   if (auto c = Processor::Require("selector")) {
-    a<Processor> p(c->Create(Ticket(this)));
+    an<Processor> p(c->Create(Ticket(this)));
     processors_.push_back(p);
   }
   else {
@@ -246,14 +246,14 @@ void Switcher::InitializeComponents() {
   }
   DLOG(INFO) << "num processors: " << processors_.size();
   if (auto c = Translator::Require("schema_list_translator")) {
-    a<Translator> t(c->Create(Ticket(this)));
+    an<Translator> t(c->Create(Ticket(this)));
     translators_.push_back(t);
   }
   else {
     LOG(WARNING) << "schema_list_translator not available.";
   }
   if (auto c = Translator::Require("switch_translator")) {
-    a<Translator> t(c->Create(Ticket(this)));
+    an<Translator> t(c->Create(Ticket(this)));
     translators_.push_back(t);
   }
   else {

--- a/src/ticket.cc
+++ b/src/ticket.cc
@@ -9,18 +9,18 @@
 
 namespace rime {
 
-Ticket::Ticket(Schema* s, const std::string& ns)
+Ticket::Ticket(Schema* s, const string& ns)
     : schema(s), name_space(ns) {
 }
 
-Ticket::Ticket(Engine* e, const std::string& ns,
-               const std::string& prescription)
+Ticket::Ticket(Engine* e, const string& ns,
+               const string& prescription)
     : engine(e),
       schema(e ? e->schema() : NULL),
       name_space(ns),
       klass(prescription) {
   size_t separator = klass.find('@');
-  if (separator != std::string::npos) {
+  if (separator != string::npos) {
     name_space = klass.substr(separator + 1);
     klass.resize(separator);
   }

--- a/src/translation.cc
+++ b/src/translation.cc
@@ -9,7 +9,7 @@
 
 namespace rime {
 
-int Translation::Compare(a<Translation> other,
+int Translation::Compare(an<Translation> other,
                          const CandidateList& candidates) {
   if (!other || other->exhausted())
     return -1;
@@ -43,7 +43,7 @@ bool UniqueTranslation::Next() {
   return true;
 }
 
-a<Candidate> UniqueTranslation::Peek() {
+an<Candidate> UniqueTranslation::Peek() {
   if (exhausted())
     return nullptr;
   return candidate_;
@@ -61,13 +61,13 @@ bool FifoTranslation::Next() {
   return true;
 }
 
-a<Candidate> FifoTranslation::Peek() {
+an<Candidate> FifoTranslation::Peek() {
   if (exhausted())
     return nullptr;
   return candies_[cursor_];
 }
 
-void FifoTranslation::Append(a<Candidate> candy) {
+void FifoTranslation::Append(an<Candidate> candy) {
   candies_.push_back(candy);
   set_exhausted(false);
 }
@@ -89,13 +89,13 @@ bool UnionTranslation::Next() {
   return true;
 }
 
-a<Candidate> UnionTranslation::Peek() {
+an<Candidate> UnionTranslation::Peek() {
   if (exhausted())
     return nullptr;
   return translations_.front()->Peek();
 }
 
-UnionTranslation& UnionTranslation::operator+= (a<Translation> t) {
+UnionTranslation& UnionTranslation::operator+= (an<Translation> t) {
   if (t && !t->exhausted()) {
     translations_.push_back(t);
     set_exhausted(false);
@@ -103,7 +103,7 @@ UnionTranslation& UnionTranslation::operator+= (a<Translation> t) {
   return *this;
 }
 
-a<UnionTranslation> operator+ (a<Translation> x, a<Translation> y) {
+an<UnionTranslation> operator+ (an<Translation> x, an<Translation> y) {
   auto z = New<UnionTranslation>();
   *z += x;
   *z += y;
@@ -130,7 +130,7 @@ bool MergedTranslation::Next() {
   return true;
 }
 
-a<Candidate> MergedTranslation::Peek() {
+an<Candidate> MergedTranslation::Peek() {
   if (exhausted()) {
     return nullptr;
   }
@@ -144,7 +144,7 @@ void MergedTranslation::Elect() {
   }
   size_t k = 0;
   for (; k < translations_.size(); ++k) {
-    a<Translation> next;
+    an<Translation> next;
     if (k + 1 < translations_.size()) {
       next = translations_[k + 1];
     }
@@ -162,7 +162,7 @@ void MergedTranslation::Elect() {
   }
 }
 
-MergedTranslation& MergedTranslation::operator+= (a<Translation> t) {
+MergedTranslation& MergedTranslation::operator+= (an<Translation> t) {
   if (t && !t->exhausted()) {
     translations_.push_back(t);
     Elect();
@@ -172,7 +172,7 @@ MergedTranslation& MergedTranslation::operator+= (a<Translation> t) {
 
 // CacheTranslation
 
-CacheTranslation::CacheTranslation(a<Translation> translation)
+CacheTranslation::CacheTranslation(an<Translation> translation)
     : translation_(translation) {
   set_exhausted(!translation_ || translation_->exhausted());
 }
@@ -188,7 +188,7 @@ bool CacheTranslation::Next() {
   return true;
 }
 
-a<Candidate> CacheTranslation::Peek() {
+an<Candidate> CacheTranslation::Peek() {
   if (exhausted())
     return nullptr;
   if (!cache_) {
@@ -199,7 +199,7 @@ a<Candidate> CacheTranslation::Peek() {
 
 // DistinctTranslation
 
-DistinctTranslation::DistinctTranslation(a<Translation> translation)
+DistinctTranslation::DistinctTranslation(an<Translation> translation)
     : CacheTranslation(translation) {
 }
 
@@ -221,7 +221,7 @@ bool DistinctTranslation::AlreadyHas(const string& text) const {
 
 // PrefetchTranslation
 
-PrefetchTranslation::PrefetchTranslation(a<Translation> translation)
+PrefetchTranslation::PrefetchTranslation(an<Translation> translation)
     : translation_(translation) {
   set_exhausted(!translation_ || translation_->exhausted());
 }
@@ -242,7 +242,7 @@ bool PrefetchTranslation::Next() {
   return true;
 }
 
-a<Candidate> PrefetchTranslation::Peek() {
+an<Candidate> PrefetchTranslation::Peek() {
   if (exhausted()) {
     return nullptr;
   }

--- a/src/translation.cc
+++ b/src/translation.cc
@@ -9,7 +9,7 @@
 
 namespace rime {
 
-int Translation::Compare(shared_ptr<Translation> other,
+int Translation::Compare(a<Translation> other,
                          const CandidateList& candidates) {
   if (!other || other->exhausted())
     return -1;
@@ -43,7 +43,7 @@ bool UniqueTranslation::Next() {
   return true;
 }
 
-shared_ptr<Candidate> UniqueTranslation::Peek() {
+a<Candidate> UniqueTranslation::Peek() {
   if (exhausted())
     return nullptr;
   return candidate_;
@@ -61,13 +61,13 @@ bool FifoTranslation::Next() {
   return true;
 }
 
-shared_ptr<Candidate> FifoTranslation::Peek() {
+a<Candidate> FifoTranslation::Peek() {
   if (exhausted())
     return nullptr;
   return candies_[cursor_];
 }
 
-void FifoTranslation::Append(shared_ptr<Candidate> candy) {
+void FifoTranslation::Append(a<Candidate> candy) {
   candies_.push_back(candy);
   set_exhausted(false);
 }
@@ -89,13 +89,13 @@ bool UnionTranslation::Next() {
   return true;
 }
 
-shared_ptr<Candidate> UnionTranslation::Peek() {
+a<Candidate> UnionTranslation::Peek() {
   if (exhausted())
     return nullptr;
   return translations_.front()->Peek();
 }
 
-UnionTranslation& UnionTranslation::operator+= (shared_ptr<Translation> t) {
+UnionTranslation& UnionTranslation::operator+= (a<Translation> t) {
   if (t && !t->exhausted()) {
     translations_.push_back(t);
     set_exhausted(false);
@@ -103,12 +103,11 @@ UnionTranslation& UnionTranslation::operator+= (shared_ptr<Translation> t) {
   return *this;
 }
 
-shared_ptr<UnionTranslation> operator+ (shared_ptr<Translation> a,
-                                        shared_ptr<Translation> b) {
-  auto c = New<UnionTranslation>();
-  *c += a;
-  *c += b;
-  return c->exhausted() ? nullptr : c;
+a<UnionTranslation> operator+ (a<Translation> x, a<Translation> y) {
+  auto z = New<UnionTranslation>();
+  *z += x;
+  *z += y;
+  return z->exhausted() ? nullptr : z;
 }
 
 // MergedTranslation
@@ -131,7 +130,7 @@ bool MergedTranslation::Next() {
   return true;
 }
 
-shared_ptr<Candidate> MergedTranslation::Peek() {
+a<Candidate> MergedTranslation::Peek() {
   if (exhausted()) {
     return nullptr;
   }
@@ -145,7 +144,7 @@ void MergedTranslation::Elect() {
   }
   size_t k = 0;
   for (; k < translations_.size(); ++k) {
-    shared_ptr<Translation> next;
+    a<Translation> next;
     if (k + 1 < translations_.size()) {
       next = translations_[k + 1];
     }
@@ -163,7 +162,7 @@ void MergedTranslation::Elect() {
   }
 }
 
-MergedTranslation& MergedTranslation::operator+= (shared_ptr<Translation> t) {
+MergedTranslation& MergedTranslation::operator+= (a<Translation> t) {
   if (t && !t->exhausted()) {
     translations_.push_back(t);
     Elect();
@@ -173,7 +172,7 @@ MergedTranslation& MergedTranslation::operator+= (shared_ptr<Translation> t) {
 
 // CacheTranslation
 
-CacheTranslation::CacheTranslation(shared_ptr<Translation> translation)
+CacheTranslation::CacheTranslation(a<Translation> translation)
     : translation_(translation) {
   set_exhausted(!translation_ || translation_->exhausted());
 }
@@ -189,7 +188,7 @@ bool CacheTranslation::Next() {
   return true;
 }
 
-shared_ptr<Candidate> CacheTranslation::Peek() {
+a<Candidate> CacheTranslation::Peek() {
   if (exhausted())
     return nullptr;
   if (!cache_) {
@@ -200,7 +199,7 @@ shared_ptr<Candidate> CacheTranslation::Peek() {
 
 // DistinctTranslation
 
-DistinctTranslation::DistinctTranslation(shared_ptr<Translation> translation)
+DistinctTranslation::DistinctTranslation(a<Translation> translation)
     : CacheTranslation(translation) {
 }
 
@@ -216,13 +215,13 @@ bool DistinctTranslation::Next() {
   return true;
 }
 
-bool DistinctTranslation::AlreadyHas(const std::string& text) const {
+bool DistinctTranslation::AlreadyHas(const string& text) const {
   return candidate_set_.find(text) != candidate_set_.end();
 }
 
 // PrefetchTranslation
 
-PrefetchTranslation::PrefetchTranslation(shared_ptr<Translation> translation)
+PrefetchTranslation::PrefetchTranslation(a<Translation> translation)
     : translation_(translation) {
   set_exhausted(!translation_ || translation_->exhausted());
 }
@@ -243,7 +242,7 @@ bool PrefetchTranslation::Next() {
   return true;
 }
 
-shared_ptr<Candidate> PrefetchTranslation::Peek() {
+a<Candidate> PrefetchTranslation::Peek() {
   if (exhausted()) {
     return nullptr;
   }

--- a/test/algebra_test.cc
+++ b/test/algebra_test.cc
@@ -28,7 +28,7 @@ TEST(RimeAlgebraTest, SpellingManipulation) {
   rime::Projection p;
   ASSERT_TRUE(p.Load(c));
 
-  std::string str("Shang");
+  rime::string str("Shang");
   EXPECT_TRUE(p.Apply(&str));
   EXPECT_EQ("sang", str);
 }

--- a/test/calculus_test.cc
+++ b/test/calculus_test.cc
@@ -17,7 +17,7 @@ static const char* kAbbreviation = "abbrev/^([zcs]h).*$/$1/";
 
 TEST(RimeCalculusTest, Transliteration) {
   rime::Calculus calc;
-  rime::unique_ptr<rime::Calculation> c(calc.Parse(kTransliteration));
+  rime::the<rime::Calculation> c(calc.Parse(kTransliteration));
   ASSERT_TRUE(bool(c));
   rime::Spelling s("abracadabra");
   EXPECT_TRUE(c->Apply(&s));
@@ -26,7 +26,7 @@ TEST(RimeCalculusTest, Transliteration) {
 
 TEST(RimeCalculusTest, Transformation) {
   rime::Calculus calc;
-  rime::unique_ptr<rime::Calculation> c(calc.Parse(kTransformation));
+  rime::the<rime::Calculation> c(calc.Parse(kTransformation));
   ASSERT_TRUE(bool(c));
   rime::Spelling s("shang");
   EXPECT_TRUE(c->Apply(&s));
@@ -38,7 +38,7 @@ TEST(RimeCalculusTest, Transformation) {
 
 TEST(RimeCalculusTest, Erasion) {
   rime::Calculus calc;
-  rime::unique_ptr<rime::Calculation> c(calc.Parse(kErasion));
+  rime::the<rime::Calculation> c(calc.Parse(kErasion));
   ASSERT_TRUE(bool(c));
   EXPECT_FALSE(c->addition());
   EXPECT_TRUE(c->deletion());
@@ -52,7 +52,7 @@ TEST(RimeCalculusTest, Erasion) {
 
 TEST(RimeCalculusTest, Derivation) {
   rime::Calculus calc;
-  rime::unique_ptr<rime::Calculation> c(calc.Parse(kDerivation));
+  rime::the<rime::Calculation> c(calc.Parse(kDerivation));
   ASSERT_TRUE(bool(c));
   EXPECT_TRUE(c->addition());
   EXPECT_FALSE(c->deletion());
@@ -66,7 +66,7 @@ TEST(RimeCalculusTest, Derivation) {
 
 TEST(RimeCalculusTest, Abbreviation) {
   rime::Calculus calc;
-  rime::unique_ptr<rime::Calculation> c(calc.Parse(kAbbreviation));
+  rime::the<rime::Calculation> c(calc.Parse(kAbbreviation));
   ASSERT_TRUE(bool(c));
   EXPECT_TRUE(c->addition());
   EXPECT_FALSE(c->deletion());

--- a/test/component_test.cc
+++ b/test/component_test.cc
@@ -10,36 +10,36 @@
 
 using namespace rime;
 
-class Greeting : public Class<Greeting, const std::string&> {
+class Greeting : public Class<Greeting, const string&> {
  public:
-  virtual std::string Say() = 0;
+  virtual string Say() = 0;
   virtual ~Greeting() = default;
 };
 
-using HelloMessage = std::pair<std::string, std::string>;
+using HelloMessage = std::pair<string, string>;
 
 class Hello : public Greeting {
  public:
   Hello(const HelloMessage& msg) : word_(msg.first), name_(msg.second) {
   }
-  std::string Say() {
+  string Say() {
     return word_ + ", " + name_ + "!";
   }
  private:
-  std::string word_;
-  std::string name_;
+  string word_;
+  string name_;
 };
 
 // customize a hello component with parameters
 class HelloComponent : public Hello::Component {
  public:
-  HelloComponent(const std::string& word) : word_(word) {}
+  HelloComponent(const string& word) : word_(word) {}
   // define a custom creator to provide an additional argument
-  Hello* Create(const std::string& name) {
+  Hello* Create(const string& name) {
     return new Hello(std::make_pair(word_, name));
   }
  private:
-  std::string word_;
+  string word_;
 };
 
 
@@ -53,7 +53,7 @@ TEST(RimeComponentTest, UsingComponent) {
   Greeting::Component* gm = Greeting::Require("test_morning");
   EXPECT_TRUE(gm != NULL);
 
-  unique_ptr<Greeting> g(gm->Create("michael"));
+  the<Greeting> g(gm->Create("michael"));
   EXPECT_STREQ("good morning, michael!", g->Say().c_str());
 
   r.Unregister("test_hello");

--- a/test/component_test.cc
+++ b/test/component_test.cc
@@ -16,7 +16,7 @@ class Greeting : public Class<Greeting, const string&> {
   virtual ~Greeting() = default;
 };
 
-using HelloMessage = std::pair<string, string>;
+using HelloMessage = pair<string, string>;
 
 class Hello : public Greeting {
  public:
@@ -36,7 +36,7 @@ class HelloComponent : public Hello::Component {
   HelloComponent(const string& word) : word_(word) {}
   // define a custom creator to provide an additional argument
   Hello* Create(const string& name) {
-    return new Hello(std::make_pair(word_, name));
+    return new Hello(make_pair(word_, name));
   }
  private:
   string word_;

--- a/test/config_test.cc
+++ b/test/config_test.cc
@@ -101,11 +101,11 @@ TEST_F(RimeConfigTest, Config_GetString) {
 }
 
 TEST_F(RimeConfigTest, Config_GetList) {
-  a<ConfigList> p;
+  an<ConfigList> p;
   p = config_->GetList("protoss/air_force");
   ASSERT_TRUE(bool(p));
   ASSERT_EQ(4, p->size());
-  a<ConfigValue> element;
+  an<ConfigValue> element;
   string value;
   element = p->GetValueAt(0);
   ASSERT_TRUE(bool(element));
@@ -119,12 +119,12 @@ TEST_F(RimeConfigTest, Config_GetList) {
 }
 
 TEST_F(RimeConfigTest, Config_GetMap) {
-  a<ConfigMap> p;
+  an<ConfigMap> p;
   p = config_->GetMap("terrans/tank/cost");
   ASSERT_TRUE(bool(p));
   EXPECT_FALSE(p->HasKey("rime"));
   ASSERT_TRUE(p->HasKey("time"));
-  a<ConfigValue> item;
+  an<ConfigValue> item;
   string time;
   int mineral = 0;
   int gas = 0;
@@ -147,10 +147,10 @@ TEST(RimeConfigWriterTest, Greetings) {
   ASSERT_TRUE(bool(config));
   // creating contents
   EXPECT_TRUE(config->SetItem("/", New<ConfigMap>()));
-  a<ConfigItem> terran_greetings = New<ConfigValue>("Greetings, Terrans!");
-  a<ConfigItem> zerg_greetings = New<ConfigValue>("Zergsss are coming!");
-  a<ConfigItem> zergs_coming = New<ConfigValue>(true);
-  a<ConfigItem> zergs_population = New<ConfigValue>(1000000);
+  an<ConfigItem> terran_greetings = New<ConfigValue>("Greetings, Terrans!");
+  an<ConfigItem> zerg_greetings = New<ConfigValue>("Zergsss are coming!");
+  an<ConfigItem> zergs_coming = New<ConfigValue>(true);
+  an<ConfigItem> zergs_population = New<ConfigValue>(1000000);
   EXPECT_TRUE(config->SetItem("greetings", terran_greetings));
   EXPECT_TRUE(config->SetItem("zergs/overmind/greetings", zerg_greetings));
   EXPECT_TRUE(config->SetItem("zergs/going", zergs_coming));
@@ -215,8 +215,8 @@ TEST(RimeConfigxxTest, Operations) {
   EXPECT_EQ(4, config["list"].size());
   EXPECT_EQ("123", config["list"][3]["abc"].ToString());
   EXPECT_EQ("Hello!", config["list"][2].ToString());
-  a<ConfigItem> v1(config["list"][2]);
-  a<ConfigItem> v2(config["nested"]["greetings"]);
+  an<ConfigItem> v1(config["list"][2]);
+  an<ConfigItem> v2(config["nested"]["greetings"]);
   EXPECT_EQ(v1, v2);
   EXPECT_TRUE(config.modified());
   EXPECT_TRUE(config.SaveToFile("rime_configxx_test.yaml"));

--- a/test/config_test.cc
+++ b/test/config_test.cc
@@ -23,8 +23,8 @@ class RimeConfigTest : public ::testing::Test {
   virtual void TearDown() {
   }
 
-  unique_ptr<Config::Component> component_;
-  unique_ptr<Config> config_;
+  the<Config::Component> component_;
+  the<Config> config_;
 };
 
 TEST(RimeConfigComponentTest, RealCreationWorkflow) {
@@ -35,7 +35,7 @@ TEST(RimeConfigComponentTest, RealCreationWorkflow) {
   Config::Component* cc = Config::Require("test_config");
   ASSERT_TRUE(cc != NULL);
   // creation
-  unique_ptr<Config> config(cc->Create("config_test"));
+  the<Config> config(cc->Create("config_test"));
   EXPECT_TRUE(bool(config));
   r.Unregister("test_config");
 }
@@ -90,7 +90,7 @@ TEST_F(RimeConfigTest, Config_GetDouble) {
 
 TEST_F(RimeConfigTest, Config_GetString) {
   bool ret;
-  std::string value;
+  string value;
   ret = config_->GetString("protoss/residence", &value);
   EXPECT_TRUE(ret);
   EXPECT_EQ("Aiur", value);
@@ -106,7 +106,7 @@ TEST_F(RimeConfigTest, Config_GetList) {
   ASSERT_TRUE(bool(p));
   ASSERT_EQ(4, p->size());
   ConfigValuePtr element;
-  std::string value;
+  string value;
   element = p->GetValueAt(0);
   ASSERT_TRUE(bool(element));
   ASSERT_TRUE(element->GetString(&value));
@@ -125,7 +125,7 @@ TEST_F(RimeConfigTest, Config_GetMap) {
   EXPECT_FALSE(p->HasKey("rime"));
   ASSERT_TRUE(p->HasKey("time"));
   ConfigValuePtr item;
-  std::string time;
+  string time;
   int mineral = 0;
   int gas = 0;
   item = p->GetValue("time");
@@ -143,7 +143,7 @@ TEST_F(RimeConfigTest, Config_GetMap) {
 }
 
 TEST(RimeConfigWriterTest, Greetings) {
-  unique_ptr<Config> config(new Config);
+  the<Config> config(new Config);
   ASSERT_TRUE(bool(config));
   // creating contents
   EXPECT_TRUE(config->SetItem("/", New<ConfigMap>()));
@@ -160,10 +160,10 @@ TEST(RimeConfigWriterTest, Greetings) {
   // saving
   EXPECT_TRUE(config->SaveToFile("config_writer_test.yaml"));
   // verify
-  unique_ptr<Config> config2(new Config);
+  the<Config> config2(new Config);
   ASSERT_TRUE(bool(config2));
   EXPECT_TRUE(config2->LoadFromFile("config_writer_test.yaml"));
-  std::string the_greetings;
+  string the_greetings;
   EXPECT_TRUE(config2->GetString("greetings", &the_greetings));
   EXPECT_EQ("Greetings, Terrans!", the_greetings);
   EXPECT_TRUE(config2->GetString("zergs/overmind/greetings", &the_greetings));
@@ -181,12 +181,12 @@ TEST(RimeConfigWriterTest, Greetings) {
   EXPECT_TRUE(config2->SetItem("zergs/overmind", ConfigItemPtr()));
   EXPECT_TRUE(config2->SaveToFile("config_rewriter_test.yaml"));
   // verify
-  unique_ptr<Config> config3(new Config);
+  the<Config> config3(new Config);
   ASSERT_TRUE(bool(config3));
   EXPECT_TRUE(config3->LoadFromFile("config_rewriter_test.yaml"));
   EXPECT_TRUE(config3->GetInt("zergs/statistics/population", &population));
   EXPECT_EQ(500000, population);
-  std::string value;
+  string value;
   EXPECT_TRUE(config3->GetString("protoss/residence", &value));
   EXPECT_EQ("Aiur", value);
   // deleted
@@ -233,7 +233,7 @@ TEST(RimeConfigxxTest, Operations) {
 TEST(RimeConfigListKeyPathTest, Greetings) {
   int id = 0;
   int value = 0;
-  unique_ptr<Config> config(new Config);
+  the<Config> config(new Config);
   ASSERT_TRUE(bool(config));
   // append items
   EXPECT_TRUE(config->SetInt("list/@next/id", 1));

--- a/test/config_test.cc
+++ b/test/config_test.cc
@@ -101,11 +101,11 @@ TEST_F(RimeConfigTest, Config_GetString) {
 }
 
 TEST_F(RimeConfigTest, Config_GetList) {
-  ConfigListPtr p;
+  a<ConfigList> p;
   p = config_->GetList("protoss/air_force");
   ASSERT_TRUE(bool(p));
   ASSERT_EQ(4, p->size());
-  ConfigValuePtr element;
+  a<ConfigValue> element;
   string value;
   element = p->GetValueAt(0);
   ASSERT_TRUE(bool(element));
@@ -119,12 +119,12 @@ TEST_F(RimeConfigTest, Config_GetList) {
 }
 
 TEST_F(RimeConfigTest, Config_GetMap) {
-  ConfigMapPtr p;
+  a<ConfigMap> p;
   p = config_->GetMap("terrans/tank/cost");
   ASSERT_TRUE(bool(p));
   EXPECT_FALSE(p->HasKey("rime"));
   ASSERT_TRUE(p->HasKey("time"));
-  ConfigValuePtr item;
+  a<ConfigValue> item;
   string time;
   int mineral = 0;
   int gas = 0;
@@ -147,10 +147,10 @@ TEST(RimeConfigWriterTest, Greetings) {
   ASSERT_TRUE(bool(config));
   // creating contents
   EXPECT_TRUE(config->SetItem("/", New<ConfigMap>()));
-  ConfigItemPtr terran_greetings = New<ConfigValue>("Greetings, Terrans!");
-  ConfigItemPtr zerg_greetings = New<ConfigValue>("Zergsss are coming!");
-  ConfigItemPtr zergs_coming = New<ConfigValue>(true);
-  ConfigItemPtr zergs_population = New<ConfigValue>(1000000);
+  a<ConfigItem> terran_greetings = New<ConfigValue>("Greetings, Terrans!");
+  a<ConfigItem> zerg_greetings = New<ConfigValue>("Zergsss are coming!");
+  a<ConfigItem> zergs_coming = New<ConfigValue>(true);
+  a<ConfigItem> zergs_population = New<ConfigValue>(1000000);
   EXPECT_TRUE(config->SetItem("greetings", terran_greetings));
   EXPECT_TRUE(config->SetItem("zergs/overmind/greetings", zerg_greetings));
   EXPECT_TRUE(config->SetItem("zergs/going", zergs_coming));
@@ -178,7 +178,7 @@ TEST(RimeConfigWriterTest, Greetings) {
   // modifying tree
   EXPECT_TRUE(config2->SetInt("zergs/statistics/population", population / 2));
   EXPECT_TRUE(config2->SetString("protoss/residence", "Aiur"));
-  EXPECT_TRUE(config2->SetItem("zergs/overmind", ConfigItemPtr()));
+  EXPECT_TRUE(config2->SetItem("zergs/overmind", nullptr));
   EXPECT_TRUE(config2->SaveToFile("config_rewriter_test.yaml"));
   // verify
   the<Config> config3(new Config);
@@ -215,8 +215,8 @@ TEST(RimeConfigxxTest, Operations) {
   EXPECT_EQ(4, config["list"].size());
   EXPECT_EQ("123", config["list"][3]["abc"].ToString());
   EXPECT_EQ("Hello!", config["list"][2].ToString());
-  ConfigItemPtr v1(config["list"][2]);
-  ConfigItemPtr v2(config["nested"]["greetings"]);
+  a<ConfigItem> v1(config["list"][2]);
+  a<ConfigItem> v2(config["nested"]["greetings"]);
   EXPECT_EQ(v1, v2);
   EXPECT_TRUE(config.modified());
   EXPECT_TRUE(config.SaveToFile("rime_configxx_test.yaml"));

--- a/test/dictionary_test.cc
+++ b/test/dictionary_test.cc
@@ -32,11 +32,11 @@ class RimeDictionaryTest : public ::testing::Test {
     dict_.reset();
   }
  protected:
-  static rime::unique_ptr<rime::Dictionary> dict_;
+  static rime::the<rime::Dictionary> dict_;
   static bool rebuilt_;
 };
 
-rime::unique_ptr<rime::Dictionary> RimeDictionaryTest::dict_;
+rime::the<rime::Dictionary> RimeDictionaryTest::dict_;
 bool RimeDictionaryTest::rebuilt_ = false;
 
 TEST_F(RimeDictionaryTest, Ready) {
@@ -71,7 +71,7 @@ TEST_F(RimeDictionaryTest, ScriptLookup) {
   ASSERT_TRUE(dict_->loaded());
   rime::SyllableGraph g;
   rime::Syllabifier s;
-  std::string input("shurufa");
+  rime::string input("shurufa");
   ASSERT_TRUE(s.BuildSyllableGraph(input, *dict_->prism(), &g) > 0);
   EXPECT_EQ(g.interpreted_length, g.input_length);
   auto c = dict_->Lookup(g, 0);

--- a/test/encoder_test.cc
+++ b/test/encoder_test.cc
@@ -63,7 +63,7 @@ TEST(RimeEncoderTest, Encode) {
   rime::RawCode c0, c1;
   c0.FromString("abc def");
   c1.FromString("abc def ghi");
-  std::string result;
+  rime::string result;
   // case 1
   config["encoder"]["rules"][0]["length_equal"] = 2;
   config["encoder"]["rules"][0]["formula"] = "AaAbBaBb";
@@ -111,7 +111,7 @@ TEST(RimeEncoderTest, TailAnchor) {
   config["encoder"]["tail_anchor"] = "'";
   rime::RawCode c;
   c.FromString("zyx'wvu'tsr qpo'nmlk'jih gfedcba");
-  std::string result;
+  rime::string result;
   // case 1
   config["encoder"]["rules"][0]["formula"] = "AaAzBaBzCaCz";
   encoder.LoadSettings(&config);

--- a/test/menu_test.cc
+++ b/test/menu_test.cc
@@ -21,7 +21,7 @@ class TranslationAlpha : public Translation {
     set_exhausted(true);
     return true;
   }
-  shared_ptr<Candidate> Peek() {
+  a<Candidate> Peek() {
     if (exhausted())
       return nullptr;
     return New<SimpleCandidate>("alpha", 0, 5, "Alpha");
@@ -44,14 +44,14 @@ class TranslationBeta : public Translation {
     return true;
   }
 
-  shared_ptr<Candidate> Peek() {
+  a<Candidate> Peek() {
     if (exhausted())
       return nullptr;
     return candies_[cursor_];
   }
 
  private:
-  std::vector<shared_ptr<Candidate>> candies_;
+  vector<a<Candidate>> candies_;
   size_t cursor_;
 };
 
@@ -63,7 +63,7 @@ TEST(RimeMenuTest, RecipeAlphaBeta) {
   menu.AddTranslation(beta);
   // explicit call to Menu::Prepare() is not necessary
   menu.Prepare(2);
-  unique_ptr<Page> page(menu.CreatePage(5, 0));
+  the<Page> page(menu.CreatePage(5, 0));
   ASSERT_TRUE(bool(page));
   EXPECT_EQ(5, page->page_size);
   EXPECT_EQ(0, page->page_no);
@@ -74,6 +74,6 @@ TEST(RimeMenuTest, RecipeAlphaBeta) {
   EXPECT_EQ("beta", page->candidates[1]->type());
   EXPECT_EQ("Beta-1", page->candidates[1]->text());
   EXPECT_EQ("Beta-3", page->candidates[3]->text());
-  unique_ptr<Page> no_more_page(menu.CreatePage(5, 1));
+  the<Page> no_more_page(menu.CreatePage(5, 1));
   EXPECT_FALSE(bool(no_more_page));
 }

--- a/test/menu_test.cc
+++ b/test/menu_test.cc
@@ -21,7 +21,7 @@ class TranslationAlpha : public Translation {
     set_exhausted(true);
     return true;
   }
-  a<Candidate> Peek() {
+  an<Candidate> Peek() {
     if (exhausted())
       return nullptr;
     return New<SimpleCandidate>("alpha", 0, 5, "Alpha");
@@ -44,7 +44,7 @@ class TranslationBeta : public Translation {
     return true;
   }
 
-  a<Candidate> Peek() {
+  an<Candidate> Peek() {
     if (exhausted())
       return nullptr;
     return candies_[cursor_];

--- a/test/menu_test.cc
+++ b/test/menu_test.cc
@@ -51,7 +51,7 @@ class TranslationBeta : public Translation {
   }
 
  private:
-  vector<a<Candidate>> candies_;
+  vector<of<Candidate>> candies_;
   size_t cursor_;
 };
 

--- a/test/prism_test.cc
+++ b/test/prism_test.cc
@@ -5,9 +5,6 @@
 // 2011-05-17 Zou xu <zouivex@gmail.com>
 //
 #include <algorithm>
-#include <set>
-#include <string>
-#include <vector>
 #include <gtest/gtest.h>
 #include <rime/dict/prism.h>
 
@@ -21,7 +18,7 @@ class RimePrismTest : public ::testing::Test {
     prism_.reset(new Prism("prism_test.bin"));
     prism_->Remove();
     
-    std::set<std::string> keyset;
+    set<string> keyset;
     keyset.insert("google");     // 4
     keyset.insert("good");       // 2
     keyset.insert("goodbye");    // 3
@@ -37,7 +34,7 @@ class RimePrismTest : public ::testing::Test {
   virtual void TearDown() {
   }
 
-  unique_ptr<Prism> prism_;
+  the<Prism> prism_;
 };
 
 TEST_F(RimePrismTest, SaveAndLoad) {
@@ -68,7 +65,7 @@ TEST_F(RimePrismTest, GetValue) {
 }
 
 TEST_F(RimePrismTest, CommonPrefixMatch) {
-  std::vector<Prism::Match> result;
+  vector<Prism::Match> result;
 
   prism_->CommonPrefixSearch("goodbye", &result);
   //result is good and goodbye.
@@ -80,7 +77,7 @@ TEST_F(RimePrismTest, CommonPrefixMatch) {
 }
 
 TEST_F(RimePrismTest, ExpandSearch) {
-  std::vector<Prism::Match> result;
+  vector<Prism::Match> result;
 
   prism_->ExpandSearch("goo", &result, 10);
   //result is good, google and goodbye (ordered by length asc).

--- a/test/segmentor_test.cc
+++ b/test/segmentor_test.cc
@@ -16,8 +16,8 @@ using namespace rime;
 TEST(AbcSegmentorTest, NoMatch) {
   Segmentor::Component* component = Segmentor::Require("abc_segmentor");
   ASSERT_TRUE(component != NULL);
-  unique_ptr<Engine> engine(Engine::Create());
-  unique_ptr<Segmentor> segmentor(component->Create(engine.get()));
+  the<Engine> engine(Engine::Create());
+  the<Segmentor> segmentor(component->Create(engine.get()));
   ASSERT_TRUE(bool(segmentor));
   Segmentation segmentation;
   segmentation.Reset("3.1415926");
@@ -30,8 +30,8 @@ TEST(AbcSegmentorTest, NoMatch) {
 TEST(AbcSegmentorTest, FullMatch) {
   Segmentor::Component* component = Segmentor::Require("abc_segmentor");
   ASSERT_TRUE(component != NULL);
-  unique_ptr<Engine> engine(Engine::Create());
-  unique_ptr<Segmentor> segmentor(component->Create(engine.get()));
+  the<Engine> engine(Engine::Create());
+  the<Segmentor> segmentor(component->Create(engine.get()));
   ASSERT_TRUE(bool(segmentor));
   Segmentation segmentation;
   segmentation.Reset("zyxwvutsrqponmlkjihgfedcba");
@@ -47,8 +47,8 @@ TEST(AbcSegmentorTest, FullMatch) {
 TEST(AbcSegmentorTest, PrefixMatch) {
   Segmentor::Component* component = Segmentor::Require("abc_segmentor");
   ASSERT_TRUE(component != NULL);
-  unique_ptr<Engine> engine(Engine::Create());
-  unique_ptr<Segmentor> segmentor(component->Create(engine.get()));
+  the<Engine> engine(Engine::Create());
+  the<Segmentor> segmentor(component->Create(engine.get()));
   ASSERT_TRUE(bool(segmentor));
   Segmentation segmentation;
   segmentation.Reset("abcdefg.1415926");

--- a/test/syllabifier_test.cc
+++ b/test/syllabifier_test.cc
@@ -5,10 +5,7 @@
 // 2011-07-05 GONG Chen <chen.sst@gmail.com>
 //
 #include <algorithm>
-#include <set>
-#include <string>
 #include <utility>
-#include <vector>
 #include <gtest/gtest.h>
 #include <rime/dict/prism.h>
 #include <rime/algo/syllabifier.h>
@@ -16,7 +13,7 @@
 class RimeSyllabifierTest : public ::testing::Test {
  public:
   virtual void SetUp() {
-    std::vector<std::string> syllables;
+    rime::vector<rime::string> syllables;
     syllables.push_back("a");      // 0 == id
     syllables.push_back("an");     // 1
     syllables.push_back("cha");    // 2
@@ -34,7 +31,7 @@ class RimeSyllabifierTest : public ::testing::Test {
     }
 
     prism_.reset(new rime::Prism("syllabifier_test.bin"));
-    std::set<std::string> keyset;
+    rime::set<rime::string> keyset;
     std::copy(syllables.begin(), syllables.end(),
               std::inserter(keyset, keyset.begin()));
     prism_->Build(keyset);
@@ -44,14 +41,14 @@ class RimeSyllabifierTest : public ::testing::Test {
   }
 
  protected:
-  std::map<std::string, rime::SyllableId> syllable_id_;
-  rime::unique_ptr<rime::Prism> prism_;
+  rime::map<rime::string, rime::SyllableId> syllable_id_;
+  rime::the<rime::Prism> prism_;
 };
 
 TEST_F(RimeSyllabifierTest, CaseAlpha) {
   rime::Syllabifier s;
   rime::SyllableGraph g;
-  const std::string input("a");
+  const rime::string input("a");
   s.BuildSyllableGraph(input, *prism_, &g);
   EXPECT_EQ(input.length(), g.input_length);
   EXPECT_EQ(input.length(), g.interpreted_length);
@@ -68,7 +65,7 @@ TEST_F(RimeSyllabifierTest, CaseAlpha) {
 TEST_F(RimeSyllabifierTest, CaseFailure) {
   rime::Syllabifier s;
   rime::SyllableGraph g;
-  const std::string input("ang");
+  const rime::string input("ang");
   s.BuildSyllableGraph(input, *prism_, &g);
   EXPECT_EQ(input.length(), g.input_length);
   EXPECT_EQ(input.length() - 1, g.interpreted_length);
@@ -84,7 +81,7 @@ TEST_F(RimeSyllabifierTest, CaseFailure) {
 TEST_F(RimeSyllabifierTest, CaseChangan) {
   rime::Syllabifier s;
   rime::SyllableGraph g;
-  const std::string input("changan");
+  const rime::string input("changan");
   s.BuildSyllableGraph(input, *prism_, &g);
   EXPECT_EQ(input.length(), g.input_length);
   EXPECT_EQ(input.length(), g.interpreted_length);
@@ -117,7 +114,7 @@ TEST_F(RimeSyllabifierTest, CaseChangan) {
 TEST_F(RimeSyllabifierTest, CaseTuan) {
   rime::Syllabifier s;
   rime::SyllableGraph g;
-  const std::string input("tuan");
+  const rime::string input("tuan");
   s.BuildSyllableGraph(input, *prism_, &g);
   EXPECT_EQ(input.length(), g.input_length);
   EXPECT_EQ(input.length(), g.interpreted_length);
@@ -143,7 +140,7 @@ TEST_F(RimeSyllabifierTest, CaseTuan) {
 TEST_F(RimeSyllabifierTest, CaseChainingAmbiguity) {
   rime::Syllabifier s;
   rime::SyllableGraph g;
-  const std::string input("anana");
+  const rime::string input("anana");
   s.BuildSyllableGraph(input, *prism_, &g);
   EXPECT_EQ(input.length(), g.input_length);
   EXPECT_EQ(input.length(), g.interpreted_length);
@@ -153,7 +150,7 @@ TEST_F(RimeSyllabifierTest, CaseChainingAmbiguity) {
 TEST_F(RimeSyllabifierTest, TransposedSyllableGraph) {
   rime::Syllabifier s;
   rime::SyllableGraph g;
-  const std::string input("changan");
+  const rime::string input("changan");
   s.BuildSyllableGraph(input, *prism_, &g);
   ASSERT_FALSE(g.indices.end() == g.indices.find(0));
   EXPECT_EQ(2, g.indices[0].size());

--- a/test/table_test.cc
+++ b/test/table_test.cc
@@ -32,15 +32,15 @@ class RimeTableTest : public ::testing::Test {
 
   static void PrepareSampleVocabulary(rime::Syllabary& syll,
                                       rime::Vocabulary& voc);
-  static std::string Text(const rime::TableAccessor& a) {
+  static rime::string Text(const rime::TableAccessor& a) {
     return table_->GetEntryText(*a.entry());
   }
-  static rime::unique_ptr<rime::Table> table_;
+  static rime::the<rime::Table> table_;
 };
 
 const char RimeTableTest::file_name[] = "table_test.bin";
 
-rime::unique_ptr<rime::Table> RimeTableTest::table_;
+rime::the<rime::Table> RimeTableTest::table_;
 
 void RimeTableTest::PrepareSampleVocabulary(rime::Syllabary& syll,
                                             rime::Vocabulary& voc) {
@@ -160,7 +160,7 @@ TEST_F(RimeTableTest, SimpleQuery) {
 }
 
 TEST_F(RimeTableTest, QueryWithSyllableGraph) {
-  const std::string input("yiersansi");
+  const rime::string input("yiersansi");
   rime::SyllableGraph g;
   g.input_length = input.length();
   g.interpreted_length = g.input_length;

--- a/test/user_db_test.cc
+++ b/test/user_db_test.cc
@@ -21,7 +21,7 @@ TEST(RimeUserDbTest, AccessRecordByKey) {
   EXPECT_TRUE(db.Update("abc", "ZYX"));
   EXPECT_TRUE(db.Update("zyx", "CBA"));
   EXPECT_TRUE(db.Update("zyx", "ABC"));
-  std::string value;
+  rime::string value;
   EXPECT_TRUE(db.Fetch("abc", &value));
   EXPECT_EQ("ZYX", value);
   value.clear();
@@ -49,10 +49,10 @@ TEST(RimeUserDbTest, Query) {
   EXPECT_TRUE(db.Update("zyx", "ABC"));
   EXPECT_TRUE(db.Update("wvu", "DEF"));
   {
-    rime::shared_ptr<rime::DbAccessor> accessor = db.Query("abc");
+    rime::a<rime::DbAccessor> accessor = db.Query("abc");
     ASSERT_TRUE(bool(accessor));
     EXPECT_FALSE(accessor->exhausted());
-    std::string key, value;
+    rime::string key, value;
     EXPECT_TRUE(accessor->GetNextRecord(&key, &value));
     EXPECT_EQ("abc", key);
     EXPECT_EQ("ZYX", value);
@@ -69,17 +69,17 @@ TEST(RimeUserDbTest, Query) {
     EXPECT_EQ("", value);
   }
   {
-    rime::shared_ptr<rime::DbAccessor> accessor = db.Query("wvu\tt");
+    rime::a<rime::DbAccessor> accessor = db.Query("wvu\tt");
     ASSERT_TRUE(bool(accessor));
     EXPECT_TRUE(accessor->exhausted());
-    std::string key, value;
+    rime::string key, value;
     EXPECT_FALSE(accessor->GetNextRecord(&key, &value));
   }
   {
-    rime::shared_ptr<rime::DbAccessor> accessor = db.Query("z");
+    rime::a<rime::DbAccessor> accessor = db.Query("z");
     ASSERT_TRUE(bool(accessor));
     EXPECT_FALSE(accessor->exhausted());
-    std::string key, value;
+    rime::string key, value;
     EXPECT_TRUE(accessor->GetNextRecord(&key, &value));
     EXPECT_EQ("zyx", key);
     EXPECT_EQ("ABC", value);

--- a/test/user_db_test.cc
+++ b/test/user_db_test.cc
@@ -51,7 +51,7 @@ TEST(RimeUserDbTest, Query) {
   EXPECT_TRUE(db.Update("zyx", "ABC"));
   EXPECT_TRUE(db.Update("wvu", "DEF"));
   {
-    a<DbAccessor> accessor = db.Query("abc");
+    an<DbAccessor> accessor = db.Query("abc");
     ASSERT_TRUE(bool(accessor));
     EXPECT_FALSE(accessor->exhausted());
     string key, value;
@@ -71,14 +71,14 @@ TEST(RimeUserDbTest, Query) {
     EXPECT_EQ("", value);
   }
   {
-    a<DbAccessor> accessor = db.Query("wvu\tt");
+    an<DbAccessor> accessor = db.Query("wvu\tt");
     ASSERT_TRUE(bool(accessor));
     EXPECT_TRUE(accessor->exhausted());
     string key, value;
     EXPECT_FALSE(accessor->GetNextRecord(&key, &value));
   }
   {
-    a<DbAccessor> accessor = db.Query("z");
+    an<DbAccessor> accessor = db.Query("z");
     ASSERT_TRUE(bool(accessor));
     EXPECT_FALSE(accessor->exhausted());
     string key, value;

--- a/test/user_db_test.cc
+++ b/test/user_db_test.cc
@@ -9,7 +9,9 @@
 #include <rime/dict/text_db.h>
 #include <rime/dict/user_db.h>
 
-using TestDb = rime::UserDbWrapper<rime::TextDb>;
+using namespace rime;
+
+using TestDb = UserDbWrapper<TextDb>;
 
 TEST(RimeUserDbTest, AccessRecordByKey) {
   TestDb db("user_db_test");
@@ -21,7 +23,7 @@ TEST(RimeUserDbTest, AccessRecordByKey) {
   EXPECT_TRUE(db.Update("abc", "ZYX"));
   EXPECT_TRUE(db.Update("zyx", "CBA"));
   EXPECT_TRUE(db.Update("zyx", "ABC"));
-  rime::string value;
+  string value;
   EXPECT_TRUE(db.Fetch("abc", &value));
   EXPECT_EQ("ZYX", value);
   value.clear();
@@ -49,10 +51,10 @@ TEST(RimeUserDbTest, Query) {
   EXPECT_TRUE(db.Update("zyx", "ABC"));
   EXPECT_TRUE(db.Update("wvu", "DEF"));
   {
-    rime::a<rime::DbAccessor> accessor = db.Query("abc");
+    a<DbAccessor> accessor = db.Query("abc");
     ASSERT_TRUE(bool(accessor));
     EXPECT_FALSE(accessor->exhausted());
-    rime::string key, value;
+    string key, value;
     EXPECT_TRUE(accessor->GetNextRecord(&key, &value));
     EXPECT_EQ("abc", key);
     EXPECT_EQ("ZYX", value);
@@ -69,17 +71,17 @@ TEST(RimeUserDbTest, Query) {
     EXPECT_EQ("", value);
   }
   {
-    rime::a<rime::DbAccessor> accessor = db.Query("wvu\tt");
+    a<DbAccessor> accessor = db.Query("wvu\tt");
     ASSERT_TRUE(bool(accessor));
     EXPECT_TRUE(accessor->exhausted());
-    rime::string key, value;
+    string key, value;
     EXPECT_FALSE(accessor->GetNextRecord(&key, &value));
   }
   {
-    rime::a<rime::DbAccessor> accessor = db.Query("z");
+    a<DbAccessor> accessor = db.Query("z");
     ASSERT_TRUE(bool(accessor));
     EXPECT_FALSE(accessor->exhausted());
-    rime::string key, value;
+    string key, value;
     EXPECT_TRUE(accessor->GetNextRecord(&key, &value));
     EXPECT_EQ("zyx", key);
     EXPECT_EQ("ABC", value);

--- a/tools/rime_console.cc
+++ b/tools/rime_console.cc
@@ -61,7 +61,7 @@ class RimeConsole {
     std::cout << "page_no: " << page_no
               << ", index: " << current.selected_index << std::endl;
     int i = 0;
-    for (const a<Candidate> &cand : page->candidates) {
+    for (const an<Candidate> &cand : page->candidates) {
       std::cout << "cand. " << (++i % 10) <<  ": [";
       std::cout << cand->text();
       std::cout << "]";

--- a/tools/rime_console.cc
+++ b/tools/rime_console.cc
@@ -25,13 +25,13 @@ class RimeConsole {
   RimeConsole() : interactive_(false),
                   engine_(rime::Engine::Create()) {
     conn_ = engine_->sink().connect(
-        [this](const std::string& x) { OnCommit(x); });
+        [this](const rime::string& x) { OnCommit(x); });
   }
   ~RimeConsole() {
     conn_.disconnect();
   }
 
-  void OnCommit(const std::string &commit_text) {
+  void OnCommit(const rime::string &commit_text) {
     if (interactive_) {
       std::cout << "commit : [" << commit_text << "]" << std::endl;
     }
@@ -53,14 +53,14 @@ class RimeConsole {
       return;
     int page_size = engine_->schema()->page_size();
     int page_no = current.selected_index / page_size;
-    rime::unique_ptr<rime::Page> page(
+    rime::the<rime::Page> page(
         current.menu->CreatePage(page_size, page_no));
     if (!page)
       return;
     std::cout << "page_no: " << page_no
               << ", index: " << current.selected_index << std::endl;
     int i = 0;
-    for (const rime::shared_ptr<rime::Candidate> &cand :
+    for (const rime::a<rime::Candidate> &cand :
                   page->candidates) {
       std::cout << "cand. " << (++i % 10) <<  ": [";
       std::cout << cand->text();
@@ -72,7 +72,7 @@ class RimeConsole {
     }
   }
 
-  void ProcessLine(const std::string &line) {
+  void ProcessLine(const rime::string &line) {
     rime::KeySequence keys;
     if (!keys.Parse(line)) {
       LOG(ERROR) << "error parsing input: '" << line << "'";
@@ -97,7 +97,7 @@ class RimeConsole {
 
  private:
   bool interactive_;
-  rime::unique_ptr<rime::Engine> engine_;
+  rime::the<rime::Engine> engine_;
   rime::connection conn_;
 };
 
@@ -127,7 +127,7 @@ int main(int argc, char *argv[]) {
   console.set_interactive(interactive);
 
   // process input
-  std::string line;
+  rime::string line;
   while (std::cin) {
     std::getline(std::cin, line);
     console.ProcessLine(line);

--- a/tools/rime_console.cc
+++ b/tools/rime_console.cc
@@ -20,18 +20,20 @@
 #include <rime/dict/dict_compiler.h>
 #include <rime/lever/deployment_tasks.h>
 
+using namespace rime;
+
 class RimeConsole {
  public:
   RimeConsole() : interactive_(false),
-                  engine_(rime::Engine::Create()) {
+                  engine_(Engine::Create()) {
     conn_ = engine_->sink().connect(
-        [this](const rime::string& x) { OnCommit(x); });
+        [this](const string& x) { OnCommit(x); });
   }
   ~RimeConsole() {
     conn_.disconnect();
   }
 
-  void OnCommit(const rime::string &commit_text) {
+  void OnCommit(const string &commit_text) {
     if (interactive_) {
       std::cout << "commit : [" << commit_text << "]" << std::endl;
     }
@@ -40,28 +42,26 @@ class RimeConsole {
     }
   }
 
-  void PrintComposition(const rime::Context *ctx) {
+  void PrintComposition(const Context *ctx) {
     if (!ctx || !ctx->IsComposing())
       return;
     std::cout << "input  : [" << ctx->input() << "]" << std::endl;
-    const rime::Composition &comp = ctx->composition();
+    const Composition &comp = ctx->composition();
     if (comp.empty())
       return;
     std::cout << "comp.  : [" << comp.GetDebugText() << "]" << std::endl;
-    const rime::Segment &current(comp.back());
+    const Segment &current(comp.back());
     if (!current.menu)
       return;
     int page_size = engine_->schema()->page_size();
     int page_no = current.selected_index / page_size;
-    rime::the<rime::Page> page(
-        current.menu->CreatePage(page_size, page_no));
+    the<Page> page(current.menu->CreatePage(page_size, page_no));
     if (!page)
       return;
     std::cout << "page_no: " << page_no
               << ", index: " << current.selected_index << std::endl;
     int i = 0;
-    for (const rime::a<rime::Candidate> &cand :
-                  page->candidates) {
+    for (const a<Candidate> &cand : page->candidates) {
       std::cout << "cand. " << (++i % 10) <<  ": [";
       std::cout << cand->text();
       std::cout << "]";
@@ -72,16 +72,16 @@ class RimeConsole {
     }
   }
 
-  void ProcessLine(const rime::string &line) {
-    rime::KeySequence keys;
+  void ProcessLine(const string &line) {
+    KeySequence keys;
     if (!keys.Parse(line)) {
       LOG(ERROR) << "error parsing input: '" << line << "'";
       return;
     }
-    for (const rime::KeyEvent &key : keys) {
+    for (const KeyEvent &key : keys) {
       engine_->ProcessKey(key);
     }
-    rime::Context *ctx = engine_->context();
+    Context *ctx = engine_->context();
     if (interactive_) {
       PrintComposition(ctx);
     }
@@ -97,24 +97,24 @@ class RimeConsole {
 
  private:
   bool interactive_;
-  rime::the<rime::Engine> engine_;
-  rime::connection conn_;
+  the<Engine> engine_;
+  connection conn_;
 };
 
 // program entry
 int main(int argc, char *argv[]) {
   // initialize la Rime
-  rime::SetupLogging("rime.console");
-  rime::LoadModules(rime::kDefaultModules);
+  SetupLogging("rime.console");
+  LoadModules(kDefaultModules);
 
-  rime::Deployer deployer;
-  rime::InstallationUpdate installation;
+  Deployer deployer;
+  InstallationUpdate installation;
   if (!installation.Run(&deployer)) {
     std::cerr << "failed to initialize installation." << std::endl;
     return 1;
   }
   std::cerr << "initializing...";
-  rime::WorkspaceUpdate workspace_update;
+  WorkspaceUpdate workspace_update;
   if (!workspace_update.Run(&deployer)) {
     std::cerr << "failure!" << std::endl;
     return 1;
@@ -127,7 +127,7 @@ int main(int argc, char *argv[]) {
   console.set_interactive(interactive);
 
   // process input
-  rime::string line;
+  string line;
   while (std::cin) {
     std::getline(std::cin, line);
     console.ProcessLine(line);

--- a/tools/rime_deployer.cc
+++ b/tools/rime_deployer.cc
@@ -11,21 +11,23 @@
 #include <rime/setup.h>
 #include <rime/lever/deployment_tasks.h>
 
+using namespace rime;
+
 int add_schema(int count, char* schemas[]) {
-  rime::Config config;
+  Config config;
   if (!config.LoadFromFile("default.custom.yaml")) {
     LOG(INFO) << "creating new file 'default.custom.yaml'.";
   }
-  rime::ConfigMapEntryRef schema_list(config["patch"]["schema_list"]);
+  ConfigMapEntryRef schema_list(config["patch"]["schema_list"]);
   for (int i = 0; i < count; ++i) {
     if (!schemas[i])
       return 1;
-    rime::string new_schema_id(schemas[i]);
+    string new_schema_id(schemas[i]);
     bool already_there = false;
     for (size_t j = 0; j < schema_list.size(); ++j) {
       if (!schema_list[j].HasKey("schema"))
         continue;
-      rime::string schema_id(schema_list[j]["schema"].ToString());
+      string schema_id(schema_list[j]["schema"].ToString());
       if (schema_id == new_schema_id) {
         already_there = true;
         break;
@@ -42,8 +44,8 @@ int add_schema(int count, char* schemas[]) {
   return 0;
 }
 
-int set_active_schema(const rime::string& schema_id) {
-  rime::Config config;
+int set_active_schema(const string& schema_id) {
+  Config config;
   if (!config.LoadFromFile("user.yaml")) {
     LOG(INFO) << "creating new file 'user.yaml'.";
   }
@@ -55,7 +57,7 @@ int set_active_schema(const rime::string& schema_id) {
   return 0;
 }
 
-static void configure_deployer(rime::Deployer* deployer,
+static void configure_deployer(Deployer* deployer,
                                int argc, char* argv[]) {
   if (argc > 0) {
     deployer->user_data_dir = argv[0];
@@ -69,7 +71,7 @@ static void configure_deployer(rime::Deployer* deployer,
 }
 
 int main(int argc, char* argv[]) {
-  rime::SetupLogging("rime.tools");
+  SetupLogging("rime.tools");
 
   if (argc == 1) {
     std::cout << "options:" << std::endl
@@ -81,15 +83,15 @@ int main(int argc, char* argv[]) {
     return 0;
   }
 
-  rime::string option;
+  string option;
   if (argc >= 2) option = argv[1];
   // shift
   argc -= 2, argv += 2;
 
   if (argc >= 0 && argc <= 2 && option == "--build") {
-    rime::Deployer& deployer(rime::Service::instance().deployer());
+    Deployer& deployer(Service::instance().deployer());
     configure_deployer(&deployer, argc, argv);
-    rime::WorkspaceUpdate update;
+    WorkspaceUpdate update;
     return update.Run(&deployer) ? 0 : 1;
   }
 
@@ -102,10 +104,10 @@ int main(int argc, char* argv[]) {
   }
 
   if (argc >= 1 && option == "--compile") {
-    rime::Deployer& deployer(rime::Service::instance().deployer());
+    Deployer& deployer(Service::instance().deployer());
     configure_deployer(&deployer, argc - 1, argv + 1);
-    rime::string schema_file(argv[0]);
-    rime::SchemaUpdate update(schema_file);
+    string schema_file(argv[0]);
+    SchemaUpdate update(schema_file);
     update.set_verbose(true);
     return update.Run(&deployer) ? 0 : 1;
   }

--- a/tools/rime_deployer.cc
+++ b/tools/rime_deployer.cc
@@ -5,7 +5,6 @@
 // 2012-07-07 GONG Chen <chen.sst@gmail.com>
 //
 #include <iostream>
-#include <string>
 #include <rime/config.h>
 #include <rime/deployer.h>
 #include <rime/service.h>
@@ -21,12 +20,12 @@ int add_schema(int count, char* schemas[]) {
   for (int i = 0; i < count; ++i) {
     if (!schemas[i])
       return 1;
-    std::string new_schema_id(schemas[i]);
+    rime::string new_schema_id(schemas[i]);
     bool already_there = false;
     for (size_t j = 0; j < schema_list.size(); ++j) {
       if (!schema_list[j].HasKey("schema"))
         continue;
-      std::string schema_id(schema_list[j]["schema"].ToString());
+      rime::string schema_id(schema_list[j]["schema"].ToString());
       if (schema_id == new_schema_id) {
         already_there = true;
         break;
@@ -43,7 +42,7 @@ int add_schema(int count, char* schemas[]) {
   return 0;
 }
 
-int set_active_schema(const std::string& schema_id) {
+int set_active_schema(const rime::string& schema_id) {
   rime::Config config;
   if (!config.LoadFromFile("user.yaml")) {
     LOG(INFO) << "creating new file 'user.yaml'.";
@@ -82,7 +81,7 @@ int main(int argc, char* argv[]) {
     return 0;
   }
 
-  std::string option;
+  rime::string option;
   if (argc >= 2) option = argv[1];
   // shift
   argc -= 2, argv += 2;
@@ -105,7 +104,7 @@ int main(int argc, char* argv[]) {
   if (argc >= 1 && option == "--compile") {
     rime::Deployer& deployer(rime::Service::instance().deployer());
     configure_deployer(&deployer, argc - 1, argv + 1);
-    std::string schema_file(argv[0]);
+    rime::string schema_file(argv[0]);
     rime::SchemaUpdate update(schema_file);
     update.set_verbose(true);
     return update.Run(&deployer) ? 0 : 1;

--- a/tools/rime_dict_manager.cc
+++ b/tools/rime_dict_manager.cc
@@ -13,11 +13,13 @@
 #include <rime/dict/user_db.h>
 #include <rime/lever/user_dict_manager.h>
 
-int main(int argc, char *argv[]) {
-  rime::SetupLogging("rime.tools");
+using namespace rime;
 
-  rime::string option;
-  rime::string arg1, arg2;
+int main(int argc, char *argv[]) {
+  SetupLogging("rime.tools");
+
+  string option;
+  string arg1, arg2;
   if (argc >= 2) option = argv[1];
   if (argc >= 3) arg1 = argv[2];
   if (argc >= 4) arg2 = argv[3];
@@ -33,25 +35,25 @@ int main(int argc, char *argv[]) {
     return 0;
   }
 
-  rime::Registry& registry = rime::Registry::instance();
-  registry.Register("userdb", new rime::UserDbComponent<rime::LevelDb>);
-  rime::Deployer& deployer(rime::Service::instance().deployer());
+  Registry& registry = Registry::instance();
+  registry.Register("userdb", new UserDbComponent<LevelDb>);
+  Deployer& deployer(Service::instance().deployer());
   {
-    rime::Config config;
+    Config config;
     if (config.LoadFromFile("installation.yaml")) {
       config.GetString("installation_id", &deployer.user_id);
       config.GetString("sync_dir", &deployer.sync_dir);
     }
   }
-  rime::UserDictManager mgr(&deployer);
+  UserDictManager mgr(&deployer);
   if (argc == 2 && (option == "-l" || option == "--list")) {
-    rime::UserDictList list;
+    UserDictList list;
     mgr.GetUserDictList(&list);
     if (list.empty()) {
       std::cerr << "no user dictionary is found." << std::endl;
       return 0;
     }
-    for (const rime::string& e : list) {
+    for (const string& e : list) {
       std::cout << e << std::endl;
     }
     return 0;

--- a/tools/rime_dict_manager.cc
+++ b/tools/rime_dict_manager.cc
@@ -5,7 +5,6 @@
 // 2012-03-24 GONG Chen <chen.sst@gmail.com>
 //
 #include <iostream>
-#include <string>
 #include <rime/config.h>
 #include <rime/deployer.h>
 #include <rime/service.h>
@@ -17,8 +16,8 @@
 int main(int argc, char *argv[]) {
   rime::SetupLogging("rime.tools");
 
-  std::string option;
-  std::string arg1, arg2;
+  rime::string option;
+  rime::string arg1, arg2;
   if (argc >= 2) option = argv[1];
   if (argc >= 3) arg1 = argv[2];
   if (argc >= 4) arg2 = argv[3];
@@ -52,7 +51,7 @@ int main(int argc, char *argv[]) {
       std::cerr << "no user dictionary is found." << std::endl;
       return 0;
     }
-    for (const std::string& e : list) {
+    for (const rime::string& e : list) {
       std::cout << e << std::endl;
     }
     return 0;

--- a/tools/rime_patch.cc
+++ b/tools/rime_patch.cc
@@ -14,9 +14,10 @@
 //   rime_patch default schema_list '[{schema: luna_pinyin}]'
 //   rime_patch default schema_list  # read yaml from stdin
 
+using namespace rime;
 
-int apply_patch(const rime::string& config_id,
-                const rime::string& key, const rime::string& yaml) {
+int apply_patch(const string& config_id,
+                const string& key, const string& yaml) {
   RimeApi* rime = rime_get_api();
   RimeModule* module = rime->find_module("levers");
   if (!module) {
@@ -64,9 +65,9 @@ int main(int argc, char *argv[]) {
 
   rime->deployer_initialize(&traits);
 
-  rime::string config_id(argv[1]);
-  rime::string key(argv[2]);
-  rime::string yaml;
+  string config_id(argv[1]);
+  string key(argv[2]);
+  string yaml;
   if (argc > 3) {
     yaml.assign(argv[3]);
   }

--- a/tools/rime_patch.cc
+++ b/tools/rime_patch.cc
@@ -2,9 +2,9 @@
 // Foodgen <chen.sst@gmail.com>
 //
 #include <iostream>
-#include <string>
 #include <rime_api.h>
 #include <rime_levers_api.h>
+#include <rime/common.h>
 
 // usage:
 //   rime_patch config_id key [yaml]
@@ -15,8 +15,8 @@
 //   rime_patch default schema_list  # read yaml from stdin
 
 
-int apply_patch(const std::string& config_id,
-                const std::string& key, const std::string& yaml) {
+int apply_patch(const rime::string& config_id,
+                const rime::string& key, const rime::string& yaml) {
   RimeApi* rime = rime_get_api();
   RimeModule* module = rime->find_module("levers");
   if (!module) {
@@ -64,9 +64,9 @@ int main(int argc, char *argv[]) {
 
   rime->deployer_initialize(&traits);
 
-  std::string config_id(argv[1]);
-  std::string key(argv[2]);
-  std::string yaml;
+  rime::string config_id(argv[1]);
+  rime::string key(argv[2]);
+  rime::string yaml;
   if (argc > 3) {
     yaml.assign(argv[3]);
   }


### PR DESCRIPTION
This change is intended to make code in librime concise while being more readable,
by removing namespace qualifiers `std::` (for most frequently used types) and `rime::`,
and by shortening template names `shared_ptr<T>` to `an<T>` or `of<T>`, `unique_ptr<T>` to `the<T>`.