### PR TITLE
fix(config_compiler): "/" mistaken as path separator in merged map key

### DIFF
--- a/src/rime/config/config_compiler.cc
+++ b/src/rime/config/config_compiler.cc
@@ -155,17 +155,22 @@ inline static string StripOperator(const string& key, bool adding) {
 }
 
 // defined in config_data.cc
-bool TraverseCopyOnWrite(an<ConfigItemRef> root, const string& path,
-                         function<bool (an<ConfigItemRef> target)> writer);
+an<ConfigItemRef> TypeCheckedCopyOnWrite(an<ConfigItemRef> parent,
+                                         const string& key);
+an<ConfigItemRef> TraverseCopyOnWrite(an<ConfigItemRef> root,
+                                      const string& path);
 
 static bool EditNode(an<ConfigItemRef> target,
                      const string& key,
                      const an<ConfigItem>& value,
                      bool merge_tree) {
-  DLOG(INFO) << "EditNode(" << key << "," << merge_tree << ")";
+  DLOG(INFO) << "edit node: " << key << ", merge_tree: " << merge_tree;
   bool appending = IsAppending(key);
   bool merging = IsMerging(key, value, merge_tree);
   auto writer = [=](an<ConfigItemRef> target) {
+    if (!target) {
+      return false;
+    }
     if ((appending || merging) && **target) {
       DLOG(INFO) << "writer: editing node";
       return !value ||
@@ -181,7 +186,8 @@ static bool EditNode(an<ConfigItemRef> target,
   string path = StripOperator(key, appending || merging);
   DLOG(INFO) << "appending: " << appending << ", merging: " << merging
              << ", path: " << path;
-  return TraverseCopyOnWrite(target, path, writer);
+  auto cow_node = merge_tree ? &TypeCheckedCopyOnWrite : &TraverseCopyOnWrite;
+  return writer(cow_node(target, path));
 }
 
 bool PatchLiteral::Resolve(ConfigCompiler* compiler) {

--- a/src/rime/config/config_compiler.cc
+++ b/src/rime/config/config_compiler.cc
@@ -157,37 +157,37 @@ inline static string StripOperator(const string& key, bool adding) {
 // defined in config_data.cc
 an<ConfigItemRef> TypeCheckedCopyOnWrite(an<ConfigItemRef> parent,
                                          const string& key);
-an<ConfigItemRef> TraverseCopyOnWrite(an<ConfigItemRef> root,
+an<ConfigItemRef> TraverseCopyOnWrite(an<ConfigItemRef> head,
                                       const string& path);
 
-static bool EditNode(an<ConfigItemRef> target,
+static bool EditNode(an<ConfigItemRef> head,
                      const string& key,
                      const an<ConfigItem>& value,
                      bool merge_tree) {
   DLOG(INFO) << "edit node: " << key << ", merge_tree: " << merge_tree;
   bool appending = IsAppending(key);
   bool merging = IsMerging(key, value, merge_tree);
-  auto writer = [=](an<ConfigItemRef> target) {
-    if (!target) {
-      return false;
-    }
-    if ((appending || merging) && **target) {
-      DLOG(INFO) << "writer: editing node";
-      return !value ||
-      (appending && (AppendToString(target, As<ConfigValue>(value)) ||
-                     AppendToList(target, As<ConfigList>(value)))) ||
-      (merging && MergeTree(target, As<ConfigMap>(value)));
-    } else {
-      DLOG(INFO) << "writer: overwriting node";
-      *target = value;
-      return true;
-    }
-  };
   string path = StripOperator(key, appending || merging);
   DLOG(INFO) << "appending: " << appending << ", merging: " << merging
              << ", path: " << path;
-  auto cow_node = merge_tree ? &TypeCheckedCopyOnWrite : &TraverseCopyOnWrite;
-  return writer(cow_node(target, path));
+  auto find_target_node =
+      merge_tree ? &TypeCheckedCopyOnWrite : &TraverseCopyOnWrite;
+  auto target = find_target_node(head, path);
+  if (!target) {
+    // error finding target node; cannot write
+    return false;
+  }
+  if ((appending || merging) && **target) {
+    DLOG(INFO) << "writer: editing node";
+    return !value ||  // no-op
+        (appending && (AppendToString(target, As<ConfigValue>(value)) ||
+                       AppendToList(target, As<ConfigList>(value)))) ||
+        (merging && MergeTree(target, As<ConfigMap>(value)));
+  } else {
+    DLOG(INFO) << "writer: overwriting node";
+    *target = value;
+    return true;
+  }
 }
 
 bool PatchLiteral::Resolve(ConfigCompiler* compiler) {

--- a/src/rime/config/config_data.cc
+++ b/src/rime/config/config_data.cc
@@ -175,13 +175,12 @@ an<ConfigItemRef> TypeCheckedCopyOnWrite(an<ConfigItemRef> parent,
   return Cow(parent, key);
 }
 
-an<ConfigItemRef> TraverseCopyOnWrite(an<ConfigItemRef> root,
+an<ConfigItemRef> TraverseCopyOnWrite(an<ConfigItemRef> head,
                                       const string& path) {
   DLOG(INFO) << "TraverseCopyOnWrite(" << path << ")";
   if (path.empty() || path == "/") {
-    return root;
+    return head;
   }
-  an<ConfigItemRef> head = root;
   vector<string> keys = ConfigData::SplitPath(path);
   size_t n = keys.size();
   for (size_t i = 0; i < n; ++i) {


### PR DESCRIPTION
Fixes #190 