### PR TITLE
chore(CHANGELOG.md): auto-generate conventional changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,7 @@ thirdparty/bin/*
 thirdparty/data/*
 thirdparty/src/*/*
 env.bat
+node_modules/
+package-lock.json
 *~
 .*.swp

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+tag-version-prefix="rime-"
+message="chore(release): %s :tada:"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,251 +64,249 @@
 
 
 
-2014-12-14  GONG Chen  <chen.sst@gmail.com>
+# 1.2.9 (2014-12-14)
 
-	* CMakeLists.txt: bump version to 1.2.9.
-	* Makefile: add make targets 'thirdparty/*' to build individual libraries.
-	* include/rime_api.h: add RIME_MODULE_LIST, RIME_REGISTER_MODULE_GROUP.
-	* legacy/src/legacy_module.cc: plugin module 'rime-legacy' for GPL'd code,
-	providing component 'legacy_userdb' for user dictionary upgrade.
-	* src/setup.cc: define module groups "default" and "deployer", to avoid
-	naming a list of built-bin modules in RimeTraits::modules.
-	* test/table_test.cc: fix random segment faults when run shuffled.
-	* thirdparty/src/leveldb: new dependency LevelDB, replacing Kyoto Cabinet.
-	* dict/level_db: userdb implementation based on LevelDB, replacing treeDb.
-	* dict/tree_db: moved to legacy/src/.
-	* dict/user_db: refactored and modularized to ease adding implementations.
-	* gear/memory: save cached phrases as soon as the next composition begins.
-	* gear/recognizer: match space iff set recognizer/use_space: true.
-	* gear/simplifier: catch and log OpenCC exceptions when loading.
-	* gear/single_char_filter: bring single character candidates to the front.
-	* lever/deployment_tasks: update and rename task 'user_dict_upgrade'.
 
-2014-11-02  LEO Yoon-Tsaw  <lyc20041@gmail.com>
+* **rime_api.h:** add `RIME_MODULE_LIST`, `RIME_REGISTER_MODULE_GROUP`.
+* **Makefile:** add make targets `thirdparty/*` to build individual libraries.
+* **legacy/src/legacy_module.cc:** plugin module `rime-legacy` for GPL code,
+  providing component `legacy_userdb` for user dictionary upgrade.
+* **src/setup.cc:** define module groups `"default"` and `"deployer"`, to avoid
+	naming a list of built-bin modules in `RimeTraits::modules`.
+* **test/table_test.cc:** fix random segment faults when run shuffled.
+* **thirdparty/src/leveldb:** new dependency LevelDB, replacing Kyoto Cabinet.
+* **dict/level_db:** userdb implementation based on LevelDB, replacing treeDb.
+* **dict/tree_db:** moved to `legacy/src/`.
+* **dict/user_db:** refactored and modularized to ease adding implementations.
+* **gear/cjk_minifier:** support CJK Extension E.
+* **gear/memory:** save cached phrases as soon as the next composition begins.
+* **gear/recognizer:** match space iff set `recognizer/use_space: true`.
+* **gear/simplifier:** catch and log OpenCC exceptions when loading.
+* **gear/single_char_filter:** bring single character candidates to the front.
+* **gear/simplifier:** adapt to OpenCC 1.0 API.
+* **thirdparty/src/opencc:** update OpenCC to v1.0.2 (incompatible with v0.4).
+* **lever/deployment_tasks:** update and rename task `user_dict_upgrade`.
 
-	* gear/cjk_minifier: support CJK Extension E.
 
-2014-10-20  Carbo Kuo  <byvoid@byvoid.com>
-	* gear/simplifier: adapt to OpenCC 1.0 API.
-	* thirdparty/src/opencc: update OpenCC to v1.0.2 (incompatible with v0.4).
 
-2014-07-15  GONG Chen  <chen.sst@gmail.com>
+# 1.2 (2014-07-15)
 
-	* config: support references to list elements in key paths.
-	eg. 'schema_list/@0/schema' is the id of the first schema in schema list.
-	* rime_api: add API functions to access complex structures in config;
-	add API to get the raw input and cursor position, or to select a candidate.
-	* switcher: enable folding IME options in the switcher menu.
-	* dict_compiler: also detect changes in essay when updating a dictionary;
-	support updating prism without the source file of the dictionary.
-	* preset_vocabulary: load 'essay.txt' instead of 'essay.kct'.
-	* reverse_lookup_dictionary: adopt a new file format with 50% space saving.
-	* table: add support for a new binary format with 20% space saving;
-	fix alignment on ARM.
-	* ascii_composer: do not toggle IME states when long pressing Shift key;
-	support discarding unfinished input when switching to ASCII mode.
-	* affix_segmentor: fix issues with selecting a partial-match candidate.
-	* chord_composer: commit raw input composed with original key strokes.
-	* navigator: do not use BackSpace to revert selecting a candidate but to
-	edit the input after moving the cursor left or right.
-	* punctuator: support 'ascii_punct' option for switching between Chinese and
-	Western (ASCII) punctuations.
-	* speller: auto-select candidates by pattern matching against the code;
-	fix issues to cooperate with punctuator.
-	* CMakeLists.txt: add options ENABLE_LOGGING and BOOST_USE_CXX11;
-	introduce a new dependency: libmarisa.
-	* cmake/FindYamlCpp.cmake: check the availability of the new (v0.5) API.
-	* sample: the directory containing a sample plug-in module.
-	* tools/rime_patch.cc: a command line tool to create patches.
-	* thirdparty: include source code of third-party libraries to ease
-	building librime on Windows and Mac.
 
-	- Release: 1.2
+* **rime_api:** add API functions to access complex structures in config;
+  add API to get the raw input and cursor position, or to select a candidate.
+* **config:** support references to list elements in key paths.
+  eg. `schema_list/@0/schema` is the id of the first schema in schema list.
+* **switcher:** enable folding IME options in the switcher menu.
+* **dict_compiler:** also detect changes in essay when updating a dictionary;
+  support updating prism without the source file of the dictionary.
+* **preset_vocabulary:** load `essay.txt` instead of `essay.kct`.
+* **reverse_lookup_dictionary:** adopt a new file format with 50% space saving.
+* **table:** add support for a new binary format with 20% space saving;
+  fix alignment on ARM.
+* **ascii_composer:** do not toggle IME states when long pressing `Shift` key;
+  support discarding unfinished input when switching to ASCII mode.
+* **affix_segmentor:** fix issues with selecting a partial-match candidate.
+* **chord_composer:** commit raw input composed with original key strokes.
+* **cjk_minifier:** a filter to hide characters in CJK extension set, works
+  with `script_translator`.
+* **navigator:** do not use `BackSpace` to revert selecting a candidate but to
+  edit the input after moving the cursor left or right.
+* **punctuator:** support `ascii_punct` option for switching between Chinese and
+  Western (ASCII) punctuations.
+* **speller:** auto-select candidates by pattern matching against the code;
+  fix issues to cooperate with punctuator.
+* **CMakeLists.txt:** add options `ENABLE_LOGGING` and `BOOST_USE_CXX11`;
+  introduce a new dependency: `libmarisa`.
+* **cmake/FindYamlCpp.cmake:** check the availability of the new (v0.5) API.
+* **sample:** the directory containing a sample plug-in module.
+* **tools/rime_patch.cc:** a command line tool to create patches.
+* **thirdparty:** include source code of third-party libraries to ease
+  building librime on Windows and Mac.
 
-2014-03-31  Chongyu Zhu  <i@lembacon.com>
 
-	* cjk_minifier: a filter to hide characters in CJK extension set, works
-	with script_translator.
 
-2013-12-26  GONG Chen  <chen.sst@gmail.com>
+# 1.1 (2013-12-26)
 
-	* new build dependency: compiler with C++11 support.
-	tested with GCC 4.8.2, Apple LLVM version 5.0, MSVC 12 (2013).
-	* encoder: disable warnings for phrase encode failures in log output;
-	limit the number of results in encoding a phrase with multiple solutions.
-	* punctuator: fixed a bug in matching nested "pairs of 'symbols'".
-	* speller: better support for auto-committing, allowing users of table
-	based input schemata to omit explicitly selecting candidates in many cases.
-	* schema_list_translator: option for static schema list order.
-	* table_translator: fixed the range of CJK-D in charset filter.
 
-	- Release: 1.1
+* **new build dependency:** compiler with C++11 support.
+  tested with GCC 4.8.2, Apple LLVM version 5.0, MSVC 12 (2013).
+* **encoder:** disable warnings for phrase encode failures in log output;
+  limit the number of results in encoding a phrase with multiple solutions.
+* **punctuator:** fixed a bug in matching nested "pairs of 'symbols'".
+* **speller:** better support for auto-committing, allowing users of table
+  based input schema to omit explicitly selecting candidates in many cases.
+* **schema_list_translator:** option for static schema list order.
+* **table_translator:** fixed the range of CJK-D in charset filter.
 
-2013-11-10  GONG Chen  <chen.sst@gmail.com>
 
-	* rime_api: version 1.0 breaks ABI compatiblility.
 
-	the minimum changes in code required to migrate from rime 0.9 api is
-	to initialize RimeTraits with either RIME_STRUCT or RIME_STRUCT_INIT macro.
+# 1.0 (2013-11-10)
 
-	while source code compatibility is largely maintained with the exception
-	of the aforementioned RimeTraits structure, rime 1.0 introduces a version
-	controlled RimeApi structure which provides all the api functions.
 
-	* module: suppport adding modules; modulize 'gears' and 'levers'.
-	* ticket: used to instantiate compnents and to associate the instance with
-	a name space in the configuration.
-	* encoder: encode new phrases for table_translator and script_translator
-	using different rules.
-	* affix_segmentor: strip optional prefix and suffix from a code segment.
-	* reverse_lookup_filter: lookup candidate text for code in a specified
-	dictonary.
-	* shape: add full-shape support.
-	* key_binder: switch input schemata and toggle options with hotkeys.
-	* switcher: list input schemata ordered by recency; support radio options.
-	* tsv: fix reading user dict snapshot files with DOS line endings.
-	* entry_collector: support custom order of table columns in *.dict.yaml.
-	* CMakeLists.txt: add options BUILD_TEST and BUILD_SEPARATE_LIBS.
+* **rime_api:** version 1.0 breaks ABI compatiblility.
 
-	- Release: 1.0
+  the minimum changes in code required to migrate from rime 0.9 api is to
+  initialize `RimeTraits` with either `RIME_STRUCT` or `RIME_STRUCT_INIT` macro.
 
-2013-05-05  GONG Chen  <chen.sst@gmail.com>
+  while source code compatibility is largely maintained with the exception
+  of the aforementioned `RimeTraits` structure, rime 1.0 introduces a version
+  controlled `RimeApi` structure which provides all the api functions.
 
-	* config: update yaml-cpp to version 0.5 (with new API);
-	emit prettier yaml.
-	* deployer: introduce a work thread for ordinary background tasks.
-	* algo/calculus: 'fuzz' calculation, to create lower quality spellings.
-	* dict/dict_compiler: importing external table files into *.dict.yaml.
-	* dict/entry_collector: support '# no comment' directive in *.dict.yaml.
-	* dict/table_db: 'tabledb' and 'stabledb' to support custom phrase.
-	* dict/user_db: implement 'plain_userdb', in plain text files.
-	* dict/user_dictionary: recover damaged userdb in work thread.
-	* gear/ascii_composer: fix unexpected mode switching with Caps Lock.
-	* gear/editor: delete previous syllable with Control+BackSpace.
-	* gear/*_translator: support multiple translator instances in a engine.
-	* gear/script_translator: rename r10n_translator to script_translator.
-	* lever/user_dict_manager: create snapshots in plain userdb format.
-	* rime_deployer: with command line option '--compile',
-	dump table/prism contents into text files while compiling a dictionary.
+* **module:** suppport adding modules; modularize `gears` and `levers`.
+* **ticket:** used to instantiate compnents and to associate the instance with
+  a name space in the configuration.
+* **encoder:** encode new phrases for `table_translator` and `script_translator`
+  using different rules.
+* **affix_segmentor:** strip optional prefix and suffix from a code segment.
+* **reverse_lookup_filter:** lookup candidate text for code in a specified
+  dictonary.
+* **shape:** add full-shape support.
+* **key_binder:** switch input schemata and toggle options with hotkeys.
+* **switcher:** list input schemata ordered by recency; support radio options.
+* **tsv:** fix reading user dict snapshot files with DOS line endings.
+* **entry_collector:** support custom order of table columns in `*.dict.yaml`.
+* **CMakeLists.txt:** add options `BUILD_TEST` and `BUILD_SEPARATE_LIBS`.
 
-	- Release: 0.9.9
 
-2013-02-02  GONG Chen  <chen.sst@gmail.com>
 
-	* ascii_composer: support customizing Caps Lock behavior.
+# 0.9.9 (2013-05-05)
 
-	* speller: support auto-selecting unique candidates.
-	add options 'speller/use_space' and 'speller/finals' for bopomofo.
 
-	* punctuator: display half-shape, full-shape labels.
-	support committing a phrase with a trailing space character.
-	support inputting special characters with mnemonics such as '/ts'.
+* **config:** update yaml-cpp to version 0.5 (with new API); emit prettier yaml.
+* **deployer:** introduce a work thread for ordinary background tasks.
+* **algo/calculus:** `fuzz` calculation, to create lower quality spellings.
+* **dict/dict_compiler:** importing external table files into `*.dict.yaml`.
+* **dict/entry_collector:** support `# no comment` directive in `*.dict.yaml`.
+* **dict/table_db:** `tabledb` and `stabledb` to support custom phrase.
+* **dict/user_db:** implement `plain_userdb`, in plain text files.
+* **dict/user_dictionary:** recover damaged userdb in work thread.
+* **gear/ascii_composer:** fix unexpected mode switching with Caps Lock.
+* **gear/editor:** delete previous syllable with `Control+BackSpace`.
+* **gear/*_translator:** support multiple translator instances in a engine.
+* **gear/script_translator:** rename `r10n_translator` to `script_translator`.
+* **lever/user_dict_manager:** create snapshots in plain userdb format.
+* **rime_deployer:** with command line option `--compile`,
+  dump table/prism contents into text files while compiling a dictionary.
 
-	* user_dictionary: fix abnormal records introduced by a bug in merging.
-	* prism, table: avoid creating / loading incomplete dictionary files.
 
-	* context: clear transient options (whose names start with '_') and
-	properties when loading a different schema.
-	chord_composer sets '_chord_typing' so that the input method program would
-	know that a chord-typing schema is in use.
 
-	* deployment_tasks.cc(BackupConfigFiles::Run): while synching user data,
-	backup user created / modified YAML files.
+## 0.9.8 (2013-02-02)
 
-	* deployer.cc(Deployer::JoinMaintenanceThread): fix a boost-related crash.
 
-	- Release: 0.9.8
+* **ascii_composer:** support customizing Caps Lock behavior.
 
-2013-01-16  GONG Chen  <chen.sst@gmail.com>
+* **speller:** support auto-selecting unique candidates.
+  add options `speller/use_space` and `speller/finals` for bopomofo.
 
-	* ascii_composer: support changing conversion mode with Caps Lock.
-	fixed Control + letter key in temporary ascii mode.
-	pressing Command/Super + Shift shouldn't toggle ascii mode.
+* **punctuator:** display half-shape, full-shape labels.
+  support committing a phrase with a trailing space character.
+  support inputting special characters with mnemonics such as `/ts`.
 
-	* user_dictionary(UserDictionary::FetchTickCount):
-	tick was reset to zero when I/O error is encountered,
-	messing up order of user dict entries.
+* **user_dictionary:** fix abnormal records introduced by a bug in merging.
+* **prism, table:** avoid creating / loading incomplete dictionary files.
 
-	* user_dict_manager(UserDictManager::Restore):
-	used to favor imported entries too much while merging snapshots.
+* **context:** clear transient options (whose names start with `_`) and
+  properties when loading a different schema.
+  `chord_composer` sets `_chord_typing` so that the input method program would
+  know that a chord-typing schema is in use.
 
-	- Release: 0.9.7
+* **deployment_tasks.cc(BackupConfigFiles::Run):** while synching user data,
+  backup user created / modified YAML files.
 
-2013-01-12  GONG Chen  <chen.sst@gmail.com>
+* **deployer.cc(Deployer::JoinMaintenanceThread):** fix a boost-related crash.
 
-	* rime_deployer:
-	manipulate user's schema list with command line options
-	--add-schema, --set-active-schema
 
-	* rime_dict_manager: add command line option --sync
 
-	* rime_api.h (RimeSyncUserData):
-	add API function to start a data synching task in maintenance thread.
+## 0.9.7 (2013-01-16)
 
-	* rime_api.h (RimeSetNotificationHandler):
-	setup a callback function to receive notifcations from librime.
-	* rime_api.h (RimeGetProperty, RimeSetProperty):
-	add API functions to access session specific string properties.
 
-	* config: support subscript, assignment operators
-	and simplified value accessors.
+* **ascii_composer:** support changing conversion mode with Caps Lock.
+  fixed Control + letter key in temporary ascii mode.
+  pressing Command/Super + Shift shouldn't toggle ascii mode.
 
-	* user_db: optimize user_db for space efficiency;
-	avoid blocking user input when the database file needs repair.
+* **user_dictionary(UserDictionary::FetchTickCount):**
+  tick was reset to zero when I/O error is encountered,
+  messing up order of user dict entries.
 
-	* user_dictionary: add transaction support.
-	* memory: cancel memorizing newly committed phrases that has been
-	immediately erased with BackSpace key.
+* **user_dict_manager(UserDictManager::Restore):**
+  used to favor imported entries too much while merging snapshots.
 
-	* navigator: move caret left by syllable in phonetic input schemas.
 
-	* express_editor: fix problem memorizing phrases committed with return key.
-	* table_translator: add option 'translator/enable_sentence'.
-	* reverse_lookup_translator:
-	a reverse lookup segment can be suffixed by a delimiter.
-	phonetic abbreviations now come after completion results in a mixed input scenario.
 
-	- Release: 0.9.6
+## 0.9.6 (2013-01-12)
 
-2012-09-26  GONG Chen  <chen.sst@gmail.com>
 
-	* new dependency: 'google-glog'.
-	* CMakeLists.txt: fix x64 build.
+* **rime_deployer:** manipulate user's schema list with command line options
+  `--add-schema`, `--set-active-schema`
 
-	- Release: 0.9.4-1
+* **rime_dict_manager:** add command line option `--sync`
 
-2012-09-25  GONG Chen  <chen.sst@gmail.com>
+* **rime_api.h (RimeSyncUserData):**
+  add API function to start a data synching task in maintenance thread.
 
-	* table_translator: add user dictionary.
-	* deployment_tasks: automatically build schema dependencies.
-	* logging: adopt google-glog.
-	* brise: install data files from a separate package.
-	* new API: accessing schema list.
-	* new API: enabling/disabling soft cursor in preedit string.
+* **rime_api.h (RimeSetNotificationHandler):**
+  setup a callback function to receive notifcations from librime.
+* **rime_api.h (RimeGetProperty, RimeSetProperty):**
+  add API functions to access session specific string properties.
 
-	- Release: 0.9.3
+* **config:** support subscript, assignment operators and simplified value accessors.
 
-2012-07-08  GONG Chen  <chen.sst@gmail.com>
+* **user_db:** optimize `user_db` for space efficiency;
+  avoid blocking user input when the database file needs repair.
 
-	* chord_composer: combine multiple keys to compose a syllable at once.
-	* configuration: global page_size setting.
-	* API: extend the API to support inline mode.
-	* table_translator: add option to filter candidates by character set.
-	* user_dictionary: automatic recovery for corrupted databases.
-	* user_dictionary: fixed a bug that was responsible for missing user phrases.
+* **user_dictionary:** add transaction support.
+* **memory:** cancel memorizing newly committed phrases that has been
+  immediately erased with `BackSpace` key.
 
-	* rime_deployer: a utility program to prepare Rime's workspace.
-	* rime_dict_manager: a utility program to import/export user dictionaries.
+* **navigator:** move caret left by syllable in phonetic input schemas.
 
-	* librime: include 'brise', a collection of preset schemata in the package.
-	* new schema: Middle Chinese Phonetic Transcription.
-	* new schema: IPA input method in X-SAMPA.
+* **express_editor:** fix problem memorizing phrases committed with return key.
+* **table_translator:** add option `translator/enable_sentence`.
+* **reverse_lookup_translator:**
+  a reverse lookup segment can be suffixed by a delimiter.
+  phonetic abbreviations now come after completion results in a mixed input scenario.
 
-	- Release: 0.9.2-1
 
-2012-05-06  GONG Chen  <chen.sst@gmail.com>
 
-	- Revised API.
+## 0.9.4-1 (2012-09-26)
 
-	- Release: 0.9.1-1
+
+* **new dependency:** 'google-glog'.
+* **CMakeLists.txt:** fix x64 build.
+
+
+
+## 0.9.3 (2012-09-25)
+
+
+* **table_translator:** add user dictionary.
+* **deployment_tasks:** automatically build schema dependencies.
+* **logging:** adopt google-glog.
+* **brise:** install data files from a separate package.
+* **new API:** accessing schema list.
+* **new API:** enabling/disabling soft cursor in preedit string.
+
+
+
+## 0.9.2-1 (2012-07-08)
+
+
+* **chord_composer:** combine multiple keys to compose a syllable at once.
+* **configuration:** global `page_size` setting.
+* **API:** extend the API to support inline mode.
+* **table_translator:** add option to filter candidates by character set.
+* **user_dictionary:** automatic recovery for corrupted databases.
+* **user_dictionary:** fixed a bug that was responsible for missing user phrases.
+* **rime_deployer:** a utility program to prepare Rime's workspace.
+* **rime_dict_manager:** a utility program to import/export user dictionaries.
+* **librime:** include `brise`, a collection of preset schemata in the package.
+* **new schema:** Middle Chinese Phonetic Transcription.
+* **new schema:** IPA input method in X-SAMPA.
+
+
+
+## 0.9.1-1 (2012-05-06)
+
+
+* Revised API.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,69 @@
+<a name="1.2.10"></a>
+## 1.2.10 (2018-02-21)
+
+
+### Bug Fixes
+
+* **config_compiler:** linking failure on blocking root node of a dependency resource ([ecf3397](https://github.com/rime/librime/commit/ecf3397))
+* table_translator not making sentence if table entry is hidden by charset filter. ([77eb12e](https://github.com/rime/librime/commit/77eb12e))
+* **appveyor.install.bat:** switch to a more stable download server for libboost ([bcc4d10](https://github.com/rime/librime/commit/bcc4d10))
+* **appveyor.yml:** archive header files ([c8b1e67](https://github.com/rime/librime/commit/c8b1e67))
+* **ascii_composer:** support key binding Shift+space in ascii mode ([7077389](https://github.com/rime/librime/commit/7077389))
+* **build.bat:** fix build errors with VS2015 build tools ([ec940c6](https://github.com/rime/librime/commit/ec940c6))
+* **calculus, recognizer:** memory leak due to unchecked regex error ([19ddc1e](https://github.com/rime/librime/commit/19ddc1e)), closes [#171](https://github.com/rime/librime/issues/171)
+* **chord_composer:** allow editor to define BackSpace key behavior ([7f41f65](https://github.com/rime/librime/commit/7f41f65))
+* **chord_composer:** letters with modifier keys should not be committed by a following enter key ([aab5eb8](https://github.com/rime/librime/commit/aab5eb8))
+* **ci:** call cmake under /usr/local with sudo by passing $PATH environment variable ([a0e6d2f](https://github.com/rime/librime/commit/a0e6d2f))
+* **cmake:** fix build break for mingw ([939893c](https://github.com/rime/librime/commit/939893c))
+* **config:** auto save modified config data; fixes [#144](https://github.com/rime/librime/issues/144) ([2736f4b](https://github.com/rime/librime/commit/2736f4b))
+* **config:** treat "@" as map key rather than list index ([a1df9c5](https://github.com/rime/librime/commit/a1df9c5))
+* **config_compiler:** duplicate PendingChild dependencies happen from multiple commands on the same node ([25c28f8](https://github.com/rime/librime/commit/25c28f8))
+* **config_compiler:** enforce dependency priorities ([69a6f3e](https://github.com/rime/librime/commit/69a6f3e))
+* **config_compiler:** null value should not overwrite a normal key in a merged tree ([4ecae44](https://github.com/rime/librime/commit/4ecae44))
+* **config_compiler:** template operator overload had compile error with NDK ([71817a0](https://github.com/rime/librime/commit/71817a0))
+* **config/build_info_plugin:** referenced but unavailable resources should also be recorded ([cd46f7a](https://github.com/rime/librime/commit/cd46f7a))
+* **ConfigFileUpdate:** should succeed if shared copy does not exist ([8a3e25c](https://github.com/rime/librime/commit/8a3e25c))
+* **custom_settings:** fall back to $shared_data_dir/build when loading config ([caf8ebb](https://github.com/rime/librime/commit/caf8ebb))
+* **custom_settings:** load built settings from $user_data_dir/build directory ([463dc09](https://github.com/rime/librime/commit/463dc09))
+* **deployment_tasks:** symbols.yaml is no longer a build target ([f920e4f](https://github.com/rime/librime/commit/f920e4f))
+* **dict_compiler:** prism should load compiled schema ([c2fd0cf](https://github.com/rime/librime/commit/c2fd0cf)), closes [#176](https://github.com/rime/librime/issues/176)
+* **key_event:** KeySequence::repr() prefer unescaped punctuation characters ([aa43e5e](https://github.com/rime/librime/commit/aa43e5e))
+* **levers:** update deployment tasks for copy-free resource resolution ([1f86413](https://github.com/rime/librime/commit/1f86413))
+* **Makefile:** make install-debug; do return error code on mac ([1177142](https://github.com/rime/librime/commit/1177142))
+* **rime_api:** use user_config_open() to access user.yaml ([4e4a491](https://github.com/rime/librime/commit/4e4a491))
+* **rime_console:** not showing switcher's context ([632cf4b](https://github.com/rime/librime/commit/632cf4b))
+* **schema:** create a "schema" component that opens Config by schema_id ([555f990](https://github.com/rime/librime/commit/555f990))
+* **simplifier:** fix crash if no opencc file ([091cb9d](https://github.com/rime/librime/commit/091cb9d))
+* **simplifier:** tips option for show_in_comment simplifier ([e7bb757](https://github.com/rime/librime/commit/e7bb757))
+* **uniquifier:** half of the duplicate candidates remain after dedup [Closes [#114](https://github.com/rime/librime/issues/114)] ([2ab76bc](https://github.com/rime/librime/commit/2ab76bc))
+
+
+### Features
+
+* **build.bat:** customize build settings via environment variables ([#178](https://github.com/rime/librime/issues/178)) ([1678b75](https://github.com/rime/librime/commit/1678b75))
+* **chord_composer:** accept escaped chording keys ([79a32b2](https://github.com/rime/librime/commit/79a32b2))
+* **chord_composer:** support chording with function keys ([48424d3](https://github.com/rime/librime/commit/48424d3))
+* **config:** add config compiler plugin that includes default:/menu into schema ([b51dda8](https://github.com/rime/librime/commit/b51dda8))
+* **config:** best effort resolution for circurlar dependencies ([2e52d54](https://github.com/rime/librime/commit/2e52d54))
+* **config:** build config files if source files changed ([0d79712](https://github.com/rime/librime/commit/0d79712))
+* **config:** config compiler plugins that port legacy features to the new YAML syntax ([a7d253e](https://github.com/rime/librime/commit/a7d253e))
+* **config:** config_builder saves output to $rime_user_dir/build/ ([e596155](https://github.com/rime/librime/commit/e596155))
+* **config:** references to optional config resources, ending with "?" ([14ec858](https://github.com/rime/librime/commit/14ec858))
+* **config:** save __build_info in compiled config ([45a7337](https://github.com/rime/librime/commit/45a7337))
+* **config:** separate out config_builder and user_config components ([9e9493b](https://github.com/rime/librime/commit/9e9493b))
+* **config:** support append and merge syntax ([04dcf42](https://github.com/rime/librime/commit/04dcf42))
+* **customizer:** disable saving patched config files ([88f5a0c](https://github.com/rime/librime/commit/88f5a0c))
+* **detect_modifications:** quick test based on last write time of files ([285fbcc](https://github.com/rime/librime/commit/285fbcc))
+* **dict:** no conditional compilation on arm ([85b945f](https://github.com/rime/librime/commit/85b945f))
+* **dict:** relocate binary files to $user_data_dir/build ([bc66a47](https://github.com/rime/librime/commit/bc66a47))
+* **dict:** use resource resolver to find dictionary files ([8ea08b3](https://github.com/rime/librime/commit/8ea08b3))
+* add property notifier ([fa7b5a5](https://github.com/rime/librime/commit/fa7b5a5))
+* **resource_resolver:** add class and unit test ([03ee8b4](https://github.com/rime/librime/commit/03ee8b4))
+* **resource_resolver:** fallback root path ([02151da](https://github.com/rime/librime/commit/02151da))
+* **translator:** add history_translator ([#115](https://github.com/rime/librime/issues/115)) ([ae13354](https://github.com/rime/librime/commit/ae13354))
+
+
+
 2014-12-14  GONG Chen  <chen.sst@gmail.com>
 
 	* CMakeLists.txt: bump version to 1.2.9.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,8 +63,8 @@
 * **translator:** add history_translator ([#115](https://github.com/rime/librime/issues/115)) ([ae13354](https://github.com/rime/librime/commit/ae13354))
 
 
-
-# 1.2.9 (2014-12-14)
+<a name="1.2.9"></a>
+## 1.2.9 (2014-12-14)
 
 
 * **rime_api.h:** add `RIME_MODULE_LIST`, `RIME_REGISTER_MODULE_GROUP`.
@@ -88,8 +88,8 @@
 * **lever/deployment_tasks:** update and rename task `user_dict_upgrade`.
 
 
-
-# 1.2 (2014-07-15)
+<a name="1.2"></a>
+## 1.2 (2014-07-15)
 
 
 * **rime_api:** add API functions to access complex structures in config;
@@ -124,8 +124,8 @@
   building librime on Windows and Mac.
 
 
-
-# 1.1 (2013-12-26)
+<a name="1.1"></a>
+## 1.1 (2013-12-26)
 
 
 * **new build dependency:** compiler with C++11 support.
@@ -139,8 +139,8 @@
 * **table_translator:** fixed the range of CJK-D in charset filter.
 
 
-
-# 1.0 (2013-11-10)
+<a name="1.0"></a>
+## 1.0 (2013-11-10)
 
 
 * **rime_api:** version 1.0 breaks ABI compatiblility.
@@ -151,7 +151,6 @@
   while source code compatibility is largely maintained with the exception
   of the aforementioned `RimeTraits` structure, rime 1.0 introduces a version
   controlled `RimeApi` structure which provides all the api functions.
-
 * **module:** suppport adding modules; modularize `gears` and `levers`.
 * **ticket:** used to instantiate compnents and to associate the instance with
   a name space in the configuration.
@@ -168,8 +167,8 @@
 * **CMakeLists.txt:** add options `BUILD_TEST` and `BUILD_SEPARATE_LIBS`.
 
 
-
-# 0.9.9 (2013-05-05)
+<a name="0.9.9"></a>
+## 0.9.9 (2013-05-05)
 
 
 * **config:** update yaml-cpp to version 0.5 (with new API); emit prettier yaml.
@@ -189,77 +188,61 @@
   dump table/prism contents into text files while compiling a dictionary.
 
 
-
+<a name="0.9.8"></a>
 ## 0.9.8 (2013-02-02)
 
 
 * **ascii_composer:** support customizing Caps Lock behavior.
-
 * **speller:** support auto-selecting unique candidates.
   add options `speller/use_space` and `speller/finals` for bopomofo.
-
 * **punctuator:** display half-shape, full-shape labels.
   support committing a phrase with a trailing space character.
   support inputting special characters with mnemonics such as `/ts`.
-
 * **user_dictionary:** fix abnormal records introduced by a bug in merging.
 * **prism, table:** avoid creating / loading incomplete dictionary files.
-
 * **context:** clear transient options (whose names start with `_`) and
   properties when loading a different schema.
   `chord_composer` sets `_chord_typing` so that the input method program would
   know that a chord-typing schema is in use.
-
 * **deployment_tasks.cc(BackupConfigFiles::Run):** while synching user data,
   backup user created / modified YAML files.
-
 * **deployer.cc(Deployer::JoinMaintenanceThread):** fix a boost-related crash.
 
 
-
+<a name="0.9.7"></a>
 ## 0.9.7 (2013-01-16)
 
 
 * **ascii_composer:** support changing conversion mode with Caps Lock.
   fixed Control + letter key in temporary ascii mode.
   pressing Command/Super + Shift shouldn't toggle ascii mode.
-
 * **user_dictionary(UserDictionary::FetchTickCount):**
   tick was reset to zero when I/O error is encountered,
   messing up order of user dict entries.
-
 * **user_dict_manager(UserDictManager::Restore):**
   used to favor imported entries too much while merging snapshots.
 
 
-
+<a name="0.9.6"></a>
 ## 0.9.6 (2013-01-12)
 
 
 * **rime_deployer:** manipulate user's schema list with command line options
   `--add-schema`, `--set-active-schema`
-
 * **rime_dict_manager:** add command line option `--sync`
-
 * **rime_api.h (RimeSyncUserData):**
   add API function to start a data synching task in maintenance thread.
-
 * **rime_api.h (RimeSetNotificationHandler):**
   setup a callback function to receive notifcations from librime.
 * **rime_api.h (RimeGetProperty, RimeSetProperty):**
   add API functions to access session specific string properties.
-
 * **config:** support subscript, assignment operators and simplified value accessors.
-
 * **user_db:** optimize `user_db` for space efficiency;
   avoid blocking user input when the database file needs repair.
-
 * **user_dictionary:** add transaction support.
 * **memory:** cancel memorizing newly committed phrases that has been
   immediately erased with `BackSpace` key.
-
 * **navigator:** move caret left by syllable in phonetic input schemas.
-
 * **express_editor:** fix problem memorizing phrases committed with return key.
 * **table_translator:** add option `translator/enable_sentence`.
 * **reverse_lookup_translator:**
@@ -267,7 +250,7 @@
   phonetic abbreviations now come after completion results in a mixed input scenario.
 
 
-
+<a name="0.9.4-1"></a>
 ## 0.9.4-1 (2012-09-26)
 
 
@@ -275,7 +258,7 @@
 * **CMakeLists.txt:** fix x64 build.
 
 
-
+<a name="0.9.3"></a>
 ## 0.9.3 (2012-09-25)
 
 
@@ -287,7 +270,7 @@
 * **new API:** enabling/disabling soft cursor in preedit string.
 
 
-
+<a name="0.9.2-1"></a>
 ## 0.9.2-1 (2012-07-08)
 
 
@@ -304,7 +287,7 @@
 * **new schema:** IPA input method in X-SAMPA.
 
 
-
+<a name="0.9.1-1"></a>
 ## 0.9.1-1 (2012-05-06)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,9 +63,9 @@
 * **translator:** add history_translator ([#115](https://github.com/rime/librime/issues/115)) ([ae13354](https://github.com/rime/librime/commit/ae13354))
 
 
+
 <a name="1.2.9"></a>
 ## 1.2.9 (2014-12-14)
-
 
 * **rime_api.h:** add `RIME_MODULE_LIST`, `RIME_REGISTER_MODULE_GROUP`.
 * **Makefile:** add make targets `thirdparty/*` to build individual libraries.
@@ -88,9 +88,9 @@
 * **lever/deployment_tasks:** update and rename task `user_dict_upgrade`.
 
 
+
 <a name="1.2"></a>
 ## 1.2 (2014-07-15)
-
 
 * **rime_api:** add API functions to access complex structures in config;
   add API to get the raw input and cursor position, or to select a candidate.
@@ -124,9 +124,9 @@
   building librime on Windows and Mac.
 
 
+
 <a name="1.1"></a>
 ## 1.1 (2013-12-26)
-
 
 * **new build dependency:** compiler with C++11 support.
   tested with GCC 4.8.2, Apple LLVM version 5.0, MSVC 12 (2013).
@@ -139,9 +139,9 @@
 * **table_translator:** fixed the range of CJK-D in charset filter.
 
 
+
 <a name="1.0"></a>
 ## 1.0 (2013-11-10)
-
 
 * **rime_api:** version 1.0 breaks ABI compatiblility.
 
@@ -167,9 +167,9 @@
 * **CMakeLists.txt:** add options `BUILD_TEST` and `BUILD_SEPARATE_LIBS`.
 
 
+
 <a name="0.9.9"></a>
 ## 0.9.9 (2013-05-05)
-
 
 * **config:** update yaml-cpp to version 0.5 (with new API); emit prettier yaml.
 * **deployer:** introduce a work thread for ordinary background tasks.
@@ -188,9 +188,9 @@
   dump table/prism contents into text files while compiling a dictionary.
 
 
+
 <a name="0.9.8"></a>
 ## 0.9.8 (2013-02-02)
-
 
 * **ascii_composer:** support customizing Caps Lock behavior.
 * **speller:** support auto-selecting unique candidates.
@@ -209,9 +209,9 @@
 * **deployer.cc(Deployer::JoinMaintenanceThread):** fix a boost-related crash.
 
 
+
 <a name="0.9.7"></a>
 ## 0.9.7 (2013-01-16)
-
 
 * **ascii_composer:** support changing conversion mode with Caps Lock.
   fixed Control + letter key in temporary ascii mode.
@@ -223,9 +223,9 @@
   used to favor imported entries too much while merging snapshots.
 
 
+
 <a name="0.9.6"></a>
 ## 0.9.6 (2013-01-12)
-
 
 * **rime_deployer:** manipulate user's schema list with command line options
   `--add-schema`, `--set-active-schema`
@@ -250,17 +250,17 @@
   phonetic abbreviations now come after completion results in a mixed input scenario.
 
 
+
 <a name="0.9.4-1"></a>
 ## 0.9.4-1 (2012-09-26)
-
 
 * **new dependency:** 'google-glog'.
 * **CMakeLists.txt:** fix x64 build.
 
 
+
 <a name="0.9.3"></a>
 ## 0.9.3 (2012-09-25)
-
 
 * **table_translator:** add user dictionary.
 * **deployment_tasks:** automatically build schema dependencies.
@@ -270,9 +270,9 @@
 * **new API:** enabling/disabling soft cursor in preedit string.
 
 
+
 <a name="0.9.2-1"></a>
 ## 0.9.2-1 (2012-07-08)
-
 
 * **chord_composer:** combine multiple keys to compose a syllable at once.
 * **configuration:** global `page_size` setting.
@@ -287,9 +287,8 @@
 * **new schema:** IPA input method in X-SAMPA.
 
 
+
 <a name="0.9.1-1"></a>
 ## 0.9.1-1 (2012-05-06)
 
-
 * Revised API.
-

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "librime",
+  "version": "1.2.10",
+  "description": "Rime Input Method Engine",
+  "main": "index.js",
+  "directories": {
+    "doc": "doc",
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "version": "conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rime/librime.git"
+  },
+  "author": "lotem",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/rime/librime/issues"
+  },
+  "homepage": "https://github.com/rime/librime#readme"
+}

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "bugs": {
     "url": "https://github.com/rime/librime/issues"
   },
-  "homepage": "https://github.com/rime/librime#readme"
+  "homepage": "https://github.com/rime/librime#readme",
+  "devDependencies": {
+    "conventional-changelog-cli": "^1.3.14"
+  }
 }


### PR DESCRIPTION
這個生成器只摘抄了 GitHub 上的 Issues / PR 動態。
因爲最近的衆多提交已經採用 conventional changelog，我想根據 commit message 生成 CHANGELOG 更合適。可我還沒時間試用相關工具，又怕因爲提交粒度不合適、自動生成的 log 詳略不當。有時間再研究。