### PR TITLE
Set up Appveyor CI for Windows platform

### DIFF
--- a/appveyor.install.bat
+++ b/appveyor.install.bat
@@ -1,0 +1,30 @@
+setlocal
+
+set nocache=0
+
+if exist thirdparty.cached (
+	echo.
+	echo Last build date of cache is
+	type thirdparty.cached
+	echo.
+) else set nocache=1
+
+if not exist %BOOST_ROOT% set nocache=1
+
+if %nocache% == 1 (
+	rmdir /s /q %BOOST_ROOT%
+	pushd C:\Libraries\boost_1_59_0
+	call .\bootstrap
+	call .\b2 --prefix=%BOOST_ROOT% toolset=msvc-12.0 variant=release link=static threading=multi runtime-link=static --with-date_time --with-filesystem --with-system --with-regex --with-signals --with-thread --with-locale -q -d0 install
+	xcopy /e /i /y %BOOST_ROOT%\include\boost-1_59\boost %BOOST_ROOT%\boost > nul
+	popd
+)
+
+if %nocache% == 1 (
+	call .\build.bat thirdparty
+	date /t > thirdparty.cached & time /t >> thirdparty.cached
+	echo.
+	echo Thirdparty libraries installed.
+	echo.
+)
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,45 @@
+skip_tags: true
+clone_depth: 1
+pull_requests:
+  do_not_increment_build_number: true
+
+version: '{branch} build {build}'
+image: Visual Studio 2013
+
+environment:
+  BOOST_ROOT: C:\Libraries\boost
+
+cache:
+  - thirdparty.cached -> appveyor.install.bat
+  - thirdparty\bin -> appveyor.install.bat
+  - thirdparty\data -> appveyor.install.bat
+  - thirdparty\include -> appveyor.install.bat
+  - thirdparty\lib -> appveyor.install.bat
+  - C:\Libraries\boost -> appveyor.install.bat
+
+init:
+  - git --version
+  - cmake --version
+  - msbuild /version
+  - git config --global core.autocrlf true
+
+install:
+  - call .\appveyor.install.bat
+
+build:
+  parallel: true
+  verbosity: minimal
+
+build_script:
+  - call .\build.bat test
+
+after_build:
+  - dir build /s
+
+before_test:
+  - copy /y build\lib\Release\rime.dll build\bin
+  - copy /y thirdparty\bin\*.dll build\bin
+
+test_script:
+  - cd build\bin
+  - echo "congmingdeRime{space}shurufa" | Release\rime_api_console

--- a/build.bat
+++ b/build.bat
@@ -89,7 +89,7 @@ if %build_thirdparty% == 1 (
   echo building leveldb.
   cd %THIRDPARTY%\src\
   echo "checking out 'windows' branch from %LEVELDB_REPOSITORY%"
-  git clone -b windows git@github.com:%LEVELDB_REPOSITORY%.git leveldb-windows
+  git clone -b windows git://github.com/%LEVELDB_REPOSITORY%.git leveldb-windows
   if %ERRORLEVEL% NEQ 0 goto ERROR
   cd leveldb-windows
   echo BOOST_ROOT=%BOOST_ROOT%
@@ -197,11 +197,13 @@ echo.
 goto EXIT
 
 :ERROR
+set EXITCODE=%ERRORLEVEL%
 echo.
 echo error building la rime.
 echo.
 
 :EXIT
 set PATH=%OLD_PATH%
-cd %RIME_ROOT%
+cd %BACK%
 rem pause
+exit /b %EXITCODE%


### PR DESCRIPTION
[![Build status](https://ci.appveyor.com/api/projects/status/hljcqan6416uakiw/branch/appveyor-ci?svg=true)](https://ci.appveyor.com/project/jakwings/librime/branch/appveyor-ci)

It is a time-consuming task:

* [build without caching thirdparty libraries](https://ci.appveyor.com/project/jakwings/librime/build/appveyor-ci%20build%209): ~25 minutes
* [build with cache](https://ci.appveyor.com/project/jakwings/librime/build/appveyor-ci%20build%2010): ~12 minutes