### PR TITLE
feat: chareset_filter always allow emoji

### DIFF
--- a/src/rime/gear/charset_filter.cc
+++ b/src/rime/gear/charset_filter.cc
@@ -44,6 +44,55 @@ bool contains_extended_cjk(const string& text)
   return false;
 }
 
+bool is_emoji(uint32_t ch)
+{
+
+  if ((ch >= 0x0000 && ch <= 0x007F) || // C0 Controls and Basic Latin
+	  (ch >= 0x0080 && ch <= 0x00FF) || // C1 Controls and Latin-1 Supplement
+	  (ch >= 0x02B0 && ch <= 0x02FF) || // Spacing Modifier Letters
+	  (ch >= 0x0900 && ch <= 0x097F) || // Devanagari
+	  (ch >= 0x2000 && ch <= 0x203C) || // General Punctuation
+	  (ch >= 0x20A0 && ch <= 0x20CF) || // Currency Symbols
+	  (ch >= 0x2100 && ch <= 0x214F) || // Letterlike Symbols
+	  (ch >= 0x2150 && ch <= 0x218F) || // Number Forms
+	  (ch >= 0x2190 && ch <= 0x21FF) || // Arrows
+	  (ch >= 0x2200 && ch <= 0x22FF) || // Mathematical Operators
+	  (ch >= 0x2300 && ch <= 0x23FF) || // Miscellaneous Technical
+	  (ch >= 0x2460 && ch <= 0x24FF) || // Enclosed Alphanumerics
+	  (ch >= 0x25A0 && ch <= 0x25FF) || // Geometric Shapes
+	  (ch >= 0x2600 && ch <= 0x26FF) || // Miscellaneous Symbols
+	  (ch >= 0x2700 && ch <= 0x27BF) || // Dingbats
+	  (ch >= 0x2900 && ch <= 0x297F) || // Supplemental Arrows-B
+	  (ch >= 0x2B00 && ch <= 0x2BFF) || // Miscellaneous Symbols and Arrows
+	  (ch >= 0x3000 && ch <= 0x303F) || // CJK Symbols and Punctuation
+	  (ch >= 0x3200 && ch <= 0x32FF) || // Enclosed CJK Letters and Months
+	  (ch >= 0x1F100 && ch <= 0x1F1FF) || // Enclosed Alphanumeric Supplement
+	  (ch >= 0x1F200 && ch <= 0x1F2FF) || // Enclosed Ideographic Supplement
+	  (ch >= 0x1F000 && ch <= 0x1F02F) || // Mahjong Tiles
+	  (ch >= 0x1F0A0 && ch <= 0x1F0FF) || // Playing Cards
+	  (ch >= 0x1F300 && ch <= 0x1F5FF) || // Miscellaneous Symbols and Pictographs
+	  (ch >= 0x1F600 && ch <= 0x1F64F) || // Emoticons
+	  (ch >= 0x1F680 && ch <= 0x1F6FF) || // Transport and Map Symbols
+	  (ch >= 0x1F900 && ch <= 0x1F9FF)) // Supplemental Symbols and Pictographs)
+	return true;
+
+  return false;
+}
+
+bool contains_emoji(const string& text)
+{
+  const char *p = text.c_str();
+  uint32_t ch;
+
+  while ((ch = utf8::unchecked::next(p)) != 0) {
+    if (is_emoji(ch)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 // CharsetFilterTranslation
 
 CharsetFilterTranslation::CharsetFilterTranslation(
@@ -81,6 +130,7 @@ bool CharsetFilterTranslation::LocateNextCandidate() {
 
 bool CharsetFilter::FilterText(const string& text, const string& charset) {
   if (charset.empty()) return !contains_extended_cjk(text);
+  if (contains_emoji(text)) return true;
   try {
     boost::locale::conv::from_utf(text, charset, boost::locale::conv::method_type::stop);
   }


### PR DESCRIPTION
https://github.com/rime/librime/issues/59
即便选择 GBK 字符集时候，始终允许 Emoji 出现。

Emoji 数据源来自于：https://github.com/rhdunn/espeak/blob/master/dictsource/en_emoji