### PR TITLE
Add Address Sanitizer support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,9 @@ option(BUILD_SEPARATE_LIBS "Build a separate rime-gears library" OFF)
 option(ENABLE_LOGGING "Enable logging with google-glog library" ON)
 option(BOOST_USE_CXX11 "Boost has been built with C++11 support" OFF)
 option(BOOST_USE_SIGNALS2 "Boost use signals2 instead of signals" ON)
+option(ENABLE_ASAN "Enable Address Sanitizer (Unix Only)" OFF)
 
-SET(rime_data_dir "/share/rime-data" CACHE STRING "Target directory for Rime data")
+set(rime_data_dir "/share/rime-data" CACHE STRING "Target directory for Rime data")
 
 if(WIN32)
   set(ext ".exe")
@@ -26,6 +27,15 @@ endif(WIN32)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "${PROJECT_SOURCE_DIR}/thirdparty")
+
+if (ENABLE_ASAN)
+  set(asan_cflags "-fsanitize=address -fno-omit-frame-pointer")
+  set(asan_lflags "-fsanitize=address -lasan")
+  set(CMAKE_C_FLAGS "${asan_cflags} ${CMAKE_C_FLAGS}")
+  set(CMAKE_CXX_FLAGS "${asan_cflags} ${CMAKE_CXX_FLAGS}")
+  set(CMAKE_EXE_LINKER_FLAGS "${asan_lflags} ${CMAKE_EXE_LINKER_FLAGS}")
+  set(CMAKE_SHARED_LINKER_FLAGS "${asan_lflags} ${CMAKE_SHARED_LINKER_FLAGS}")
+endif()
 
 set(Boost_USE_STATIC_LIBS ${BUILD_STATIC})
 set(Gflags_STATIC ${BUILD_STATIC})

--- a/src/rime/engine.cc
+++ b/src/rime/engine.cc
@@ -257,8 +257,9 @@ void ConcreteEngine::OnSelect(Context* ctx) {
       ctx->composition().Forward();
   }
   else {
+    bool updateCaret = (seg.end >= ctx->caret_pos());
     ctx->composition().Forward();
-    if (seg.end >= ctx->caret_pos()) {
+    if (updateCaret) {
       // finished converting current segment
       // move caret to the end of input
       ctx->set_caret_pos(ctx->input().length());


### PR DESCRIPTION
内置ENABLE_ASAN选项，方便开启[Address Sanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer)内存检测～
加上ASAN_OPTIONS=abort_on_error=1环境变量在调试时遇到内存问题则会断下来，
印象Windows版Clang还不能用这功能，我没还加平台宏，你们看看有没有必要。

另外，我简单测了下rime_api_console，发现报出一个问题（输入test，选“特色”），你们看看我这样改的是不是你们所期望的～