### PR TITLE
config: support append and merge syntax

### DIFF
--- a/data/test/config_compiler_test.yaml
+++ b/data/test/config_compiler_test.yaml
@@ -33,54 +33,11 @@ patch_list:
     - protoss/ground_units/@next: dark templar
     - protoss/ground_units/@next: dark archon
 
-dependency_chaining:
-  alpha:
-    __include: /dependency_chaining/beta
-  beta:
-    __include: /dependency_chaining/epsilon
-  delta:
-    __include: /dependency_chaining/beta
-  epsilon: success
-
-dependency_priorities:
-  terrans:
-    __include: /starcraft/terrans
-    __patch:
-      player: nada
-  protoss:
-    __patch:
-      player: bisu
-    __include: /starcraft/protoss
-
-optional_reference:
-  __include: nonexistent.yaml:/?
-  __patch:
-    - local/nonexistent_patch?
-    - config_test:/nonexistent_patch?
-    - nonexistent:/patch?
-  untouched: true
+# data for testing
 
 local:
   patch:
     battlefields/@next: match point
 
 starcraft:
-  terrans:
-    player: slayers_boxer
-  protoss:
-    ground_units:
-      - probe
-      - zealot
-      - dragoon
-      - high templar
-      - archon
-      - reaver
-    player: grrrr
-  zerg:
-    ground_units:
-      - drone
-      - zergling
-      - hydralisk
-      - ultralisk
-      - defiler
-    player: yellow
+  __include: starcraft:/

--- a/data/test/config_dependency_test.yaml
+++ b/data/test/config_dependency_test.yaml
@@ -1,0 +1,20 @@
+# tests for ConfigCompiler features
+
+dependency_chaining:
+  alpha:
+    __include: /dependency_chaining/beta
+  beta:
+    __include: /dependency_chaining/epsilon
+  delta:
+    __include: /dependency_chaining/beta
+  epsilon: success
+
+dependency_priorities:
+  terrans:
+    __include: starcraft:/terrans
+    __patch:
+      player: nada
+  protoss:
+    __patch:
+      player: bisu
+    __include: starcraft:/protoss

--- a/data/test/config_merge_test.yaml
+++ b/data/test/config_merge_test.yaml
@@ -1,0 +1,48 @@
+# tests for ConfigCompiler features
+
+starcraft:
+  __include: starcraft:/
+
+append_with_include:
+  list:
+    __include: starcraft/protoss/ground_units
+    __append:
+      - dark templar
+      - dark archon
+
+append_with_patch:
+  __include: starcraft
+  __patch:
+    # append to string
+    terrans/player/+: ', nada'
+    # append to empty list
+    terrans/air_units/+:
+      - wraith
+      - battlecruiser
+    # append to existing list
+    protoss/ground_units/+:
+      - dark templar
+      - dark archon
+
+merge_tree:
+  __include: starcraft
+  # merge tree triggered by `__include`
+  terrans:
+    ground_units:
+      - scv
+      - marine
+      - firebat
+      - vulture
+      - tank
+    # patch `/merge_tree/terrans` before merging
+    __patch:
+      # append with `__patch`
+      ground_units/+:
+      - medic
+      - goliath
+  protoss:
+    # append to exising list, alternative syntax
+    ground_units: {__append: [dark templar, dark archon]}
+  zerg:
+    # overwrite existing list
+    ground_units: []

--- a/data/test/config_optional_reference_test.yaml
+++ b/data/test/config_optional_reference_test.yaml
@@ -1,0 +1,8 @@
+# tests for ConfigCompiler features
+
+__include: nonexistent.yaml:/?
+__patch:
+  - local/nonexistent_patch?
+  - config_test:/nonexistent_patch?
+  - nonexistent:/patch?
+untouched: true

--- a/data/test/starcraft.yaml
+++ b/data/test/starcraft.yaml
@@ -1,0 +1,22 @@
+# incomplete knowledge base of starcraft, for testing the config component
+# no special syntax, internal/external references
+
+terrans:
+  player: slayers_boxer
+protoss:
+  ground_units:
+    - probe
+    - zealot
+    - dragoon
+    - high templar
+    - archon
+    - reaver
+  player: grrrr
+zerg:
+  ground_units:
+    - drone
+    - zergling
+    - hydralisk
+    - ultralisk
+    - defiler
+  player: yellow

--- a/src/rime/config/config_compiler.h
+++ b/src/rime/config/config_compiler.h
@@ -43,6 +43,8 @@ class ConfigCompiler {
  public:
   static constexpr const char* INCLUDE_DIRECTIVE = "__include";
   static constexpr const char* PATCH_DIRECTIVE = "__patch";
+  static constexpr const char* APPEND_DIRECTIVE = "__append";
+  static constexpr const char* MERGE_DIRECTIVE = "__merge";
 
   explicit ConfigCompiler(ResourceResolver* resource_resolver);
   virtual ~ConfigCompiler();

--- a/src/rime/config/config_types.h
+++ b/src/rime/config/config_types.h
@@ -22,6 +22,10 @@ class ConfigItem {
 
   ValueType type() const { return type_; }
 
+  virtual bool empty() const {
+    return type_ == kNull;
+  }
+
  protected:
   ConfigItem(ValueType type) : type_(type) {}
 
@@ -50,6 +54,10 @@ class ConfigValue : public ConfigItem {
 
   const string& str() const { return value_; }
 
+  bool empty() const override {
+    return value_.empty();
+  }
+
  protected:
   string value_;
 };
@@ -72,6 +80,10 @@ class ConfigList : public ConfigItem {
   Iterator begin();
   Iterator end();
 
+  bool empty() const override {
+    return seq_.empty();
+  }
+
  protected:
   Sequence seq_;
 };
@@ -91,6 +103,10 @@ class ConfigMap : public ConfigItem {
 
   Iterator begin();
   Iterator end();
+
+  bool empty() const override {
+    return map_.empty();
+  }
 
  protected:
   Map map_;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,12 +8,8 @@ target_link_libraries(rime_test
                       ${GTEST_LIBRARIES})
 add_dependencies(rime_test ${rime_library} ${rime_gears_library})
 
-file(COPY ${PROJECT_SOURCE_DIR}/data/test/config_test.yaml
-     DESTINATION ${EXECUTABLE_OUTPUT_PATH})
-file(COPY ${PROJECT_SOURCE_DIR}/data/test/config_compiler_test.yaml
-     DESTINATION ${EXECUTABLE_OUTPUT_PATH})
-file(COPY ${PROJECT_SOURCE_DIR}/data/test/dictionary_test.dict.yaml
-     DESTINATION ${EXECUTABLE_OUTPUT_PATH})
+file(GLOB test_data_files ${PROJECT_SOURCE_DIR}/data/test/*.yaml)
+file(COPY ${test_data_files} DESTINATION ${EXECUTABLE_OUTPUT_PATH})
 
 set(rime_test_executable ${EXECUTABLE_OUTPUT_PATH}/rime_test${ext})
 add_test(rime_test ${rime_test_executable})


### PR DESCRIPTION
usage:

```yaml
# sample config to showcase __append and __merge syntax

schema_list:
  # include a list
  __include: default:/schema_list
  # append to the list
  __append:
    - excited
    - too young

punctuator:
  __include: default:/punctuator
  # merged with defaults and override some values
  half_shape: # '/+' is optional after a key in merged map
    '.' : '.'
    '-' : ['-', '--'] # overwriting
    '*' : {__append: ['*-*', '*<*>*']}

key_binder:
  __include: default:/key_binder
  bindings/+: # '/+' is required for appending to a list
      - {key: one more}
      - {key: two more}

__patch:
  # appending is supported also in patch keys
  schema_list/+:
    - sometimes
    - naive
  # merging to a map
  punctuator/half_shape/+:
    '.' : '...'
  # clearing the map. '/=' is optional in patch keys
  punctuator/full_shape/=: {}
  # overwriting a list
  key_binder/bindings:
      - {key: the only one}
```