### PR TITLE
feat(dict): specify vocabulary db name in dict settings

### DIFF
--- a/src/rime/dict/dict_compiler.cc
+++ b/src/rime/dict/dict_compiler.cc
@@ -76,7 +76,7 @@ bool DictCompiler::Compile(const string &schema_file) {
       cc.ProcessFile(file_name);
     }
     if (settings.use_preset_vocabulary()) {
-      cc.ProcessFile(PresetVocabulary::DictFilePath());
+      cc.ProcessFile(PresetVocabulary::DictFilePath(settings.vocabulary()));
     }
     dict_file_checksum = cc.Checksum();
   }

--- a/src/rime/dict/dict_settings.cc
+++ b/src/rime/dict/dict_settings.cc
@@ -50,7 +50,15 @@ string DictSettings::sort_order() {
 }
 
 bool DictSettings::use_preset_vocabulary() {
-  return (*this)["use_preset_vocabulary"].ToBool();
+  return (*this)["use_preset_vocabulary"].ToBool() ||
+      (*this)["vocabulary"].IsValue();
+}
+
+static const string kDefaultVocabulary = "essay";
+
+string DictSettings::vocabulary() {
+  string value = (*this)["vocabulary"].ToString();
+  return !value.empty() ? value : kDefaultVocabulary;
 }
 
 bool DictSettings::use_rule_based_encoder() {

--- a/src/rime/dict/dict_settings.h
+++ b/src/rime/dict/dict_settings.h
@@ -21,6 +21,7 @@ class DictSettings : public Config {
   string dict_version();
   string sort_order();
   bool use_preset_vocabulary();
+  string vocabulary();
   bool use_rule_based_encoder();
   int max_phrase_length();
   double min_phrase_weight();

--- a/src/rime/dict/entry_collector.cc
+++ b/src/rime/dict/entry_collector.cc
@@ -41,9 +41,10 @@ void EntryCollector::Collect(const vector<string>& dict_files) {
 }
 
 void EntryCollector::LoadPresetVocabulary(DictSettings* settings) {
-  LOG(INFO) << "loading preset vocabulary.";
-  preset_vocabulary.reset(new PresetVocabulary);
-  if (preset_vocabulary && settings) {
+  auto vocabulary = settings->vocabulary();
+  LOG(INFO) << "loading preset vocabulary: " << vocabulary;
+  preset_vocabulary.reset(new PresetVocabulary(vocabulary));
+  if (preset_vocabulary) {
     if (settings->max_phrase_length() > 0)
       preset_vocabulary->set_max_phrase_length(settings->max_phrase_length());
     if (settings->min_phrase_weight() > 0)

--- a/src/rime/dict/preset_vocabulary.cc
+++ b/src/rime/dict/preset_vocabulary.cc
@@ -18,8 +18,6 @@ static const ResourceType kVocabularyResourceType = {
   "vocabulary", "", ".txt"
 };
 
-static const string kDefaultVocabulary = "essay";
-
 struct VocabularyDb : public TextDb {
   explicit VocabularyDb(const string& path);
   an<DbAccessor> cursor;
@@ -56,14 +54,14 @@ const TextFormat VocabularyDb::format = {
   "Rime vocabulary",
 };
 
-string PresetVocabulary::DictFilePath() {
+string PresetVocabulary::DictFilePath(const string& vocabulary) {
   the<ResourceResolver> resource_resolver(
       Service::instance().CreateResourceResolver(kVocabularyResourceType));
-  return resource_resolver->ResolvePath(kDefaultVocabulary).string();
+  return resource_resolver->ResolvePath(vocabulary).string();
 }
 
-PresetVocabulary::PresetVocabulary() {
-  db_.reset(new VocabularyDb(DictFilePath()));
+PresetVocabulary::PresetVocabulary(const string& vocabulary) {
+  db_.reset(new VocabularyDb(DictFilePath(vocabulary)));
   if (db_ && db_->OpenReadOnly()) {
     db_->cursor = db_->QueryAll();
   }

--- a/src/rime/dict/preset_vocabulary.h
+++ b/src/rime/dict/preset_vocabulary.h
@@ -15,7 +15,7 @@ struct VocabularyDb;
 
 class PresetVocabulary {
  public:
-  PresetVocabulary();
+  explicit PresetVocabulary(const string& vocabulary);
   ~PresetVocabulary();
 
   // random access
@@ -29,7 +29,7 @@ class PresetVocabulary {
   void set_max_phrase_length(int length) { max_phrase_length_ = length; }
   void set_min_phrase_weight(double weight) { min_phrase_weight_ = weight; }
 
-  static string DictFilePath();
+  static string DictFilePath(const string& vacabulary);
 
  protected:
   the<VocabularyDb> db_;


### PR DESCRIPTION
the new settings item `vocabulary: essay` is equivalent to `use_preset_vocabulary: true`.
this commit enables changing `essay` to a user specified vocabulary db eg. `essay-zh-hans`.