### PR TITLE
Do not auto-clean the cache of thirdparty modules.

### DIFF
--- a/Makefile.xcode
+++ b/Makefile.xcode
@@ -23,7 +23,6 @@ clean:
 
 thirdparty:
 	$(RIME_COMPILER_OPTIONS) make -f Makefile.thirdparty
-	make -f Makefile.thirdparty clean-src
 
 thirdparty/%:
 	make -f Makefile.thirdparty $(@:thirdparty/%=%)


### PR DESCRIPTION
When third-party modules fail to compile, we might have to clean them manually.