### PR TITLE
perf(dictionary): refactor DictEntryIterator and do partial sort

### DIFF
--- a/src/rime/dict/dictionary.h
+++ b/src/rime/dict/dictionary.h
@@ -39,30 +39,29 @@ bool compare_chunk_by_leading_element(const Chunk& a, const Chunk& b);
 
 }  // namespace dictionary
 
-class DictEntryIterator : protected list<dictionary::Chunk>,
-                          public DictEntryFilterBinder {
+class DictEntryIterator : public DictEntryFilterBinder {
  public:
-  using Base = list<dictionary::Chunk>;
-
-  RIME_API DictEntryIterator();
-  RIME_API DictEntryIterator(const DictEntryIterator& other);
-  DictEntryIterator& operator= (DictEntryIterator& other);
+  DictEntryIterator() = default;
+  DictEntryIterator(DictEntryIterator&& other) = default;
+  DictEntryIterator& operator= (DictEntryIterator&& other) = default;
 
   void AddChunk(dictionary::Chunk&& chunk, Table* table);
   void Sort();
   RIME_API an<DictEntry> Peek();
   RIME_API bool Next();
   bool Skip(size_t num_entries);
-  RIME_API bool exhausted() const;
+  bool exhausted() const { return chunk_index_ == chunks_.size(); }
   size_t entry_count() const { return entry_count_; }
 
  protected:
   void PrepareEntry();
 
  private:
-  Table* table_;
-  an<DictEntry> entry_;
-  size_t entry_count_;
+  vector<dictionary::Chunk> chunks_;
+  size_t chunk_index_ = 0;
+  Table* table_ = nullptr;
+  an<DictEntry> entry_ = nullptr;
+  size_t entry_count_ = 0;
 };
 
 struct DictEntryCollector : map<size_t, DictEntryIterator> {

--- a/src/rime/gear/reverse_lookup_translator.cc
+++ b/src/rime/gear/reverse_lookup_translator.cc
@@ -32,9 +32,10 @@ class ReverseLookupTranslation : public TableTranslation {
                            const string& input,
                            size_t start, size_t end,
                            const string& preedit,
-                           const DictEntryIterator& iter,
+                           DictEntryIterator&& iter,
                            bool quality)
-      : TableTranslation(options, NULL, input, start, end, preedit, iter),
+      : TableTranslation(
+            options, NULL, input, start, end, preedit, std::move(iter)),
         dict_(dict), options_(options), quality_(quality) {
   }
   virtual an<Candidate> Peek();
@@ -185,7 +186,7 @@ an<Translation> ReverseLookupTranslator::Query(const string& input,
         auto collector = dict_->Lookup(graph, 0);
         if (collector && !collector->empty() &&
             collector->rbegin()->first == consumed) {
-          iter = collector->rbegin()->second;
+          iter = std::move(collector->rbegin()->second);
           quality = !graph.vertices.empty() &&
               (graph.vertices.rbegin()->second == kNormalSpelling);
         }
@@ -199,7 +200,8 @@ an<Translation> ReverseLookupTranslator::Query(const string& input,
                                             segment.start,
                                             segment.end,
                                             preedit,
-                                            iter, quality);
+                                            std::move(iter),
+                                            quality);
   }
   return nullptr;
 }

--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -254,7 +254,6 @@ size_t ScriptSyllabifier::BuildSyllableGraph(Prism& prism) {
 
 bool ScriptSyllabifier::IsCandidateCorrection(const rime::Phrase &cand) const {
   std::stack<bool> results;
-  bool result = false;
   // Perform DFS on syllable graph to find whether this candidate is a correction
   SyllabifyTask task {
     cand.code(),

--- a/src/rime/gear/table_translator.cc
+++ b/src/rime/gear/table_translator.cc
@@ -33,11 +33,11 @@ TableTranslation::TableTranslation(TranslatorOptions* options,
                                    size_t start,
                                    size_t end,
                                    const string& preedit,
-                                   const DictEntryIterator& iter,
-                                   const UserDictEntryIterator& uter)
+                                   DictEntryIterator&& iter,
+                                   UserDictEntryIterator&& uter)
     : options_(options), language_(language),
       input_(input), start_(start), end_(end), preedit_(preedit),
-      iter_(iter), uter_(uter) {
+      iter_(std::move(iter)), uter_(std::move(uter)) {
   if (options_)
     options_->preedit_formatter().Apply(&preedit_);
   CheckEmpty();
@@ -190,7 +190,7 @@ bool LazyTableTranslation::FetchMoreTableEntries() {
   }
   if (more.entry_count() > previous_entry_count) {
     more.Skip(previous_entry_count);
-    iter_ = more;
+    iter_ = std::move(more);
   }
   return true;
 }
@@ -276,8 +276,8 @@ an<Translation> TableTranslator::Query(const string& input,
           segment.start,
           segment.start + input.length(),
           preedit,
-          iter,
-          uter);
+          std::move(iter),
+          std::move(uter));
   }
   if (translation) {
     bool filter_by_charset = enable_charset_filter_ &&
@@ -618,7 +618,7 @@ TableTranslator::MakeSentence(const string& input, size_t start,
         entries[consumed_length] = iter.Peek();
         if (start_pos == 0 && !iter.exhausted()) {
           // also provide words for manual composition
-          collector[consumed_length] = iter;
+          collector[consumed_length] = std::move(iter);
           DLOG(INFO) << "table[" << consumed_length << "]: "
                      << collector[consumed_length].entry_count();
         }

--- a/src/rime/gear/table_translator.h
+++ b/src/rime/gear/table_translator.h
@@ -56,8 +56,8 @@ class TableTranslation : public Translation {
                    size_t start,
                    size_t end,
                    const string& preedit,
-                   const DictEntryIterator& iter = DictEntryIterator(),
-                   const UserDictEntryIterator& uter = UserDictEntryIterator());
+                   DictEntryIterator&& iter = {},
+                   UserDictEntryIterator&& uter = {});
 
   virtual bool Next();
   virtual an<Candidate> Peek();

--- a/test/dictionary_test.cc
+++ b/test/dictionary_test.cc
@@ -78,7 +78,7 @@ TEST_F(RimeDictionaryTest, ScriptLookup) {
   ASSERT_TRUE(bool(c));
 
   ASSERT_TRUE(c->find(3) != c->end());
-  rime::DictEntryIterator d3((*c)[3]);
+  rime::DictEntryIterator& d3((*c)[3]);
   EXPECT_FALSE(d3.exhausted());
   auto e1 = d3.Peek();
   ASSERT_TRUE(bool(e1));
@@ -87,14 +87,14 @@ TEST_F(RimeDictionaryTest, ScriptLookup) {
   EXPECT_TRUE(d3.Next());
 
   ASSERT_TRUE(c->find(5) != c->end());
-  rime::DictEntryIterator d5((*c)[5]);
+  rime::DictEntryIterator& d5((*c)[5]);
   EXPECT_FALSE(d5.exhausted());
   auto e2 = d5.Peek();
   ASSERT_TRUE(bool(e2));
   EXPECT_EQ(2, e2->code.size());
 
   ASSERT_TRUE(c->find(7) != c->end());
-  rime::DictEntryIterator d7((*c)[7]);
+  rime::DictEntryIterator& d7((*c)[7]);
   EXPECT_FALSE(d7.exhausted());
   auto e3 = d7.Peek();
   ASSERT_TRUE(bool(e3));

--- a/test/generate_pinyin_initials.js
+++ b/test/generate_pinyin_initials.js
@@ -1,0 +1,7 @@
+const initials = 'bpmfdtnlgkhjqxzcsryw';
+const len = Number(process.argv[2]);
+let t = [];
+for (let i = 0; i < len; ++i) {
+    t.push(initials.charAt(Math.floor(Math.random() * initials.length)));
+}
+console.log(t.join(''));


### PR DESCRIPTION
measure performance:

```bash
cd librime
make
(cd build/bin; echo | ./rime_console)  # build data

node test/generate_pinyin_initials.js 512 > build/bin/input.txt
(cd build/bin; time ./rime_console < input.txt > output.txt)
```
compared to `master` version, conversion of long pinyin initial sequence is about 10% faster.