### PR TITLE
chore(rime_test): link with Windows DLL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/c_flag_over
 set(CMAKE_USER_MAKE_RULES_OVERRIDE_CXX ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cxx_flag_overrides.cmake)
 
 project(rime)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.11)
 
 set(rime_version 1.2.9)
 set(rime_soversion 1)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,11 +36,11 @@ after_build:
   - dir build /s
 
 before_test:
-  - copy /y build\lib\Release\rime.dll build\bin
+  - copy /y build\lib\Release\rime.dll build\test\Release
 
 test_script:
-  - cd build\bin
-  - echo "congmingdeRime{space}shurufa" | Release\rime_api_console.exe
+  - cd build\test
+  - .\Release\rime_test.exe
 
 artifacts:
   - path: rime.zip

--- a/src/rime/algo/algebra.h
+++ b/src/rime/algo/algebra.h
@@ -19,7 +19,7 @@ class Schema;
 
 class Script : public map<string, vector<Spelling>> {
  public:
-  bool AddSyllable(const string& syllable);
+  RIME_API bool AddSyllable(const string& syllable);
   void Merge(const string& s,
              const SpellingProperties& sp,
              const vector<Spelling>& v);
@@ -28,11 +28,11 @@ class Script : public map<string, vector<Spelling>> {
 
 class Projection {
  public:
-  bool Load(an<ConfigList> settings);
+  RIME_API bool Load(an<ConfigList> settings);
   // "spelling" -> "gnilleps"
-  bool Apply(string* value);
+  RIME_API bool Apply(string* value);
   // {z, y, x} -> {a, b, c, d}
-  bool Apply(Script* value);
+  RIME_API bool Apply(Script* value);
  protected:
   vector<of<Calculation>> calculation_;
 };

--- a/src/rime/algo/calculus.h
+++ b/src/rime/algo/calculus.h
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <boost/regex.hpp>
+#include <rime_api.h>
 #include <rime/common.h>
 #include "spelling.h"
 
@@ -28,9 +29,9 @@ class Calculation {
 
 class Calculus {
  public:
-  Calculus();
+  RIME_API Calculus();
   void Register(const string& token, Calculation::Factory* factory);
-  Calculation* Parse(const string& defintion);
+  RIME_API Calculation* Parse(const string& defintion);
 
  private:
   map<string, Calculation::Factory*> factories_;

--- a/src/rime/algo/encoder.h
+++ b/src/rime/algo/encoder.h
@@ -9,13 +9,14 @@
 #define RIME_ENCODER_H_
 
 #include <boost/regex.hpp>
+#include <rime_api.h>
 
 namespace rime {
 
 class RawCode : public vector<string> {
  public:
-  string ToString() const;
-  void FromString(const string &code_str);
+  RIME_API string ToString() const;
+  RIME_API void FromString(const string &code_str);
 };
 
 class PhraseCollector {
@@ -68,14 +69,14 @@ struct TableEncodingRule {
 // for rule-based phrase encoding
 class TableEncoder : public Encoder {
  public:
-  TableEncoder(PhraseCollector* collector = NULL);
+  RIME_API TableEncoder(PhraseCollector* collector = NULL);
 
-  bool LoadSettings(Config* config);
+  RIME_API bool LoadSettings(Config* config);
 
-  bool Encode(const RawCode& code, string* result);
+  RIME_API bool Encode(const RawCode& code, string* result);
   bool EncodePhrase(const string& phrase, const string& value);
 
-  bool IsCodeExcluded(const string& code);
+  RIME_API bool IsCodeExcluded(const string& code);
 
   bool loaded() const { return loaded_; }
   const vector<TableEncodingRule>& encoding_rules() const {

--- a/src/rime/algo/syllabifier.h
+++ b/src/rime/algo/syllabifier.h
@@ -9,6 +9,7 @@
 #define RIME_SYLLABIFIER_H_
 
 #include <stdint.h>
+#include <rime_api.h>
 #include "spelling.h"
 
 namespace rime {
@@ -45,9 +46,9 @@ class Syllabifier {
         strict_spelling_(strict_spelling) {
   }
 
-  int BuildSyllableGraph(const string &input,
-                         Prism &prism,
-                         SyllableGraph *graph);
+  RIME_API int BuildSyllableGraph(const string &input,
+                                  Prism &prism,
+                                  SyllableGraph *graph);
 
  protected:
   void CheckOverlappedSpellings(SyllableGraph *graph,

--- a/src/rime/config/config_component.h
+++ b/src/rime/config/config_component.h
@@ -21,41 +21,41 @@ class Config : public Class<Config, const string&>, public ConfigItemRef {
  public:
   // CAVEAT: Config instances created without argument will NOT
   // be managed by ConfigComponent
-  Config();
-  virtual ~Config();
+  RIME_API Config();
+  RIME_API virtual ~Config();
   // instances of Config with identical config id share a copy of config data
   // in the ConfigComponent
   explicit Config(an<ConfigData> data);
 
   bool LoadFromStream(std::istream& stream);
   bool SaveToStream(std::ostream& stream);
-  bool LoadFromFile(const string& file_name);
-  bool SaveToFile(const string& file_name);
+  RIME_API bool LoadFromFile(const string& file_name);
+  RIME_API bool SaveToFile(const string& file_name);
 
   // access a tree node of a particular type with "path/to/node"
-  bool IsNull(const string& path);
+  RIME_API bool IsNull(const string& path);
   bool IsValue(const string& path);
-  bool IsList(const string& path);
-  bool IsMap(const string& path);
-  bool GetBool(const string& path, bool* value);
-  bool GetInt(const string& path, int* value);
-  bool GetDouble(const string& path, double* value);
-  bool GetString(const string& path, string* value);
-  size_t GetListSize(const string& path);
+  RIME_API bool IsList(const string& path);
+  RIME_API bool IsMap(const string& path);
+  RIME_API bool GetBool(const string& path, bool* value);
+  RIME_API bool GetInt(const string& path, int* value);
+  RIME_API bool GetDouble(const string& path, double* value);
+  RIME_API bool GetString(const string& path, string* value);
+  RIME_API size_t GetListSize(const string& path);
 
   an<ConfigItem> GetItem(const string& path);
   an<ConfigValue> GetValue(const string& path);
-  an<ConfigList> GetList(const string& path);
-  an<ConfigMap> GetMap(const string& path);
+  RIME_API an<ConfigList> GetList(const string& path);
+  RIME_API an<ConfigMap> GetMap(const string& path);
 
   // setters
   bool SetBool(const string& path, bool value);
-  bool SetInt(const string& path, int value);
+  RIME_API bool SetInt(const string& path, int value);
   bool SetDouble(const string& path, double value);
-  bool SetString(const string& path, const char* value);
+  RIME_API bool SetString(const string& path, const char* value);
   bool SetString(const string& path, const string& value);
   // setter for adding or replacing items in the tree
-  bool SetItem(const string& path, an<ConfigItem> item);
+  RIME_API bool SetItem(const string& path, an<ConfigItem> item);
   using ConfigItemRef::operator=;
 
  protected:
@@ -70,7 +70,7 @@ struct ConfigResource;
 
 class ConfigComponent : public Config::Component {
  public:
-  ConfigComponent();
+  RIME_API ConfigComponent();
   ~ConfigComponent();
   Config* Create(const string& file_name);
   void InstallPlugin(ConfigCompilerPlugin *plugin);

--- a/src/rime/config/config_types.h
+++ b/src/rime/config/config_types.h
@@ -8,6 +8,7 @@
 #define RIME_CONFIG_TYPES_H_
 
 #include <type_traits>
+#include <rime_api.h>
 #include <rime/common.h>
 
 namespace rime {
@@ -35,17 +36,17 @@ class ConfigItem {
 class ConfigValue : public ConfigItem {
  public:
   ConfigValue() : ConfigItem(kScalar) {}
-  ConfigValue(bool value);
-  ConfigValue(int value);
+  RIME_API ConfigValue(bool value);
+  RIME_API ConfigValue(int value);
   ConfigValue(double value);
-  ConfigValue(const char* value);
+  RIME_API ConfigValue(const char* value);
   ConfigValue(const string& value);
 
   // schalar value accessors
   bool GetBool(bool* value) const;
-  bool GetInt(int* value) const;
+  RIME_API bool GetInt(int* value) const;
   bool GetDouble(double* value) const;
-  bool GetString(string* value) const;
+  RIME_API bool GetString(string* value) const;
   bool SetBool(bool value);
   bool SetInt(int value);
   bool SetDouble(double value);
@@ -68,14 +69,14 @@ class ConfigList : public ConfigItem {
   using Iterator = Sequence::iterator;
 
   ConfigList() : ConfigItem(kList) {}
-  an<ConfigItem> GetAt(size_t i) const;
-  an<ConfigValue> GetValueAt(size_t i) const;
-  bool SetAt(size_t i, an<ConfigItem> element);
+  RIME_API an<ConfigItem> GetAt(size_t i) const;
+  RIME_API an<ConfigValue> GetValueAt(size_t i) const;
+  RIME_API bool SetAt(size_t i, an<ConfigItem> element);
   bool Insert(size_t i, an<ConfigItem> element);
-  bool Append(an<ConfigItem> element);
+  RIME_API bool Append(an<ConfigItem> element);
   bool Resize(size_t size);
-  bool Clear();
-  size_t size() const;
+  RIME_API bool Clear();
+  RIME_API size_t size() const;
 
   Iterator begin();
   Iterator end();
@@ -95,10 +96,10 @@ class ConfigMap : public ConfigItem {
   using Iterator = Map::iterator;
 
   ConfigMap() : ConfigItem(kMap) {}
-  bool HasKey(const string& key) const;
-  an<ConfigItem> Get(const string& key) const;
-  an<ConfigValue> GetValue(const string& key) const;
-  bool Set(const string& key, an<ConfigItem> element);
+  RIME_API bool HasKey(const string& key) const;
+  RIME_API an<ConfigItem> Get(const string& key) const;
+  RIME_API an<ConfigValue> GetValue(const string& key) const;
+  RIME_API bool Set(const string& key, an<ConfigItem> element);
   bool Clear();
 
   Iterator begin();
@@ -150,28 +151,28 @@ class ConfigItemRef {
   ConfigListEntryRef operator[] (size_t index);
   ConfigMapEntryRef operator[] (const string& key);
 
-  bool IsNull() const;
+  RIME_API bool IsNull() const;
   bool IsValue() const;
-  bool IsList() const;
+  RIME_API bool IsList() const;
   bool IsMap() const;
 
-  bool ToBool() const;
-  int ToInt() const;
+  RIME_API bool ToBool() const;
+  RIME_API int ToInt() const;
   double ToDouble() const;
-  string ToString() const;
+  RIME_API string ToString() const;
 
-  an<ConfigList> AsList();
-  an<ConfigMap> AsMap();
-  void Clear();
+  RIME_API an<ConfigList> AsList();
+  RIME_API an<ConfigMap> AsMap();
+  RIME_API void Clear();
 
   // list
-  bool Append(an<ConfigItem> item);
-  size_t size() const;
+  RIME_API bool Append(an<ConfigItem> item);
+  RIME_API size_t size() const;
   // map
   bool HasKey(const string& key) const;
 
-  bool modified() const;
-  void set_modified();
+  RIME_API bool modified() const;
+  RIME_API void set_modified();
 
  protected:
   virtual an<ConfigItem> GetItem() const = 0;

--- a/src/rime/dict/db.h
+++ b/src/rime/dict/db.h
@@ -7,6 +7,7 @@
 #ifndef RIME_DB_H_
 #define RIME_DB_H_
 
+#include <rime_api.h>
 #include <rime/common.h>
 #include <rime/component.h>
 
@@ -35,8 +36,8 @@ class Db : public Class<Db, const string&> {
   explicit Db(const string& name);
   virtual ~Db() = default;
 
-  bool Exists() const;
-  virtual bool Remove();
+  RIME_API bool Exists() const;
+  RIME_API virtual bool Remove();
 
   virtual bool Open() = 0;
   virtual bool OpenReadOnly() = 0;

--- a/src/rime/dict/dict_compiler.h
+++ b/src/rime/dict/dict_compiler.h
@@ -7,6 +7,7 @@
 #ifndef RIME_DICT_COMPILER_H_
 #define RIME_DICT_COMPILER_H_
 
+#include <rime_api.h>
 #include <rime/common.h>
 
 namespace rime {
@@ -30,10 +31,10 @@ class DictCompiler {
     kDump = 4,
   };
 
-  DictCompiler(Dictionary *dictionary,
-               DictFileFinder finder = NULL);
+  RIME_API DictCompiler(Dictionary *dictionary,
+                        DictFileFinder finder = NULL);
 
-  bool Compile(const string &schema_file);
+  RIME_API bool Compile(const string &schema_file);
   void set_options(int options) { options_ = options; }
 
  private:

--- a/src/rime/dict/dictionary.h
+++ b/src/rime/dict/dictionary.h
@@ -44,16 +44,16 @@ class DictEntryIterator : protected list<dictionary::Chunk>,
  public:
   using Base = list<dictionary::Chunk>;
 
-  DictEntryIterator();
-  DictEntryIterator(const DictEntryIterator& other);
+  RIME_API DictEntryIterator();
+  RIME_API DictEntryIterator(const DictEntryIterator& other);
   DictEntryIterator& operator= (DictEntryIterator& other);
 
   void AddChunk(dictionary::Chunk&& chunk, Table* table);
   void Sort();
-  an<DictEntry> Peek();
-  bool Next();
+  RIME_API an<DictEntry> Peek();
+  RIME_API bool Next();
   bool Skip(size_t num_entries);
-  bool exhausted() const;
+  RIME_API bool exhausted() const;
   size_t entry_count() const { return entry_count_; }
 
  protected:
@@ -75,29 +75,29 @@ struct Ticket;
 
 class Dictionary : public Class<Dictionary, const Ticket&> {
  public:
-  Dictionary(const string& name,
-             const an<Table>& table,
-             const an<Prism>& prism);
+  RIME_API Dictionary(const string& name,
+                      const an<Table>& table,
+                      const an<Prism>& prism);
   virtual ~Dictionary();
 
   bool Exists() const;
-  bool Remove();
-  bool Load();
+  RIME_API bool Remove();
+  RIME_API bool Load();
 
-  an<DictEntryCollector> Lookup(const SyllableGraph& syllable_graph,
-                                        size_t start_pos,
-                                        double initial_credibility = 1.0);
+  RIME_API an<DictEntryCollector> Lookup(const SyllableGraph& syllable_graph,
+                                         size_t start_pos,
+                                         double initial_credibility = 1.0);
   // if predictive is true, do an expand search with limit,
   // otherwise do an exact match.
   // return num of matching keys.
-  size_t LookupWords(DictEntryIterator* result,
-                     const string& str_code,
-                     bool predictive, size_t limit = 0);
+  RIME_API size_t LookupWords(DictEntryIterator* result,
+                              const string& str_code,
+                              bool predictive, size_t limit = 0);
   // translate syllable id sequence to string code
-  bool Decode(const Code& code, vector<string>* result);
+  RIME_API bool Decode(const Code& code, vector<string>* result);
 
   const string& name() const { return name_; }
-  bool loaded() const;
+  RIME_API bool loaded() const;
 
   an<Table> table() { return table_; }
   an<Prism> prism() { return prism_; }
@@ -122,4 +122,4 @@ class DictionaryComponent : public Dictionary::Component {
 
 }  // namespace rime
 
-#endif  // RIME_DICTIONRAY_H_
+#endif  // RIME_DICTIONARY_H_

--- a/src/rime/dict/mapped_file.h
+++ b/src/rime/dict/mapped_file.h
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <cstring>
 #include <boost/utility.hpp>
+#include <rime_api.h>
 #include <rime/common.h>
 
 namespace rime {
@@ -89,7 +90,7 @@ class MappedFileImpl;
 class MappedFile : boost::noncopyable {
  protected:
   explicit MappedFile(const string& file_name);
-  virtual ~MappedFile();
+  RIME_API virtual ~MappedFile();
 
   bool Create(size_t capacity);
   bool OpenReadOnly();
@@ -113,8 +114,8 @@ class MappedFile : boost::noncopyable {
  public:
   bool Exists() const;
   bool IsOpen() const;
-  void Close();
-  bool Remove();
+  RIME_API void Close();
+  RIME_API bool Remove();
 
   template <class T>
   T* Find(size_t offset);

--- a/src/rime/dict/prism.h
+++ b/src/rime/dict/prism.h
@@ -65,22 +65,22 @@ class Prism : public MappedFile {
  public:
   using Match = Darts::DoubleArray::result_pair_type;
 
-  explicit Prism(const string& file_name);
+  RIME_API explicit Prism(const string& file_name);
 
-  bool Load();
-  bool Save();
-  bool Build(const Syllabary& syllabary,
-             const Script* script = NULL,
-             uint32_t dict_file_checksum = 0,
-             uint32_t schema_file_checksum = 0);
+  RIME_API bool Load();
+  RIME_API bool Save();
+  RIME_API bool Build(const Syllabary& syllabary,
+                      const Script* script = NULL,
+                      uint32_t dict_file_checksum = 0,
+                      uint32_t schema_file_checksum = 0);
 
-  bool HasKey(const string& key);
-  bool GetValue(const string& key, int* value);
-  void CommonPrefixSearch(const string& key, vector<Match>* result);
-  void ExpandSearch(const string& key, vector<Match>* result, size_t limit);
+  RIME_API bool HasKey(const string& key);
+  RIME_API bool GetValue(const string& key, int* value);
+  RIME_API void CommonPrefixSearch(const string& key, vector<Match>* result);
+  RIME_API void ExpandSearch(const string& key, vector<Match>* result, size_t limit);
   SpellingAccessor QuerySpelling(SyllableId spelling_id);
 
-  size_t array_size() const;
+  RIME_API size_t array_size() const;
 
   uint32_t dict_file_checksum() const;
   uint32_t schema_file_checksum() const;

--- a/src/rime/dict/table.h
+++ b/src/rime/dict/table.h
@@ -112,12 +112,12 @@ class TableAccessor {
   TableAccessor(const Code& index_code, const table::TailIndex* code_map,
                 double credibility = 1.0);
 
-  bool Next();
+  RIME_API bool Next();
 
-  bool exhausted() const;
-  size_t remaining() const;
-  const table::Entry* entry() const;
-  const table::Code* extra_code() const;
+  RIME_API bool exhausted() const;
+  RIME_API size_t remaining() const;
+  RIME_API const table::Entry* entry() const;
+  RIME_API const table::Code* extra_code() const;
   const Code& index_code() const { return index_code_; }
   Code code() const;
   double credibility() const { return credibility_; }
@@ -138,24 +138,24 @@ class TableQuery;
 
 class Table : public MappedFile {
  public:
-  Table(const string& file_name);
+  RIME_API Table(const string& file_name);
   virtual ~Table();
 
-  bool Load();
-  bool Save();
-  bool Build(const Syllabary& syllabary,
-             const Vocabulary& vocabulary,
-             size_t num_entries,
-             uint32_t dict_file_checksum = 0);
+  RIME_API bool Load();
+  RIME_API bool Save();
+  RIME_API bool Build(const Syllabary& syllabary,
+                      const Vocabulary& vocabulary,
+                      size_t num_entries,
+                      uint32_t dict_file_checksum = 0);
 
   bool GetSyllabary(Syllabary* syllabary);
-  string GetSyllableById(int syllable_id);
-  TableAccessor QueryWords(int syllable_id);
-  TableAccessor QueryPhrases(const Code& code);
-  bool Query(const SyllableGraph& syll_graph,
-             size_t start_pos,
-             TableQueryResult* result);
-  string GetEntryText(const table::Entry& entry);
+  RIME_API string GetSyllableById(int syllable_id);
+  RIME_API TableAccessor QueryWords(int syllable_id);
+  RIME_API TableAccessor QueryPhrases(const Code& code);
+  RIME_API bool Query(const SyllableGraph& syll_graph,
+                      size_t start_pos,
+                      TableQueryResult* result);
+  RIME_API string GetEntryText(const table::Entry& entry);
 
   uint32_t dict_file_checksum() const;
 

--- a/src/rime/dict/text_db.h
+++ b/src/rime/dict/text_db.h
@@ -42,11 +42,11 @@ class TextDb : public Db {
   TextDb(const string& name,
          const string& db_type,
          TextFormat format);
-  virtual ~TextDb();
+  RIME_API virtual ~TextDb();
 
-  virtual bool Open();
+  RIME_API virtual bool Open();
   virtual bool OpenReadOnly();
-  virtual bool Close();
+  RIME_API virtual bool Close();
 
   virtual bool Backup(const string& snapshot_file);
   virtual bool Restore(const string& snapshot_file);
@@ -57,10 +57,10 @@ class TextDb : public Db {
 
   virtual an<DbAccessor> QueryMetadata();
   virtual an<DbAccessor> QueryAll();
-  virtual an<DbAccessor> Query(const string& key);
-  virtual bool Fetch(const string& key, string* value);
-  virtual bool Update(const string& key, const string& value);
-  virtual bool Erase(const string& key);
+  RIME_API virtual an<DbAccessor> Query(const string& key);
+  RIME_API virtual bool Fetch(const string& key, string* value);
+  RIME_API virtual bool Update(const string& key, const string& value);
+  RIME_API virtual bool Erase(const string& key);
 
  protected:
   void Clear();

--- a/src/rime/dict/user_db.h
+++ b/src/rime/dict/user_db.h
@@ -81,7 +81,7 @@ class UserDbHelper {
 template <class BaseDb>
 class UserDbWrapper : public BaseDb {
  public:
-  UserDbWrapper(const string& db_name);
+  RIME_API UserDbWrapper(const string& db_name);
 
   virtual bool CreateMetadata() {
     return BaseDb::CreateMetadata() &&

--- a/src/rime/engine.h
+++ b/src/rime/engine.h
@@ -7,6 +7,7 @@
 #ifndef RIME_ENGINE_H_
 #define RIME_ENGINE_H_
 
+#include <rime_api.h>
 #include <rime/common.h>
 #include <rime/messenger.h>
 
@@ -37,7 +38,7 @@ class Engine : public Messenger {
     active_context_ = context;
   }
 
-  static Engine* Create();
+  RIME_API static Engine* Create();
 
  protected:
   Engine();

--- a/src/rime/key_event.h
+++ b/src/rime/key_event.h
@@ -19,7 +19,7 @@ class KeyEvent {
   KeyEvent() = default;
   KeyEvent(int keycode, int modifier)
       : keycode_(keycode), modifier_(modifier) {}
-  KeyEvent(const string& repr);
+  RIME_API KeyEvent(const string& repr);
 
   int keycode() const { return keycode_; }
   void keycode(int value) { keycode_ = value; }
@@ -35,10 +35,10 @@ class KeyEvent {
   // 按鍵表示為形如「狀態+鍵名」的文字
   // 若無鍵名，則以四位或六位十六进制数形式的文字來標識
   // 形如 "0x12ab", "0xfffffe"
-  string repr() const;
+  RIME_API string repr() const;
 
   // 解析文字表示的按鍵
-  bool Parse(const string& repr);
+  RIME_API bool Parse(const string& repr);
 
   bool operator== (const KeyEvent& other) const {
     return keycode_ == other.keycode_ && modifier_ == other.modifier_;
@@ -59,15 +59,15 @@ class KeyEvent {
 class KeySequence : public vector<KeyEvent> {
  public:
   KeySequence() = default;
-  KeySequence(const string& repr);
+  RIME_API KeySequence(const string& repr);
 
   // 可表示為一串文字
   // 若其中包含不產生可打印字符的按鍵，以 {鍵名} 來標記
   // 組合鍵也用 {組合鍵狀態+鍵名} 來標記
-  string repr() const;
+  RIME_API string repr() const;
 
   // 解析按鍵序列描述文字
-  bool Parse(const string& repr);
+  RIME_API bool Parse(const string& repr);
 };
 
 inline std::ostream& operator<< (std::ostream& out, const KeyEvent& key_event) {

--- a/src/rime/key_table.cc
+++ b/src/rime/key_table.cc
@@ -2,6 +2,7 @@
 #include <stddef.h>
 #include <string.h>
 #include <X11/keysym.h>
+#include <rime_api.h>
 
 static const char *modifier_name[] = {
   "Shift",    // 0
@@ -3959,7 +3960,7 @@ static const key_entry keys_by_name[] = {
   { 0x0001be, 1449 }
 };
 
-int RimeGetModifierByName(const char *name) {
+RIME_API int RimeGetModifierByName(const char *name) {
   const int n = sizeof(modifier_name) / sizeof(const char*);
   if (!name)
     return 0;
@@ -3971,7 +3972,7 @@ int RimeGetModifierByName(const char *name) {
   return 0;
 }
 
-const char* RimeGetModifierName(int modifier) {
+RIME_API const char* RimeGetModifierName(int modifier) {
   const int n = sizeof(modifier_name) / sizeof(const char*);
   for (int i = 0; i < n && modifier != 0; ++i) {
     if ((modifier & 1) != 0) {
@@ -3982,7 +3983,7 @@ const char* RimeGetModifierName(int modifier) {
   return NULL;
 }
 
-int RimeGetKeycodeByName(const char *name) {
+RIME_API int RimeGetKeycodeByName(const char *name) {
   for (const key_entry *p = keys_by_keyval; p->keyval != XK_VoidSymbol; ++p) {
     if (!strcmp(name, key_names + p->offset)) {
       return p->keyval;
@@ -3991,7 +3992,7 @@ int RimeGetKeycodeByName(const char *name) {
   return XK_VoidSymbol;
 }
 
-const char* RimeGetKeyName(int keycode) {
+RIME_API const char* RimeGetKeyName(int keycode) {
   const int n = sizeof(keys_by_name) / sizeof(const key_entry);
   for (int i = 0; i < n; ++i) {
     if (keycode == keys_by_name[i].keyval) {

--- a/src/rime/key_table.h
+++ b/src/rime/key_table.h
@@ -9,6 +9,7 @@
 #define RIME_KEY_TABLE_H_
 
 #include <X11/keysym.h>
+#include <rime_api.h>
 
 typedef enum {
   kShiftMask    = 1 << 0,
@@ -47,19 +48,19 @@ typedef enum {
 // 给定modifier文字，返回马赛克值
 // 例如 RimeGetModifierByName("Alt") == (1 << 3)
 // 如果不认得所给的键名，返回 0
-int RimeGetModifierByName(const char* name);
+RIME_API int RimeGetModifierByName(const char* name);
 
 // 给一个数值，取得最低的非0位所对应的modifier文字
 // 例如 RimeGetModifierName(12) == "Control"
 // 取不到则返回 NULL
-const char* RimeGetModifierName(int modifier);
+RIME_API const char* RimeGetModifierName(int modifier);
 
 // 由键名取得键值
 // 查无此键则返回 XK_VoidSymbol
-int RimeGetKeycodeByName(const char* name);
+RIME_API int RimeGetKeycodeByName(const char* name);
 
 // 由键值取得键名
 // 不认得此键，则返回 NULL
-const char* RimeGetKeyName(int keycode);
+RIME_API const char* RimeGetKeyName(int keycode);
 
 #endif  // RIME_KEY_TABLE_H_

--- a/src/rime/menu.h
+++ b/src/rime/menu.h
@@ -7,6 +7,7 @@
 #ifndef RIME_MENU_H_
 #define RIME_MENU_H_
 
+#include <rime_api.h>
 #include <rime/candidate.h>
 #include <rime/common.h>
 
@@ -25,13 +26,13 @@ class Translation;
 
 class Menu {
  public:
-  Menu();
+  RIME_API Menu();
 
-  void AddTranslation(an<Translation> translation);
+  RIME_API void AddTranslation(an<Translation> translation);
   void AddFilter(Filter* filter);
 
-  size_t Prepare(size_t candidate_count);
-  Page* CreatePage(size_t page_size, size_t page_no);
+  RIME_API size_t Prepare(size_t candidate_count);
+  RIME_API Page* CreatePage(size_t page_size, size_t page_no);
   an<Candidate> GetCandidateAt(size_t index);
 
   // CAVEAT: returns the number of candidates currently obtained,

--- a/src/rime/registry.h
+++ b/src/rime/registry.h
@@ -7,6 +7,7 @@
 #ifndef RIME_REGISTRY_H_
 #define RIME_REGISTRY_H_
 
+#include <rime_api.h>
 #include <rime/common.h>
 
 namespace rime {
@@ -17,12 +18,12 @@ class Registry {
  public:
   using ComponentMap = map<string, ComponentBase*>;
 
-  ComponentBase* Find(const string& name);
-  void Register(const string& name, ComponentBase* component);
-  void Unregister(const string& name);
+  RIME_API ComponentBase* Find(const string& name);
+  RIME_API void Register(const string& name, ComponentBase* component);
+  RIME_API void Unregister(const string& name);
   void Clear();
 
-  static Registry& instance();
+  RIME_API static Registry& instance();
 
  private:
   Registry() = default;

--- a/src/rime/resource.h
+++ b/src/rime/resource.h
@@ -7,6 +7,7 @@
 #define RIME_RESOURCE_H_
 
 #include <boost/filesystem.hpp>
+#include <rime_api.h>
 #include <rime/common.h>
 
 namespace rime {
@@ -25,7 +26,7 @@ class ResourceResolver {
   }
   virtual ~ResourceResolver() {
   }
-  virtual boost::filesystem::path ResolvePath(const string& resource_id);
+  RIME_API virtual boost::filesystem::path ResolvePath(const string& resource_id);
   string ToResourceId(const string& file_path) const;
   string ToFilePath(const string& resource_id) const;
   void set_root_path(const boost::filesystem::path& root_path) {
@@ -45,7 +46,7 @@ class FallbackResourceResolver : public ResourceResolver {
   explicit FallbackResourceResolver(const ResourceType& type)
       : ResourceResolver(type) {
   }
-  boost::filesystem::path ResolvePath(const string& resource_id) override;
+  RIME_API boost::filesystem::path ResolvePath(const string& resource_id) override;
   void set_fallback_root_path(const boost::filesystem::path& fallback_root_path) {
     fallback_root_path_ = fallback_root_path;
   }

--- a/src/rime/segmentation.h
+++ b/src/rime/segmentation.h
@@ -7,6 +7,7 @@
 #ifndef RIME_SEGMENTATION_H_
 #define RIME_SEGMENTATION_H_
 
+#include <rime_api.h>
 #include <rime/common.h>
 
 namespace rime {
@@ -57,15 +58,15 @@ struct Segment {
 
 class Segmentation : public vector<Segment> {
  public:
-  Segmentation();
+  RIME_API Segmentation();
   virtual ~Segmentation() {}
-  void Reset(const string& input);
+  RIME_API void Reset(const string& input);
   void Reset(size_t num_segments);
   bool AddSegment(Segment segment);
 
   bool Forward();
   bool Trim();
-  bool HasFinishedSegmentation() const;
+  RIME_API bool HasFinishedSegmentation() const;
   size_t GetCurrentStartPosition() const;
   size_t GetCurrentEndPosition() const;
   size_t GetCurrentSegmentLength() const;

--- a/src/rime/setup.cc
+++ b/src/rime/setup.cc
@@ -14,11 +14,11 @@
 
 namespace rime {
 
-RIME_MODULE_LIST(kDefaultModules, "default");
+RIME_API RIME_MODULE_LIST(kDefaultModules, "default");
 RIME_MODULE_LIST(kDeployerModules, "deployer");
 RIME_MODULE_LIST(kLegacyModules, "legacy");
 
-void LoadModules(const char* module_names[]) {
+RIME_API void LoadModules(const char* module_names[]) {
   ModuleManager& mm(ModuleManager::instance());
   for (const char** m = module_names; *m; ++m) {
     if (RimeModule* module = mm.Find(*m)) {
@@ -27,7 +27,7 @@ void LoadModules(const char* module_names[]) {
   }
 }
 
-void SetupLogging(const char* app_name) {
+RIME_API void SetupLogging(const char* app_name) {
 #ifdef RIME_ENABLE_LOGGING
   google::InitGoogleLogging(app_name);
 #endif  // RIME_ENABLE_LOGGING

--- a/src/rime/setup.h
+++ b/src/rime/setup.h
@@ -7,15 +7,17 @@
 #ifndef RIME_SETUP_H_
 #define RIME_SETUP_H_
 
+#include <rime_api.h>
+
 namespace rime {
 
-extern const char* kDefaultModules[];
+RIME_API extern const char* kDefaultModules[];
 extern const char* kDeployerModules[];
 extern const char* kLegacyModules[];
 
-void LoadModules(const char* module_names[]);
+RIME_API void LoadModules(const char* module_names[]);
 
-void SetupLogging(const char* app_name);
+RIME_API void SetupLogging(const char* app_name);
 
 }  // namespace rime
 

--- a/src/rime/ticket.h
+++ b/src/rime/ticket.h
@@ -7,6 +7,7 @@
 #ifndef RIME_TICKET_H_
 #define RIME_TICKET_H_
 
+#include <rime_api.h>
 
 namespace rime {
 
@@ -23,8 +24,8 @@ struct Ticket {
   Ticket(Schema* s, const string& ns);
   // prescription: in the form of "klass" or "klass@alias"
   // where alias, if given, will override default name space
-  Ticket(Engine* e, const string& ns = "",
-         const string& prescription = "");
+  RIME_API Ticket(Engine* e, const string& ns = "",
+                  const string& prescription = "");
 };
 
 }  // namespace rime

--- a/src/rime/translation.h
+++ b/src/rime/translation.h
@@ -8,6 +8,7 @@
 #ifndef RIME_TRANSLATION_H_
 #define RIME_TRANSLATION_H_
 
+#include <rime_api.h>
 #include <rime/candidate.h>
 #include <rime/common.h>
 
@@ -26,8 +27,8 @@ class Translation {
 
   // should it provide the next candidate (negative value, zero) or
   // should it give up the chance for other translations (positive)?
-  virtual int Compare(an<Translation> other,
-                      const CandidateList& candidates);
+  RIME_API virtual int Compare(an<Translation> other,
+                               const CandidateList& candidates);
 
   bool exhausted() const { return exhausted_; }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,12 @@
-if(NOT (WIN32 AND BUILD_SHARED_LIBS))
-
 aux_source_directory(. rime_test_src)
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/test)
 add_executable(rime_test ${rime_test_src})
 target_link_libraries(rime_test
                       ${rime_library} ${rime_gears_library}
                       ${GTEST_LIBRARIES})
+if(BUILD_SHARED_LIBS)
+  target_compile_definitions(rime_test PRIVATE RIME_IMPORTS)
+endif(BUILD_SHARED_LIBS)
 add_dependencies(rime_test ${rime_library} ${rime_gears_library})
 
 file(GLOB test_data_files ${PROJECT_SOURCE_DIR}/data/test/*.yaml)
@@ -13,5 +14,3 @@ file(COPY ${test_data_files} DESTINATION ${EXECUTABLE_OUTPUT_PATH})
 
 set(rime_test_executable ${EXECUTABLE_OUTPUT_PATH}/rime_test${ext})
 add_test(rime_test ${rime_test_executable})
-
-endif()

--- a/test/resource_resolver_test.cc
+++ b/test/resource_resolver_test.cc
@@ -15,7 +15,7 @@ TEST(RimeResourceResolverTest, ResolvePath) {
   ResourceResolver rr(kMineralsType);
   rr.set_root_path("/starcraft");
   auto actual = rr.ResolvePath("enough");
-  boost::filesystem::path expected = "/starcraft/not_enough.minerals";
+  boost::filesystem::path expected = boost::filesystem::system_complete(boost::filesystem::current_path()).root_name().string() + "/starcraft/not_enough.minerals";
   EXPECT_TRUE(actual.is_absolute());
   EXPECT_TRUE(expected == actual);
 }


### PR DESCRIPTION
This pull request replaces #151, avoiding two drawbacks from the previous solution:
1. The previous approach required CMake 3.4, which was not provided in Travis CI build environment.
2. Exporting all symbols would increase the DLL size significantly.

This commit utilizes `target_compile_definitions`, introduced in CMake 2.8.11.