### PR TITLE
WIP feature: relocate built config/dictionary files to $user_data_dir/build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE_CXX ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cxx_fla
 project(rime)
 cmake_minimum_required(VERSION 2.8.11)
 
-set(rime_version 1.2.9)
+set(rime_version 1.2.10)
 set(rime_soversion 1)
 
 add_definitions(-DRIME_VERSION="${rime_version}")

--- a/src/rime/config/build_info_plugin.cc
+++ b/src/rime/config/build_info_plugin.cc
@@ -1,0 +1,39 @@
+//
+// Copyright RIME Developers
+// Distributed under the BSD License
+//
+#include <boost/filesystem.hpp>
+#include <rime/service.h>
+#include <rime/config/config_compiler.h>
+#include <rime/config/config_types.h>
+#include <rime/config/plugins.h>
+
+namespace rime {
+
+bool BuildInfoPlugin::ReviewCompileOutput(
+    ConfigCompiler* compiler, an<ConfigResource> resource) {
+  return true;
+}
+
+bool BuildInfoPlugin::ReviewLinkOutput(
+    ConfigCompiler* compiler, an<ConfigResource> resource) {
+  auto build_info = (*resource)["__build_info"];
+  build_info["rime_version"] = RIME_VERSION;
+  auto timestamps = build_info["timestamps"];
+  compiler->EnumerateResources([&](an<ConfigResource> resource) {
+    if (!resource->loaded) {
+      LOG(WARNING) << "resource '" << resource->resource_id << "' not loaded.";
+      return;
+    }
+    auto file_name = resource->data->file_name();
+    if (file_name.empty()) {
+      return;
+    }
+    // TODO: store as 64-bit number to avoid the year 2038 problem
+    timestamps[resource->resource_id] =
+        (int) boost::filesystem::last_write_time(file_name);
+  });
+  return true;
+}
+
+}  // namespace rime

--- a/src/rime/config/config_compiler.cc
+++ b/src/rime/config/config_compiler.cc
@@ -295,6 +295,13 @@ void ConfigCompiler::Pop() {
   graph_->Pop();
 }
 
+void ConfigCompiler::EnumerateResources(
+    function<void (an<ConfigResource> resource)> process_resource) {
+  for (const auto& r : graph_->resources) {
+    process_resource(r.second);
+  }
+}
+
 an<ConfigResource> ConfigCompiler::GetCompiledResource(
     const string& resource_id) const {
   return graph_->resources[resource_id];

--- a/src/rime/config/config_compiler.h
+++ b/src/rime/config/config_compiler.h
@@ -64,6 +64,8 @@ class ConfigCompiler {
   bool Parse(const string& key, const an<ConfigItem>& item);
   void Pop();
 
+  void EnumerateResources(
+      function<void (an<ConfigResource> resource)> process_resource);
   an<ConfigResource> GetCompiledResource(const string& resource_id) const;
   an<ConfigResource> Compile(const string& file_name);
   bool Link(an<ConfigResource> target);

--- a/src/rime/config/config_data.cc
+++ b/src/rime/config/config_data.cc
@@ -16,7 +16,7 @@
 namespace rime {
 
 ConfigData::~ConfigData() {
-  if (modified_ && !file_name_.empty())
+  if (auto_save_ && modified_ && !file_name_.empty())
     SaveToFile(file_name_);
 }
 

--- a/src/rime/config/config_data.h
+++ b/src/rime/config/config_data.h
@@ -37,6 +37,7 @@ class ConfigData {
   const string& file_name() const { return file_name_; }
   bool modified() const { return modified_; }
   void set_modified() { modified_ = true; }
+  void set_auto_save(bool auto_save) { auto_save_ = auto_save; }
 
   an<ConfigItem> root;
 
@@ -51,6 +52,7 @@ class ConfigData {
 
   string file_name_;
   bool modified_ = false;
+  bool auto_save_ = false;
 };
 
 }  // namespace rime

--- a/src/rime/config/plugins.h
+++ b/src/rime/config/plugins.h
@@ -45,6 +45,12 @@ class LegacyDictionaryConfigPlugin : public ConfigCompilerPlugin {
   Review ReviewLinkOutput;
 };
 
+class BuildInfoPlugin : public ConfigCompilerPlugin {
+ public:
+  Review ReviewCompileOutput;
+  Review ReviewLinkOutput;
+};
+
 }  // namespace rime
 
 #endif  // RIME_CONFIG_PLUGINS_H_

--- a/src/rime/config/plugins.h
+++ b/src/rime/config/plugins.h
@@ -51,6 +51,21 @@ class BuildInfoPlugin : public ConfigCompilerPlugin {
   Review ReviewLinkOutput;
 };
 
+class ResourceResolver;
+struct ResourceType;
+
+class SaveOutputPlugin : public ConfigCompilerPlugin {
+ public:
+  SaveOutputPlugin(const ResourceType& output_resource);
+  ~SaveOutputPlugin();
+
+  Review ReviewCompileOutput;
+  Review ReviewLinkOutput;
+
+ private:
+  the<ResourceResolver> resource_resolver_;
+};
+
 }  // namespace rime
 
 #endif  // RIME_CONFIG_PLUGINS_H_

--- a/src/rime/config/save_output_plugin.cc
+++ b/src/rime/config/save_output_plugin.cc
@@ -1,0 +1,33 @@
+//
+// Copyright RIME Developers
+// Distributed under the BSD License
+//
+#include <boost/filesystem.hpp>
+#include <rime/resource.h>
+#include <rime/service.h>
+#include <rime/config/config_compiler.h>
+#include <rime/config/config_types.h>
+#include <rime/config/plugins.h>
+
+namespace rime {
+
+SaveOutputPlugin::SaveOutputPlugin(const ResourceType& output_resource)
+    : resource_resolver_(new ResourceResolver(output_resource)) {
+  resource_resolver_->set_root_path(
+      Service::instance().deployer().user_data_dir);
+}
+
+SaveOutputPlugin::~SaveOutputPlugin() {}
+
+bool SaveOutputPlugin::ReviewCompileOutput(
+    ConfigCompiler* compiler, an<ConfigResource> resource) {
+  return true;
+}
+
+bool SaveOutputPlugin::ReviewLinkOutput(
+    ConfigCompiler* compiler, an<ConfigResource> resource) {
+  auto file_path = resource_resolver_->ResolvePath(resource->resource_id);
+  return resource->data->SaveToFile(file_path.string());
+}
+
+}  // namespace rime

--- a/src/rime/core_module.cc
+++ b/src/rime/core_module.cc
@@ -20,20 +20,21 @@ static void rime_core_initialize() {
   LOG(INFO) << "registering core components.";
   Registry& r = Registry::instance();
 
+  const ResourceType build_output{"config", "build/", ".yaml"};
   auto config_builder = new ConfigComponent<ConfigBuilder>(
-      [](ConfigBuilder* builder) {
+      [&](ConfigBuilder* builder) {
         builder->InstallPlugin(new AutoPatchConfigPlugin);
         builder->InstallPlugin(new DefaultConfigPlugin);
         builder->InstallPlugin(new LegacyPresetConfigPlugin);
         builder->InstallPlugin(new LegacyDictionaryConfigPlugin);
         builder->InstallPlugin(new BuildInfoPlugin);
+        builder->InstallPlugin(new SaveOutputPlugin(build_output));
       });
   r.Register("config_builder", config_builder);
 
-  //auto config_loader =
-  //    new ConfigComponent<ConfigLoader>({"config", "build/", ".yaml"});
-  r.Register("config", config_builder);
-  r.Register("schema", new SchemaComponent(config_builder));
+  auto config_loader = new ConfigComponent<ConfigLoader>(build_output);
+  r.Register("config", config_loader);
+  r.Register("schema", new SchemaComponent(config_loader));
 
   auto user_config = new ConfigComponent<ConfigLoader>(
       [](ConfigLoader* loader) {

--- a/src/rime/core_module.cc
+++ b/src/rime/core_module.cc
@@ -25,6 +25,7 @@ static void rime_core_initialize() {
   config->InstallPlugin(new DefaultConfigPlugin);
   config->InstallPlugin(new LegacyPresetConfigPlugin);
   config->InstallPlugin(new LegacyDictionaryConfigPlugin);
+  config->InstallPlugin(new BuildInfoPlugin);
   r.Register("config", config);
   r.Register("schema", new SchemaComponent(config));
 }

--- a/src/rime/core_module.cc
+++ b/src/rime/core_module.cc
@@ -20,14 +20,26 @@ static void rime_core_initialize() {
   LOG(INFO) << "registering core components.";
   Registry& r = Registry::instance();
 
-  auto config = new ConfigComponent;
-  config->InstallPlugin(new AutoPatchConfigPlugin);
-  config->InstallPlugin(new DefaultConfigPlugin);
-  config->InstallPlugin(new LegacyPresetConfigPlugin);
-  config->InstallPlugin(new LegacyDictionaryConfigPlugin);
-  config->InstallPlugin(new BuildInfoPlugin);
-  r.Register("config", config);
-  r.Register("schema", new SchemaComponent(config));
+  auto config_builder = new ConfigComponent<ConfigBuilder>(
+      [](ConfigBuilder* builder) {
+        builder->InstallPlugin(new AutoPatchConfigPlugin);
+        builder->InstallPlugin(new DefaultConfigPlugin);
+        builder->InstallPlugin(new LegacyPresetConfigPlugin);
+        builder->InstallPlugin(new LegacyDictionaryConfigPlugin);
+        builder->InstallPlugin(new BuildInfoPlugin);
+      });
+  r.Register("config_builder", config_builder);
+
+  //auto config_loader =
+  //    new ConfigComponent<ConfigLoader>({"config", "build/", ".yaml"});
+  r.Register("config", config_builder);
+  r.Register("schema", new SchemaComponent(config_builder));
+
+  auto user_config = new ConfigComponent<ConfigLoader>(
+      [](ConfigLoader* loader) {
+        loader->set_auto_save(true);
+      });
+  r.Register("user_config", user_config);
 }
 
 static void rime_core_finalize() {

--- a/src/rime/dict/dict_compiler.h
+++ b/src/rime/dict/dict_compiler.h
@@ -27,7 +27,7 @@ class DictCompiler {
     kDump = 4,
   };
 
-  RIME_API DictCompiler(Dictionary *dictionary);
+  RIME_API DictCompiler(Dictionary *dictionary, const string& prefix = "");
 
   RIME_API bool Compile(const string &schema_file);
   void set_options(int options) { options_ = options; }
@@ -37,13 +37,15 @@ class DictCompiler {
                   const vector<string>& dict_files,
                   uint32_t dict_file_checksum);
   bool BuildPrism(const string& schema_file,
-                  uint32_t dict_file_checksum, uint32_t schema_file_checksum);
+                  uint32_t dict_file_checksum,
+                  uint32_t schema_file_checksum);
   bool BuildReverseLookupDict(ReverseDb* db, uint32_t dict_file_checksum);
 
   string dict_name_;
   an<Prism> prism_;
   an<Table> table_;
   int options_ = 0;
+  string prefix_;
 };
 
 }  // namespace rime

--- a/src/rime/dict/dictionary.cc
+++ b/src/rime/dict/dictionary.cc
@@ -281,11 +281,11 @@ bool Dictionary::loaded() const {
 // DictionaryComponent members
 
 static const ResourceType kPrismResourceType = {
-  "prism", "", ".prism.bin"
+  "prism", "build/", ".prism.bin"
 };
 
 static const ResourceType kTableResourceType = {
-  "table", "", ".table.bin"
+  "table", "build/", ".table.bin"
 };
 
 DictionaryComponent::DictionaryComponent()
@@ -321,7 +321,6 @@ Dictionary*
 DictionaryComponent::CreateDictionaryWithName(const string& dict_name,
                                               const string& prism_name) {
   // obtain prism and table objects
-  boost::filesystem::path path(Service::instance().deployer().user_data_dir);
   auto table = table_map_[dict_name].lock();
   if (!table) {
     auto file_path = table_resource_resolver_->ResolvePath(dict_name).string();

--- a/src/rime/dict/reverse_lookup_dictionary.cc
+++ b/src/rime/dict/reverse_lookup_dictionary.cc
@@ -226,7 +226,7 @@ an<DictSettings> ReverseLookupDictionary::GetDictSettings() {
 }
 
 static const ResourceType kReverseDbResourceType = {
-  "reverse_db", "", ".reverse.bin"
+  "reverse_db", "build/", ".reverse.bin"
 };
 
 ReverseLookupDictionaryComponent::ReverseLookupDictionaryComponent()

--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -575,6 +575,7 @@ bool CleanupTrash::Run(Deployer* deployer) {
       continue;
     auto filename = entry.filename().string();
     if (filename == "rime.log" ||
+        boost::ends_with(filename, ".bin") ||
         boost::ends_with(filename, ".reverse.kct") ||
         boost::ends_with(filename, ".userdb.kct.old") ||
         boost::ends_with(filename, ".userdb.kct.snapshot")) {

--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -66,7 +66,7 @@ bool DetectModifications::Run(Deployer* deployer) {
   // TODO: store as 64-bit number to avoid the year 2038 problem
   int last_build_time = 0;
   {
-    the<Config> user_config(Config::Require("config")->Create("user"));
+    the<Config> user_config(Config::Require("user_config")->Create("user"));
     user_config->GetInt("var/last_build_time", &last_build_time);
   }
   if (last_modified > (time_t)last_build_time) {
@@ -235,7 +235,7 @@ bool WorkspaceUpdate::Run(Deployer* deployer) {
   LOG(INFO) << "finished updating schemas: "
             << success << " success, " << failure << " failure.";
 
-  the<Config> user_config(Config::Require("config")->Create("user"));
+  the<Config> user_config(Config::Require("user_config")->Create("user"));
   // TODO: store as 64-bit number to avoid the year 2038 problem
   user_config->SetInt("var/last_build_time", (int)time(NULL));
 

--- a/src/rime/lever/deployment_tasks.h
+++ b/src/rime/lever/deployment_tasks.h
@@ -7,11 +7,23 @@
 #ifndef RIME_DEPLOYMENT_TASKS_H_
 #define RIME_DEPLOYMENT_TASKS_H_
 
+#include <rime/common.h>
 #include <rime/deployer.h>
 
 namespace rime {
 
-// initialize/update installation.yaml, default.yaml
+// detects changes in either user configuration or upgraded shared data
+class DetectModifications : public DeploymentTask {
+ public:
+  DetectModifications(TaskInitializer arg = TaskInitializer());
+  // Unlike other tasks, its return value indicates whether modifications
+  // has been detected and workspace needs update.
+  bool Run(Deployer* deployer);
+ protected:
+  vector<string> data_dirs_;
+};
+
+// initialize/update installation.yaml
 class InstallationUpdate : public DeploymentTask {
  public:
   InstallationUpdate(TaskInitializer arg = TaskInitializer()) {}

--- a/src/rime/lever/levers_module.cc
+++ b/src/rime/lever/levers_module.cc
@@ -24,6 +24,7 @@ static void rime_levers_initialize() {
   Registry& r = Registry::instance();
 
   // deployment tools
+  r.Register("detect_modifications", new Component<DetectModifications>);
   r.Register("installation_update", new Component<InstallationUpdate>);
   r.Register("workspace_update", new Component<WorkspaceUpdate>);
   r.Register("schema_update", new Component<SchemaUpdate>);

--- a/src/rime/schema.h
+++ b/src/rime/schema.h
@@ -42,15 +42,15 @@ class Schema {
 
 class SchemaComponent : public Config::Component {
  public:
-  SchemaComponent(ConfigComponent* config_component)
+  SchemaComponent(Config::Component* config_component)
       : config_component_(config_component) {
   }
   // NOTE: creates `Config` for the schema
   Config* Create(const string& schema_id) override;
  private:
-  // we do not own the ConfigComponent, do not try to deallocate it
+  // we do not own the config component, do not try to deallocate it
   // also be careful that there is no guarantee it will outlive us
-  ConfigComponent* config_component_;
+  Config::Component* config_component_;
 };
 
 }  // namespace rime

--- a/src/rime/switcher.cc
+++ b/src/rime/switcher.cc
@@ -27,7 +27,7 @@ Switcher::Switcher(const Ticket& ticket) : Processor(ticket) {
   context_->select_notifier().connect(
       [this](Context* ctx) { OnSelect(ctx); });
 
-  user_config_.reset(Config::Require("config")->Create("user"));
+  user_config_.reset(Config::Require("user_config")->Create("user"));
   InitializeComponents();
   LoadSettings();
   RestoreSavedOptions();

--- a/src/rime_api.cc
+++ b/src/rime_api.cc
@@ -542,24 +542,28 @@ RIME_API Bool RimeSelectSchema(RimeSessionId session_id, const char* schema_id) 
 
 // config
 
-RIME_API Bool RimeSchemaOpen(const char *schema_id, RimeConfig* config) {
-  if (!schema_id || !config) return False;
-  Config::Component* cc = Config::Require("schema");
-  if (!cc) return False;
-  Config* c = cc->Create(schema_id);
-  if (!c) return False;
-  config->ptr = (void*)c;
-  return True;
-}
-
-RIME_API Bool RimeConfigOpen(const char *config_id, RimeConfig* config) {
+static Bool open_config_in_component(const char* config_component,
+                                     const char* config_id,
+                                     RimeConfig* config) {
   if (!config_id || !config) return False;
-  Config::Component* cc = Config::Require("config");
+  Config::Component* cc = Config::Require(config_component);
   if (!cc) return False;
   Config* c = cc->Create(config_id);
   if (!c) return False;
   config->ptr = (void*)c;
   return True;
+}
+
+RIME_API Bool RimeSchemaOpen(const char *schema_id, RimeConfig* config) {
+  return open_config_in_component("schema", schema_id, config);
+}
+
+RIME_API Bool RimeConfigOpen(const char *config_id, RimeConfig* config) {
+  return open_config_in_component("config", config_id, config);
+}
+
+RIME_API Bool RimeUserConfigOpen(const char* config_id, RimeConfig* config) {
+  return open_config_in_component("user_config", config_id, config);
 }
 
 RIME_API Bool RimeConfigClose(RimeConfig *config) {
@@ -1008,6 +1012,7 @@ RIME_API RimeApi* rime_get_api() {
     s_api.select_schema = &RimeSelectSchema;
     s_api.schema_open = &RimeSchemaOpen;
     s_api.config_open = &RimeConfigOpen;
+    s_api.user_config_open = &RimeUserConfigOpen;
     s_api.config_close = &RimeConfigClose;
     s_api.config_get_bool = &RimeConfigGetBool;
     s_api.config_get_int = &RimeConfigGetInt;

--- a/src/rime_api.cc
+++ b/src/rime_api.cc
@@ -105,8 +105,9 @@ RIME_API Bool RimeStartMaintenance(Bool full_check) {
   }
   if (!full_check) {
     TaskInitializer args{
-        make_pair<string, string>("default.yaml", "config_version")};
-    if (!deployer.RunTask("config_file_update", args)) {
+      vector<string>{deployer.user_data_dir, deployer.shared_data_dir}
+    };
+    if (!deployer.RunTask("detect_modifications", args)) {
       return False;
     }
     LOG(INFO) << "changes detected; starting maintenance.";

--- a/src/rime_api.h
+++ b/src/rime_api.h
@@ -283,6 +283,8 @@ RIME_API Bool RimeSelectSchema(RimeSessionId session_id, const char* schema_id);
 RIME_API Bool RimeSchemaOpen(const char* schema_id, RimeConfig* config);
 // <config_id>.yaml
 RIME_API Bool RimeConfigOpen(const char* config_id, RimeConfig* config);
+// access config files in user data directory, eg. user.yaml and installation.yaml
+RIME_API Bool RimeUserConfigOpen(const char* config_id, RimeConfig* config);
 RIME_API Bool RimeConfigClose(RimeConfig* config);
 RIME_API Bool RimeConfigInit(RimeConfig* config);
 RIME_API Bool RimeConfigLoadString(RimeConfig* config, const char* yaml);
@@ -512,6 +514,9 @@ typedef struct rime_api_t {
   Bool (*candidate_list_begin)(RimeSessionId session_id, RimeCandidateListIterator* iterator);
   Bool (*candidate_list_next)(RimeCandidateListIterator* iterator);
   void (*candidate_list_end)(RimeCandidateListIterator* iterator);
+
+  // access config files in user data directory, eg. user.yaml and installation.yaml
+  Bool (*user_config_open)(const char *config_id, RimeConfig* config);
 
 } RimeApi;
 

--- a/test/config_compiler_test.cc
+++ b/test/config_compiler_test.cc
@@ -17,7 +17,7 @@ class RimeConfigCompilerTestBase : public ::testing::Test {
   virtual string test_config_id() const = 0;
 
   virtual void SetUp() {
-    component_.reset(new ConfigComponent);
+    component_.reset(new ConfigComponent<ConfigBuilder>);
     config_.reset(component_->Create(test_config_id()));
   }
 

--- a/test/config_test.cc
+++ b/test/config_test.cc
@@ -16,7 +16,7 @@ class RimeConfigTest : public ::testing::Test {
   RimeConfigTest() = default;
 
   virtual void SetUp() {
-    component_.reset(new ConfigComponent);
+    component_.reset(new ConfigComponent<ConfigLoader>);
     config_.reset(component_->Create("config_test"));
   }
 
@@ -30,7 +30,10 @@ class RimeConfigTest : public ::testing::Test {
 TEST(RimeConfigComponentTest, RoundTrip) {
   // registration
   Registry& r = Registry::instance();
-  r.Register("test_config", new ConfigComponent);
+  r.Register("test_config", new ConfigComponent<ConfigLoader>(
+      [](ConfigLoader* loader) {
+        loader->set_auto_save(true);
+      }));
   // find component
   Config::Component* cc = Config::Require("test_config");
   ASSERT_TRUE(cc != NULL);


### PR DESCRIPTION
These changes aim to fix #164, fix rime/weasel#99, fix osfans/PRIME#30, and close rime/ibus-rime#37.

- [x] quick check for rebuilding workspace on startup based on file/dir timestamps
Used to compare the checksum of $user_data_dir/default.yaml, but the file is now optional.
- [x] relocate *.bin files to build/
- [x] compile YAML config and save the compiled copy in build/; save build info
- [x] check if dictionary needs rebuild by detecting changes in the built config file
Detection for changes in YAML (could invalidate *.prism.bin) is now broken by cross-file YAML references. It requires all contents are gathered into the checksummed file.
- [x] cleanup *.bin and copied/patched YAML in $user_data_dir from older release
- [x] bump version number