### PR TITLE
当正则匹配时指定键不做编码

### DIFF
--- a/src/rime/gear/speller.cc
+++ b/src/rime/gear/speller.cc
@@ -66,6 +66,7 @@ Speller::Speller(const Ticket& ticket) : Processor(ticket),
     config->GetString("speller/delimiter", &delimiters_);
     config->GetString("speller/initials", &initials_);
     config->GetString("speller/finals", &finals_);
+    config->GetString("speller/submit_keys", &submit_keys_);
     config->GetInt("speller/max_code_length", &max_code_length_);
     config->GetBool("speller/auto_select", &auto_select_);
     config->GetBool("speller/use_space", &use_space_);
@@ -78,6 +79,10 @@ Speller::Speller(const Ticket& ticket) : Processor(ticket),
       if (auto_clear == "auto") auto_clear_ = kClearAuto;
       else if (auto_clear == "manual") auto_clear_ = kClearManual;
       else if (auto_clear == "max_length") auto_clear_ = kClearMaxLength;
+    }
+    string submit_regex;
+    if (config->GetString("speller/submit_regex", &submit_regex)) {
+      submit_regex_ = submit_regex;
     }
   }
   if (initials_.empty()) {
@@ -96,6 +101,9 @@ ProcessResult Speller::ProcessKeyEvent(const KeyEvent& key_event) {
   if (!belongs_to(ch, alphabet_) && !belongs_to(ch, delimiters_))
     return kNoop;
   Context* ctx = engine_->context();
+  if (belongs_to(ch, submit_keys_) && boost::regex_match(ctx->GetScriptText(), submit_regex_)) {
+    return kNoop;
+  }
   bool is_initial = belongs_to(ch, initials_);
   if (!is_initial &&
       expecting_an_initial(ctx, alphabet_, finals_)) {

--- a/src/rime/gear/speller.h
+++ b/src/rime/gear/speller.h
@@ -36,10 +36,12 @@ class Speller : public Processor {
   string delimiters_;
   string initials_;
   string finals_;
+  string submit_keys_;
   int max_code_length_ = 0;
   bool auto_select_ = false;
   bool use_space_ = false;
   boost::regex auto_select_pattern_;
+  boost::regex submit_regex_;
   AutoClearMethod auto_clear_ = kClearNone;
 };
 


### PR DESCRIPTION
无能为力了，找不到更好的办法了。本来我也只是用空格的，因为天马输入法有用标点作编码的需求我才改成这样的。关于之前提到的a键上屏，我想没有人会想要这么做。代码还是上次提交的代码。