### PR TITLE
chore: build and run rime_test in AppVeyor CI script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,11 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/c_flag_over
 set(CMAKE_USER_MAKE_RULES_OVERRIDE_CXX ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cxx_flag_overrides.cmake)
 
 project(rime)
-cmake_minimum_required(VERSION 3.4)
+if(WIN32)
+  cmake_minimum_required(VERSION 3.4)
+else(WIN32)
+  cmake_minimum_required(VERSION 2.8)
+endif(WIN32)
 
 set(rime_version 1.2.9)
 set(rime_soversion 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/c_flag_over
 set(CMAKE_USER_MAKE_RULES_OVERRIDE_CXX ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cxx_flag_overrides.cmake)
 
 project(rime)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.4)
 
 set(rime_version 1.2.9)
 set(rime_soversion 1)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,11 +36,11 @@ after_build:
   - dir build /s
 
 before_test:
-  - copy /y build\lib\Release\rime.dll build\bin
+  - copy /y build\lib\Release\rime.dll build\test\Release
 
 test_script:
-  - cd build\bin
-  - echo "congmingdeRime{space}shurufa" | Release\rime_api_console.exe
+  - cd build\test
+  - .\Release\rime_test.exe
 
 artifacts:
   - path: rime.zip

--- a/build.bat
+++ b/build.bat
@@ -94,7 +94,7 @@ if %build_thirdparty% == 1 (
   echo building leveldb.
   cd %THIRDPARTY%\src\leveldb-windows
   echo BOOST_ROOT=%BOOST_ROOT%
-  msbuild.exe leveldb.sln /p:Configuration=Release
+  msbuild.exe leveldb.sln /p:Configuration=Release /p:Platform=Win32
   if %ERRORLEVEL% NEQ 0 goto ERROR
   echo built. copying artifacts.
   xcopy /S /I /Y include\leveldb %THIRDPARTY%\include\leveldb\
@@ -128,7 +128,7 @@ if %build_thirdparty% == 1 (
 
   echo building marisa.
   cd %THIRDPARTY%\src\marisa-trie\vs2015
-  msbuild.exe vs2015.sln /p:Configuration=Release
+  msbuild.exe vs2015.sln /p:Configuration=Release /p:Platform=Win32
   if %ERRORLEVEL% NEQ 0 goto ERROR
   echo built. copying artifacts.
   xcopy /S /I /Y ..\lib\marisa %THIRDPARTY%\include\marisa\
@@ -169,6 +169,10 @@ if %build_thirdparty% == 1 (
 if %build_librime% == 0 goto EXIT
 
 set RIME_CMAKE_FLAGS=-DBUILD_STATIC=ON -DBUILD_SHARED_LIBS=%build_shared% -DBUILD_TEST=%build_test% -DENABLE_LOGGING=%enable_logging% -DBOOST_USE_CXX11=ON -DCMAKE_CONFIGURATION_TYPES="Release"
+
+if "%build_shared%" == "ON" (
+  set RIME_CMAKE_FLAGS=%RIME_CMAKE_FLAGS% -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE
+)
 
 cd /d %RIME_ROOT%
 echo cmake %RIME_ROOT% -B%build% -G%CMAKE_GENERATOR% -T%CMAKE_TOOLSET% %RIME_CMAKE_FLAGS%

--- a/src/rime/setup.h
+++ b/src/rime/setup.h
@@ -7,9 +7,11 @@
 #ifndef RIME_SETUP_H_
 #define RIME_SETUP_H_
 
+#include <rime_api.h>
+
 namespace rime {
 
-extern const char* kDefaultModules[];
+RIME_API extern const char* kDefaultModules[];
 extern const char* kDeployerModules[];
 extern const char* kLegacyModules[];
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,12 @@
-if(NOT (WIN32 AND BUILD_SHARED_LIBS))
-
 aux_source_directory(. rime_test_src)
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/test)
 add_executable(rime_test ${rime_test_src})
 target_link_libraries(rime_test
                       ${rime_library} ${rime_gears_library}
                       ${GTEST_LIBRARIES})
+if(BUILD_SHARED_LIBS)
+  target_compile_definitions(rime_test PRIVATE RIME_IMPORTS)
+endif()
 add_dependencies(rime_test ${rime_library} ${rime_gears_library})
 
 file(GLOB test_data_files ${PROJECT_SOURCE_DIR}/data/test/*.yaml)
@@ -13,5 +14,3 @@ file(COPY ${test_data_files} DESTINATION ${EXECUTABLE_OUTPUT_PATH})
 
 set(rime_test_executable ${EXECUTABLE_OUTPUT_PATH}/rime_test${ext})
 add_test(rime_test ${rime_test_executable})
-
-endif()


### PR DESCRIPTION
This commit utilizes `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS`, a new variable since CMake 3.4, to export all symbols from `rime.dll`.

The AppVeyor CI test failed, however it did not seem that I broke relevant code.