### PR TITLE
Add includes and OpenCC data into AppVeyor CI artifacts.

### DIFF
--- a/appveyor.install.bat
+++ b/appveyor.install.bat
@@ -7,7 +7,7 @@ if not exist %BOOST_ROOT% set nocache=1
 
 if %nocache% == 1 (
 	pushd C:\Libraries
-	curl -fsSO http://superb-sea2.dl.sourceforge.net/project/boost/boost/1.61.0/boost_1_61_0.7z
+	appveyor DownloadFile http://superb-sea2.dl.sourceforge.net/project/boost/boost/1.61.0/boost_1_61_0.7z
 	7z x boost_1_61_0.7z | find "ing archive"
 	cd boost_1_61_0
 	call .\bootstrap.bat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ build_script:
   - .\build.bat test
 
 after_build:
-  - 7z a rime.zip %CD%\build\bin %CD%\build\lib
+  - 7z a rime.zip build\bin build\lib include thirdparty\data\opencc
   - dir build /s
 
 before_test:
@@ -42,4 +42,4 @@ test_script:
 
 artifacts:
   - path: rime.zip
-    name: Binaries
+    name: Binaries, includes and OpenCC data


### PR DESCRIPTION
* Now artifacts consists of minimal files needed for Weasel build.
* Use `appveyor DownloadFile` instead of curl, since curl on AppVeyor doesn't support HTTPS.