### PR TITLE
feat(config): config compiler plugins for auto-patching and supporting legacy import_preset syntax

### DIFF
--- a/src/rime/config/auto_patch_config_plugin.cc
+++ b/src/rime/config/auto_patch_config_plugin.cc
@@ -1,0 +1,42 @@
+//
+// Copyright RIME Developers
+// Distributed under the BSD License
+//
+#include <boost/algorithm/string.hpp>
+#include <rime/config/config_compiler_impl.h>
+#include <rime/config/plugins.h>
+
+namespace rime {
+
+static string remove_suffix(const string& input, const string& suffix) {
+  return boost::ends_with(input, suffix) ?
+      input.substr(0, input.length() - suffix.length()) : input;
+}
+
+// auto-patch applies to all loaded config resources, including dependencies.
+// therefore it's done at the end of Compile phase.
+bool AutoPatchConfigPlugin::ReviewCompileOutput(ConfigCompiler* compiler,
+                                                an<ConfigResource> resource) {
+  if (boost::ends_with(resource->resource_id, ".custom"))
+    return true;
+  // skip auto-patch if there is already an explicit `__patch` at the root node
+  auto root_deps = compiler->GetDependencies(resource->resource_id + ":");
+  if (!root_deps.empty() && root_deps.back()->priority() >= kPatch)
+    return true;
+  auto patch_resource_id =
+      remove_suffix(resource->resource_id, ".schema") + ".custom";
+  LOG(INFO) << "auto-patch " << resource->resource_id << ":/__patch: "
+            << patch_resource_id << ":/patch?";
+  compiler->Push(resource);
+  compiler->AddDependency(
+      New<PatchReference>(Reference{patch_resource_id, "patch", true}));
+  compiler->Pop();
+  return true;
+}
+
+bool AutoPatchConfigPlugin::ReviewLinkOutput(ConfigCompiler* compiler,
+                                             an<ConfigResource> resource) {
+  return true;
+}
+
+}  // namespace rime

--- a/src/rime/config/config_compiler.cc
+++ b/src/rime/config/config_compiler.cc
@@ -2,99 +2,11 @@
 #include <rime/common.h>
 #include <rime/resource.h>
 #include <rime/config/config_compiler.h>
+#include <rime/config/config_compiler_impl.h>
 #include <rime/config/config_data.h>
 #include <rime/config/config_types.h>
 
 namespace rime {
-
-enum DependencyPriority {
-  kPendingChild = 0,
-  kInclude = 1,
-  kPatch = 2,
-};
-
-struct Dependency {
-  an<ConfigItemRef> target;
-
-  virtual DependencyPriority priority() const = 0;
-  bool blocking() const {
-    return priority() > kPendingChild;
-  }
-  virtual string repr() const = 0;
-  virtual bool Resolve(ConfigCompiler* compiler) = 0;
-};
-
-template <class StreamT>
-StreamT& operator<< (StreamT& stream, const Dependency& dep) {
-  return stream << dep.repr();
-}
-
-struct PendingChild : Dependency {
-  string child_path;
-  an<ConfigItemRef> child_ref;
-
-  PendingChild(const string& path, const an<ConfigItemRef>& ref)
-      : child_path(path), child_ref(ref) {
-  }
-  DependencyPriority priority() const override {
-    return kPendingChild;
-  }
-  string repr() const override {
-    return "PendingChild(" + child_path + ")";
-  }
-  bool Resolve(ConfigCompiler* compiler) override;
-};
-
-string Reference::repr() const {
-  return resource_id + ":" + local_path + (optional ? " <optional>" : "");
-}
-
-template <class StreamT>
-StreamT& operator<< (StreamT& stream, const Reference& reference) {
-  return stream << reference.repr();
-}
-
-struct IncludeReference : Dependency {
-  IncludeReference(const Reference& r) : reference(r) {
-  }
-  DependencyPriority priority() const override {
-    return kInclude;
-  }
-  string repr() const override {
-    return "Include(" + reference.repr() + ")";
-  }
-  bool Resolve(ConfigCompiler* compiler) override;
-
-  Reference reference;
-};
-
-struct PatchReference : Dependency {
-  PatchReference(const Reference& r) : reference(r) {
-  }
-  DependencyPriority priority() const override {
-    return kPatch;
-  }
-  string repr() const override {
-    return "Patch(" + reference.repr() + ")";
-  }
-  bool Resolve(ConfigCompiler* compiler) override;
-
-  Reference reference;
-};
-
-struct PatchLiteral : Dependency {
-  an<ConfigMap> patch;
-
-  PatchLiteral(an<ConfigMap> map) : patch(map) {
-  }
-  DependencyPriority priority() const override {
-    return kPatch;
-  }
-  string repr() const override {
-    return "Patch(<literal>)";
-  }
-  bool Resolve(ConfigCompiler* compiler) override;
-};
 
 struct ConfigDependencyGraph {
   map<string, of<ConfigResource>> resources;
@@ -114,11 +26,17 @@ struct ConfigDependencyGraph {
     key_stack.pop_back();
   }
 
-  string current_resource_id() const {
-    return key_stack.empty() ? string()
-        : boost::trim_right_copy_if(key_stack.front(), boost::is_any_of(":"));
-  }
+  string current_resource_id() const;
 };
+
+string ConfigDependencyGraph::current_resource_id() const {
+  return key_stack.empty() ? string()
+      : boost::trim_right_copy_if(key_stack.front(), boost::is_any_of(":"));
+}
+
+string Reference::repr() const {
+  return resource_id + ":" + local_path + (optional ? " <optional>" : "");
+}
 
 bool PendingChild::Resolve(ConfigCompiler* compiler) {
   return compiler->ResolveDependencies(child_path);
@@ -156,8 +74,7 @@ bool PatchReference::Resolve(ConfigCompiler* compiler) {
     return false;
   }
   PatchLiteral patch{As<ConfigMap>(item)};
-  patch.target = target;
-  return patch.Resolve(compiler);
+  return patch.TargetedAt(target).Resolve(compiler);
 }
 
 static bool AppendToString(an<ConfigItemRef> target, an<ConfigValue> value) {
@@ -294,7 +211,7 @@ void ConfigDependencyGraph::Add(an<Dependency> dependency) {
              << node_stack.size();
   if (node_stack.empty()) return;
   const auto& target = node_stack.back();
-  dependency->target = target;
+  dependency->TargetedAt(target);
   auto target_path = ConfigData::JoinPath(key_stack);
   auto& target_deps = deps[target_path];
   bool target_was_pending = !target_deps.empty();
@@ -353,6 +270,10 @@ void ConfigCompiler::AddDependency(an<Dependency> dependency) {
   graph_->Add(dependency);
 }
 
+void ConfigCompiler::Push(an<ConfigResource> resource) {
+  graph_->Push(resource, resource->resource_id + ":");
+}
+
 void ConfigCompiler::Push(an<ConfigList> config_list, size_t index) {
   graph_->Push(
       New<ConfigListEntryRef>(nullptr, config_list, index),
@@ -378,10 +299,10 @@ an<ConfigResource> ConfigCompiler::Compile(const string& file_name) {
   auto resource_id = resource_resolver_->ToResourceId(file_name);
   auto resource = New<ConfigResource>(resource_id, New<ConfigData>());
   graph_->resources[resource_id] = resource;
-  graph_->Push(resource, resource_id + ":");
+  Push(resource);
   resource->loaded = resource->data->LoadFromFile(
       resource_resolver_->ResolvePath(resource_id).string(), this);
-  graph_->Pop();
+  Pop();
   return resource;
 }
 
@@ -460,6 +381,11 @@ bool ConfigCompiler::pending(const string& full_path) const {
 bool ConfigCompiler::resolved(const string& full_path) const {
   auto found = graph_->deps.find(full_path);
   return found == graph_->deps.end() || found->second.empty();
+}
+
+vector<of<Dependency>> ConfigCompiler::GetDependencies(const string& path) {
+  auto found = graph_->deps.find(path);
+  return found == graph_->deps.end() ? vector<of<Dependency>>() : found->second;
 }
 
 static an<ConfigItem> ResolveReference(ConfigCompiler* compiler,

--- a/src/rime/config/config_compiler.cc
+++ b/src/rime/config/config_compiler.cc
@@ -140,7 +140,7 @@ inline static bool IsMerging(const string& key,
                              bool merge_tree) {
   return key == ConfigCompiler::MERGE_DIRECTIVE ||
       boost::ends_with(key, ADD_SUFFIX_OPERATOR) ||
-      (merge_tree && Is<ConfigMap>(value) &&
+      (merge_tree && (!value || Is<ConfigMap>(value)) &&
        !boost::ends_with(key, EQU_SUFFIX_OPERATOR));
 }
 

--- a/src/rime/config/config_compiler.h
+++ b/src/rime/config/config_compiler.h
@@ -51,6 +51,7 @@ class ConfigCompiler {
 
   Reference CreateReference(const string& qualified_path);
   void AddDependency(an<Dependency> dependency);
+  void Push(an<ConfigResource> resource);
   void Push(an<ConfigList> config_list, size_t index);
   void Push(an<ConfigMap> config_map, const string& key);
   bool Parse(const string& key, const an<ConfigItem>& item);
@@ -63,6 +64,7 @@ class ConfigCompiler {
   bool blocking(const string& full_path) const;
   bool pending(const string& full_path) const;
   bool resolved(const string& full_path) const;
+  vector<of<Dependency>> GetDependencies(const string& path);
   bool ResolveDependencies(const string& path);
 
  private:

--- a/src/rime/config/config_compiler.h
+++ b/src/rime/config/config_compiler.h
@@ -35,6 +35,7 @@ struct Reference {
   string repr() const;
 };
 
+class ConfigCompilerPlugin;
 class ResourceResolver;
 struct Dependency;
 struct ConfigDependencyGraph;
@@ -46,7 +47,8 @@ class ConfigCompiler {
   static constexpr const char* APPEND_DIRECTIVE = "__append";
   static constexpr const char* MERGE_DIRECTIVE = "__merge";
 
-  explicit ConfigCompiler(ResourceResolver* resource_resolver);
+  ConfigCompiler(ResourceResolver* resource_resolver,
+                 ConfigCompilerPlugin* plugin);
   virtual ~ConfigCompiler();
 
   Reference CreateReference(const string& qualified_path);
@@ -69,6 +71,7 @@ class ConfigCompiler {
 
  private:
   ResourceResolver* resource_resolver_;
+  ConfigCompilerPlugin* plugin_;
   the<ConfigDependencyGraph> graph_;
 };
 

--- a/src/rime/config/config_compiler_impl.h
+++ b/src/rime/config/config_compiler_impl.h
@@ -1,0 +1,100 @@
+//
+// Copyright RIME Developers
+// Distributed under the BSD License
+//
+#ifndef RIME_CONFIG_COMPILER_IMPL_H_
+#define RIME_CONFIG_COMPILER_IMPL_H_
+
+#include <rime/common.h>
+#include <rime/config/config_compiler.h>
+#include <rime/config/config_types.h>
+
+namespace rime {
+
+enum DependencyPriority {
+  kPendingChild = 0,
+  kInclude = 1,
+  kPatch = 2,
+};
+
+struct Dependency {
+  an<ConfigItemRef> target;
+
+  virtual DependencyPriority priority() const = 0;
+  bool blocking() const {
+    return priority() > kPendingChild;
+  }
+  virtual string repr() const = 0;
+  Dependency& TargetedAt(an<ConfigItemRef> target) {
+    this->target = target;
+    return *this;
+  }
+  virtual bool Resolve(ConfigCompiler* compiler) = 0;
+};
+
+template <class StreamT, class RepresentableT>
+StreamT& operator<< (StreamT& stream, const RepresentableT& representable) {
+  return stream << representable.repr();
+}
+
+struct PendingChild : Dependency {
+  string child_path;
+  an<ConfigItemRef> child_ref;
+
+  PendingChild(const string& path, const an<ConfigItemRef>& ref)
+      : child_path(path), child_ref(ref) {
+  }
+  DependencyPriority priority() const override {
+    return kPendingChild;
+  }
+  string repr() const override {
+    return "PendingChild(" + child_path + ")";
+  }
+  bool Resolve(ConfigCompiler* compiler) override;
+};
+
+struct IncludeReference : Dependency {
+  Reference reference;
+
+  IncludeReference(const Reference& r) : reference(r) {
+  }
+  DependencyPriority priority() const override {
+    return kInclude;
+  }
+  string repr() const override {
+    return "Include(" + reference.repr() + ")";
+  }
+  bool Resolve(ConfigCompiler* compiler) override;
+};
+
+struct PatchReference : Dependency {
+  Reference reference;
+
+  PatchReference(const Reference& r) : reference(r) {
+  }
+  DependencyPriority priority() const override {
+    return kPatch;
+  }
+  string repr() const override {
+    return "Patch(" + reference.repr() + ")";
+  }
+  bool Resolve(ConfigCompiler* compiler) override;
+};
+
+struct PatchLiteral : Dependency {
+  an<ConfigMap> patch;
+
+  PatchLiteral(an<ConfigMap> map) : patch(map) {
+  }
+  DependencyPriority priority() const override {
+    return kPatch;
+  }
+  string repr() const override {
+    return "Patch(<literal>)";
+  }
+  bool Resolve(ConfigCompiler* compiler) override;
+};
+
+}  // namespace rime
+
+#endif  // RIME_CONFIG_COMPILER_IMPL_H_

--- a/src/rime/config/config_component.h
+++ b/src/rime/config/config_component.h
@@ -63,18 +63,24 @@ class Config : public Class<Config, const string&>, public ConfigItemRef {
   void SetItem(an<ConfigItem> item);
 };
 
+class ConfigCompiler;
+class ConfigCompilerPlugin;
 class ResourceResolver;
+struct ConfigResource;
 
 class ConfigComponent : public Config::Component {
  public:
   ConfigComponent();
   ~ConfigComponent();
   Config* Create(const string& file_name);
+  void InstallPlugin(ConfigCompilerPlugin *plugin);
+  bool ApplyPlugins(ConfigCompiler* compiler, an<ConfigResource> resource);
 
 private:
   an<ConfigData> GetConfigData(const string& file_name);
   map<string, weak<ConfigData>> cache_;
   the<ResourceResolver> resource_resolver_;
+  vector<the<ConfigCompilerPlugin>> plugins_;
 };
 
 }  // namespace rime

--- a/src/rime/config/config_cow_ref.h
+++ b/src/rime/config/config_cow_ref.h
@@ -1,0 +1,91 @@
+//
+// Copyright RIME Developers
+// Distributed under the BSD License
+//
+
+#ifndef RIME_CONFIG_COW_REF_H_
+#define RIME_CONFIG_COW_REF_H_
+
+#include <rime/common.h>
+#include <rime/config/config_data.h>
+#include <rime/config/config_types.h>
+
+namespace rime {
+
+template <class T>
+class ConfigCowRef : public ConfigItemRef {
+ public:
+  ConfigCowRef(an<ConfigItemRef> parent, string key)
+      : ConfigItemRef(nullptr), parent_(parent), key_(key) {
+  }
+  an<ConfigItem> GetItem() const override {
+    auto container = As<T>(**parent_);
+    return container ? Read(container, key_) : nullptr;
+  }
+  void SetItem(an<ConfigItem> item) override {
+    auto container = As<T>(**parent_);
+    if (!copied_) {
+      *parent_ = container = CopyOnWrite(container, key_);
+      copied_ = true;
+    }
+    Write(container, key_, item);
+  }
+ protected:
+  static an<T> CopyOnWrite(const an<T>& container, const string& key);
+  static an<ConfigItem> Read(const an<T>& container, const string& key);
+  static void Write(const an<T>& container,
+                    const string& key,
+                    an<ConfigItem> value);
+
+  an<ConfigItemRef> parent_;
+  string key_;
+  bool copied_ = false;
+};
+
+template <class T>
+inline an<T> ConfigCowRef<T>::CopyOnWrite(const an<T>& container,
+                                          const string& key) {
+  if (!container) {
+    DLOG(INFO) << "creating node: " << key;
+    return New<T>();
+  }
+  DLOG(INFO) << "copy on write: " << key;
+  return New<T>(*container);
+}
+
+template <>
+inline an<ConfigItem> ConfigCowRef<ConfigMap>::Read(const an<ConfigMap>& map,
+                                                    const string& key) {
+  return map->Get(key);
+}
+
+template <>
+inline void ConfigCowRef<ConfigMap>::Write(const an<ConfigMap>& map,
+                                           const string& key,
+                                           an<ConfigItem> value) {
+  map->Set(key, value);
+}
+
+template <>
+inline an<ConfigItem> ConfigCowRef<ConfigList>::Read(const an<ConfigList>& list,
+                                                     const string& key) {
+  return list->GetAt(ConfigData::ResolveListIndex(list, key, true));
+}
+
+template <>
+inline void ConfigCowRef<ConfigList>::Write(const an<ConfigList>& list,
+                                            const string& key,
+                                            an<ConfigItem> value) {
+  list->SetAt(ConfigData::ResolveListIndex(list, key), value);
+}
+
+inline an<ConfigItemRef> Cow(an<ConfigItemRef> parent, string key) {
+  if (ConfigData::IsListItemReference(key))
+    return New<ConfigCowRef<ConfigList>>(parent, key);
+  else
+    return New<ConfigCowRef<ConfigMap>>(parent, key);
+}
+
+}  // namespace rime
+
+#endif  // RIME_CONFIG_COW_REF_H_

--- a/src/rime/config/legacy_dictionary_config_plugin.cc
+++ b/src/rime/config/legacy_dictionary_config_plugin.cc
@@ -1,0 +1,22 @@
+//
+// Copyright RIME Developers
+// Distributed under the BSD License
+//
+#include <rime/config/config_compiler_impl.h>
+#include <rime/config/plugins.h>
+
+namespace rime {
+
+bool LegacyDictionaryConfigPlugin::ReviewCompileOutput(
+    ConfigCompiler* compiler, an<ConfigResource> resource) {
+  // TODO: unimplemented
+  return true;
+}
+
+bool LegacyDictionaryConfigPlugin::ReviewLinkOutput(
+    ConfigCompiler* compiler, an<ConfigResource> resource) {
+  // TODO: unimplemented
+  return true;
+}
+
+}  // namespace rime

--- a/src/rime/config/legacy_preset_config_plugin.cc
+++ b/src/rime/config/legacy_preset_config_plugin.cc
@@ -1,0 +1,75 @@
+//
+// Copyright RIME Developers
+// Distributed under the BSD License
+//
+#include <boost/algorithm/string.hpp>
+#include <rime/config/config_compiler_impl.h>
+#include <rime/config/config_cow_ref.h>
+#include <rime/config/plugins.h>
+
+namespace rime {
+
+bool LegacyPresetConfigPlugin::ReviewCompileOutput(
+    ConfigCompiler* compiler, an<ConfigResource> resource) {
+  return true;
+}
+
+bool LegacyPresetConfigPlugin::ReviewLinkOutput(
+    ConfigCompiler* compiler, an<ConfigResource> resource) {
+  if (!boost::ends_with(resource->resource_id, ".schema"))
+    return true;
+  if (auto preset = resource->data->Traverse("key_binder/import_preset")) {
+    if (!Is<ConfigValue>(preset))
+      return false;
+    auto preset_config_id = As<ConfigValue>(preset)->str();
+    LOG(INFO) << "interpreting key_binder/import_preset: " << preset_config_id;
+    auto target = Cow(resource, "key_binder");
+    auto map = As<ConfigMap>(**target);
+    if (map && map->HasKey("bindings")) {
+      // append to included list `key_binder/bindings/+` instead of overwriting
+      auto appended = map->Get("bindings");
+      *Cow(target, "bindings/+") = appended;
+      // `*target` is already referencing a copied map, safe to edit directly
+      (*target)["bindings"] = nullptr;
+    }
+    Reference reference{preset_config_id, "key_binder", false};
+    if (!IncludeReference{reference}
+        .TargetedAt(target).Resolve(compiler)) {
+      LOG(ERROR) << "failed to include section " << reference;
+      return false;
+    }
+  }
+  // NOTE: in the following cases, Cow() is not strictly necessary because
+  // we know for sure that no other ConfigResource is going to reference the
+  // root map node that will be modified. But other than the root node of the
+  // resource being linked, it's possbile a map or list has multiple references
+  // in the node tree, therefore Cow() is recommended to make sure the
+  // modifications only happen to one place.
+  if (auto preset = resource->data->Traverse("punctuator/import_preset")) {
+    if (!Is<ConfigValue>(preset))
+      return false;
+    auto preset_config_id = As<ConfigValue>(preset)->str();
+    LOG(INFO) << "interpreting punctuator/import_preset: " << preset_config_id;
+    Reference reference{preset_config_id, "punctuator", false};
+    if (!IncludeReference{reference}
+        .TargetedAt(Cow(resource, "punctuator")).Resolve(compiler)) {
+      LOG(ERROR) << "failed to include section " << reference;
+      return false;
+    }
+  }
+  if (auto preset = resource->data->Traverse("recognizer/import_preset")) {
+    if (!Is<ConfigValue>(preset))
+      return false;
+    auto preset_config_id = As<ConfigValue>(preset)->str();
+    LOG(INFO) << "interpreting recognizer/import_preset: " << preset_config_id;
+    Reference reference{preset_config_id, "recognizer", false};
+    if (!IncludeReference{reference}
+        .TargetedAt(Cow(resource, "recognizer")).Resolve(compiler)) {
+      LOG(ERROR) << "failed to include section " << reference;
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace rime

--- a/src/rime/config/plugins.h
+++ b/src/rime/config/plugins.h
@@ -1,0 +1,44 @@
+//
+// Copyright RIME Developers
+// Distributed under the BSD License
+//
+#ifndef RIME_CONFIG_PLUGINS_H_
+#define RIME_CONFIG_PLUGINS_H_
+
+#include <rime/common.h>
+
+namespace rime {
+
+class ConfigCompiler;
+struct ConfigResource;
+
+class ConfigCompilerPlugin {
+ public:
+  typedef bool Review(ConfigCompiler* compiler,
+                      an<ConfigResource> resource);
+
+  virtual Review ReviewCompileOutput = 0;
+  virtual Review ReviewLinkOutput = 0;
+};
+
+class AutoPatchConfigPlugin : public ConfigCompilerPlugin {
+ public:
+  Review ReviewCompileOutput;
+  Review ReviewLinkOutput;
+};
+
+class LegacyPresetConfigPlugin : public ConfigCompilerPlugin {
+ public:
+  Review ReviewCompileOutput;
+  Review ReviewLinkOutput;
+};
+
+class LegacyDictionaryConfigPlugin : public ConfigCompilerPlugin {
+ public:
+  Review ReviewCompileOutput;
+  Review ReviewLinkOutput;
+};
+
+}  // namespace rime
+
+#endif  // RIME_CONFIG_PLUGINS_H_

--- a/src/rime/core_module.cc
+++ b/src/rime/core_module.cc
@@ -11,6 +11,7 @@
 
 // built-in components
 #include <rime/config.h>
+#include <rime/config/plugins.h>
 #include <rime/schema.h>
 
 using namespace rime;
@@ -20,6 +21,9 @@ static void rime_core_initialize() {
   Registry& r = Registry::instance();
 
   auto config = new ConfigComponent;
+  config->InstallPlugin(new AutoPatchConfigPlugin);
+  config->InstallPlugin(new LegacyPresetConfigPlugin);
+  config->InstallPlugin(new LegacyDictionaryConfigPlugin);
   r.Register("config", config);
   r.Register("schema", new SchemaComponent(config));
 }

--- a/src/rime/gear/key_binder.cc
+++ b/src/rime/gear/key_binder.cc
@@ -212,19 +212,6 @@ void KeyBinder::LoadConfig() {
   if (!engine_)
     return;
   Config* config = engine_->schema()->config();
-  string preset;
-  if (config->GetString("key_binder/import_preset", &preset)) {
-    the<Config> preset_config(Config::Require("config")->Create(preset));
-    if (!preset_config) {
-      LOG(ERROR) << "Error importing preset key bindings '" << preset << "'.";
-      return;
-    }
-    if (auto bindings = preset_config->GetList("key_binder/bindings"))
-      key_bindings_->LoadBindings(bindings);
-    else
-      LOG(WARNING) << "missing preset key bindings.";
-  }
-  // per schema configuration, overriding preset bindings
   if (auto bindings = config->GetList("key_binder/bindings"))
     key_bindings_->LoadBindings(bindings);
 }

--- a/src/rime/gear/punctuator.cc
+++ b/src/rime/gear/punctuator.cc
@@ -27,24 +27,8 @@ void PunctConfig::LoadConfig(Engine* engine, bool load_symbols) {
     return;
   shape_ = shape;
   Config* config = engine->schema()->config();
-  string preset;
-  if (config->GetString("punctuator/import_preset", &preset)) {
-    the<Config> preset_config(
-        Config::Require("config")->Create(preset));
-    if (!preset_config) {
-      LOG(ERROR) << "Error importing preset punctuation '" << preset << "'.";
-      return;
-    }
-    preset_mapping_ = preset_config->GetMap("punctuator/" + shape);
-    if (!preset_mapping_) {
-      LOG(WARNING) << "missing preset punctuation mapping.";
-    }
-    if (load_symbols && !preset_symbols_) {
-      preset_symbols_ = preset_config->GetMap("punctuator/symbols");
-    }
-  }
   mapping_ = config->GetMap("punctuator/" + shape);
-  if (!mapping_ && !preset_mapping_) {
+  if (!mapping_) {
     LOG(WARNING) << "missing punctuation mapping.";
   }
   if (load_symbols) {
@@ -53,25 +37,8 @@ void PunctConfig::LoadConfig(Engine* engine, bool load_symbols) {
 }
 
 an<ConfigItem> PunctConfig::GetPunctDefinition(const string key) {
-  an<ConfigItem> punct_definition;
-  if (mapping_)
-    punct_definition = mapping_->Get(key);
-  if (punct_definition)
-    return punct_definition;
-
-  if (preset_mapping_)
-    punct_definition = preset_mapping_->Get(key);
-  if (punct_definition)
-    return punct_definition;
-
-  if (symbols_)
-    punct_definition = symbols_->Get(key);
-  if (punct_definition)
-    return punct_definition;
-
-  if (preset_symbols_)
-    punct_definition = preset_symbols_->Get(key);
-  return punct_definition;
+  an<ConfigItem> result = mapping_ ? mapping_->Get(key) : nullptr;
+  return result ? result : symbols_ ? symbols_->Get(key) : nullptr;
 }
 
 Punctuator::Punctuator(const Ticket& ticket) : Processor(ticket) {

--- a/src/rime/gear/punctuator.h
+++ b/src/rime/gear/punctuator.h
@@ -23,11 +23,9 @@ class PunctConfig {
   void LoadConfig(Engine* engine, bool load_symbols = false);
   an<ConfigItem> GetPunctDefinition(const string key);
  protected:
-  an<ConfigMap> mapping_;
-  an<ConfigMap> preset_mapping_;
   string shape_;
+  an<ConfigMap> mapping_;
   an<ConfigMap> symbols_;
-  an<ConfigMap> preset_symbols_;
 };
 
 class Punctuator : public Processor {

--- a/src/rime/gear/recognizer.cc
+++ b/src/rime/gear/recognizer.cc
@@ -27,20 +27,7 @@ static void load_patterns(RecognizerPatterns* patterns, an<ConfigMap> map) {
 }
 
 void RecognizerPatterns::LoadConfig(Config* config) {
-  an<ConfigMap> pattern_map;
-  string preset;
-  if (config->GetString("recognizer/import_preset", &preset)) {
-    the<Config> preset_config(
-        Config::Require("config")->Create(preset));
-    if (!preset_config) {
-      LOG(ERROR) << "Error importing preset patterns '" << preset << "'.";
-      return;
-    }
-    pattern_map = preset_config->GetMap("recognizer/patterns");
-    load_patterns(this, pattern_map);
-  }
-  pattern_map = config->GetMap("recognizer/patterns");
-  load_patterns(this, pattern_map);
+  load_patterns(this, config->GetMap("recognizer/patterns"));
 }
 
 RecognizerMatch

--- a/src/rime/lever/customizer.cc
+++ b/src/rime/lever/customizer.cc
@@ -28,6 +28,7 @@ namespace rime {
 // 1.0    X      2.0.custom.X (up-to-date)
 // 1.0    Y      1.0.custom.X  --> Update: 1.0.custom.Y
 //
+// DEPRECATED: in favor of auto-patch config compiler plugin
 bool Customizer::UpdateConfigFile() {
   bool need_update = false;
   bool redistribute = false;
@@ -144,6 +145,11 @@ bool Customizer::UpdateConfigFile() {
   }
 
   return true;
+}
+
+bool Customizer::TrashCustomizedCopy() {
+  // TODO: unimplemented
+  return false;
 }
 
 }  // namespace rime

--- a/src/rime/lever/customizer.h
+++ b/src/rime/lever/customizer.h
@@ -2,8 +2,6 @@
 // Copyright RIME Developers
 // Distributed under the BSD License
 //
-// 2012-02-12 GONG Chen <chen.sst@gmail.com>
-//
 #ifndef RIME_CUSTOMIZER_H_
 #define RIME_CUSTOMIZER_H_
 
@@ -20,7 +18,10 @@ class Customizer {
         dest_path_(dest_path),
         version_key_(version_key) {}
 
+  // DEPRECATED: in favor of auto-patch config compiler plugin
   bool UpdateConfigFile();
+
+  bool TrashCustomizedCopy();
 
  protected:
   boost::filesystem::path source_path_;

--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -268,8 +268,8 @@ bool SchemaUpdate::Run(Deployer* deployer) {
   fs::path user_data_path(deployer->user_data_dir);
   fs::path destination_path(user_data_path / (schema_id + ".schema.yaml"));
   Customizer customizer(source_path, destination_path, "schema/version");
-  if (customizer.UpdateConfigFile()) {
-    LOG(INFO) << "schema '" << schema_id << "' is updated.";
+  if (customizer.TrashCustomizedCopy()) {
+    LOG(INFO) << "patched copy of schema '" << schema_id << "' is moved to trash";
   }
 
   Schema schema(schema_id, new Config);
@@ -327,7 +327,8 @@ bool ConfigFileUpdate::Run(Deployer* deployer) {
     source_config_path = dest_config_path;
   }
   Customizer customizer(source_config_path, dest_config_path, version_key_);
-  return customizer.UpdateConfigFile();
+  customizer.TrashCustomizedCopy();
+  return true;
 }
 
 bool PrebuildAllSchemas::Run(Deployer* deployer) {


### PR DESCRIPTION
Fixes #149 , also:
 - Fixed two bugs in config dependency resolution append/merge algorithm.
 - Disabled the old Customizer.

TODO:
 - Remove the patched copy on next upgrade.
 - Schema copied to user direction without notification, as well as symlinks should be removed too,
 - after applying the fallback resource resolver to dictionary files.
