### PR TITLE
 feat(translator): contextual suggestions

### DIFF
--- a/src/rime/commit_history.h
+++ b/src/rime/commit_history.h
@@ -29,6 +29,9 @@ class CommitHistory : public list<CommitRecord> {
   void Push(const KeyEvent& key_event);
   void Push(const Composition& composition, const string& input);
   string repr() const;
+  string latest_text() const {
+    return empty() ? string() : back().text;
+  }
 };
 
 }  // Namespace rime

--- a/src/rime/composition.cc
+++ b/src/rime/composition.cc
@@ -5,6 +5,7 @@
 // 2011-06-19 GONG Chen <chen.sst@gmail.com>
 //
 #include <boost/algorithm/string.hpp>
+#include <boost/range/adaptor/reversed.hpp>
 #include <rime/candidate.h>
 #include <rime/composition.h>
 #include <rime/menu.h>
@@ -165,6 +166,18 @@ string Composition::GetDebugText() const {
     }
   }
   return result;
+}
+
+string Composition::GetTextBefore(size_t pos) const {
+  if (empty()) return string();
+  for (const auto& seg : boost::adaptors::reverse(*this)) {
+    if (seg.end <= pos) {
+      if (auto cand = seg.GetSelectedCandidate()) {
+        return cand->text();
+      }
+    }
+  }
+  return string();
 }
 
 }  // namespace rime

--- a/src/rime/composition.h
+++ b/src/rime/composition.h
@@ -29,6 +29,8 @@ class Composition : public Segmentation {
   string GetCommitText() const;
   string GetScriptText() const;
   string GetDebugText() const;
+  // Returns text of the last segment before the given position.
+  string GetTextBefore(size_t pos) const;
 };
 
 }  // namespace rime

--- a/src/rime/gear/contextual_translation.cc
+++ b/src/rime/gear/contextual_translation.cc
@@ -1,0 +1,60 @@
+#include <algorithm>
+#include <iterator>
+#include <rime/gear/contextual_translation.h>
+#include <rime/gear/translator_commons.h>
+
+namespace rime {
+
+const int kContextualSearchLimit = 32;
+
+bool ContextualTranslation::Replenish() {
+  vector<of<Phrase>> queue;
+  size_t end_pos = 0;
+  while (!translation_->exhausted() &&
+         cache_.size() + queue.size() < kContextualSearchLimit) {
+    auto cand = translation_->Peek();
+    DLOG(INFO) << cand->text() << " cache/queue: "
+               << cache_.size() << "/" << queue.size();
+    if (cand->type() == "phrase" || cand->type() == "table") {
+      if (end_pos != cand->end()) {
+        end_pos = cand->end();
+        AppendToCache(queue);
+      }
+      queue.push_back(Evaluate(As<Phrase>(cand)));
+    } else {
+      AppendToCache(queue);
+      cache_.push_back(cand);
+    }
+    if (!translation_->Next()) {
+      break;
+    }
+  }
+  AppendToCache(queue);
+  return !cache_.empty();
+}
+
+an<Phrase> ContextualTranslation::Evaluate(an<Phrase> phrase) {
+  auto sentence = New<Sentence>(phrase->language());
+  sentence->Offset(phrase->start());
+  bool is_rear = phrase->end() == input_.length();
+  sentence->Extend(phrase->entry(), phrase->end(), is_rear, preceding_text_,
+                   grammar_);
+  phrase->set_weight(sentence->weight());
+  DLOG(INFO) << "contextual suggestion: " << phrase->text()
+             << " weight: " << phrase->weight();
+  return phrase;
+}
+
+static bool compare_by_weight_desc(const an<Phrase>& a, const an<Phrase>& b) {
+  return a->weight() > b->weight();
+}
+
+void ContextualTranslation::AppendToCache(vector<of<Phrase>>& queue) {
+  if (queue.empty()) return;
+  DLOG(INFO) << "appending to cache " << queue.size() << " candidates.";
+  std::sort(queue.begin(), queue.end(), compare_by_weight_desc);
+  std::copy(queue.begin(), queue.end(), std::back_inserter(cache_));
+  queue.clear();
+}
+
+}  // namespace rime

--- a/src/rime/gear/contextual_translation.h
+++ b/src/rime/gear/contextual_translation.h
@@ -1,0 +1,38 @@
+//
+// Copyright RIME Developers
+// Distributed under the BSD License
+//
+
+#include <rime/common.h>
+#include <rime/translation.h>
+
+namespace rime {
+
+class Candidate;
+class Grammar;
+class Phrase;
+
+class ContextualTranslation : public PrefetchTranslation {
+ public:
+  ContextualTranslation(an<Translation> translation,
+                        string input,
+                        string preceding_text,
+                        Grammar* grammar)
+      : PrefetchTranslation(translation),
+        input_(input),
+        preceding_text_(preceding_text),
+        grammar_(grammar) {}
+
+ protected:
+  bool Replenish() override;
+
+ private:
+  an<Phrase> Evaluate(an<Phrase> phrase);
+  void AppendToCache(vector<of<Phrase>>& queue);
+
+  string input_;
+  string preceding_text_;
+  Grammar* grammar_;
+};
+
+}  // namespace rime

--- a/src/rime/gear/poet.cc
+++ b/src/rime/gear/poet.cc
@@ -43,11 +43,10 @@ an<Sentence> Poet::MakeSentence(const WordGraph& graph,
       if (start_pos == 0 && end_pos == total_length)
         continue;  // exclude single words from the result
       DLOG(INFO) << "end pos: " << end_pos;
+      bool is_rear = end_pos == total_length;
       const DictEntryList& entries(x.second);
-      for (size_t i = 0; i < entries.size(); ++i) {
-        const auto& entry(entries[i]);
+      for (const auto& entry : entries) {
         auto new_sentence = New<Sentence>(*sentences[start_pos]);
-        bool is_rear = end_pos == total_length;
         new_sentence->Extend(*entry, end_pos, is_rear, grammar_.get());
         if (sentences.find(end_pos) == sentences.end() ||
             sentences[end_pos]->weight() < new_sentence->weight()) {

--- a/src/rime/gear/poet.cc
+++ b/src/rime/gear/poet.cc
@@ -42,7 +42,8 @@ bool Poet::LeftAssociateCompare(const Sentence& one, const Sentence& other) {
 }
 
 an<Sentence> Poet::MakeSentence(const WordGraph& graph,
-                                size_t total_length) {
+                                size_t total_length,
+                                const string& preceding_text) {
   // TODO: save more intermediate sentence candidates
   map<int, an<Sentence>> sentences;
   sentences[0] = New<Sentence>(language_);
@@ -61,7 +62,8 @@ an<Sentence> Poet::MakeSentence(const WordGraph& graph,
       const DictEntryList& entries(x.second);
       for (const auto& entry : entries) {
         auto new_sentence = New<Sentence>(*sentences[start_pos]);
-        new_sentence->Extend(*entry, end_pos, is_rear, grammar_.get());
+        new_sentence->Extend(
+            *entry, end_pos, is_rear, preceding_text, grammar_.get());
         if (sentences.find(end_pos) == sentences.end() ||
             compare_(*sentences[end_pos], *new_sentence)) {
           DLOG(INFO) << "updated sentences " << end_pos << ") with "

--- a/src/rime/gear/poet.h
+++ b/src/rime/gear/poet.h
@@ -11,8 +11,10 @@
 #define RIME_POET_H_
 
 #include <rime/common.h>
+#include <rime/translation.h>
 #include <rime/dict/user_dictionary.h>
 #include <rime/gear/translator_commons.h>
+#include <rime/gear/contextual_translation.h>
 
 namespace rime {
 
@@ -38,6 +40,19 @@ class Poet {
   an<Sentence> MakeSentence(const WordGraph& graph,
                             size_t total_length,
                             const string& preceding_text);
+
+  template <class TranslatorT>
+  an<Translation> ContextualWeighted(an<Translation> translation,
+                                     const string& input,
+                                     TranslatorT* translator) {
+    if (!translator->contextual_suggestions() || !grammar_) {
+      return translation;
+    }
+    return New<ContextualTranslation>(translation,
+                                      input,
+                                      translator->GetPrecedingText(),
+                                      grammar_.get());
+  }
 
  private:
   const Language* language_;

--- a/src/rime/gear/poet.h
+++ b/src/rime/gear/poet.h
@@ -23,14 +23,24 @@ class Language;
 
 class Poet {
  public:
-  Poet(const Language* language, Config* config);
+  // sentence "less", used to compare sentences of the same input range.
+  using Compare = function<bool (const Sentence&, const Sentence&)>;
+
+  static bool CompareWeight(const Sentence& one, const Sentence& other) {
+    return one.weight() < other.weight();
+  }
+  static bool LeftAssociateCompare(const Sentence& one, const Sentence& other);
+
+  Poet(const Language* language, Config* config,
+       Compare compare = CompareWeight);
   ~Poet();
 
   an<Sentence> MakeSentence(const WordGraph& graph, size_t total_length);
 
- protected:
+ private:
   const Language* language_;
   the<Grammar> grammar_;
+  Compare compare_;
 };
 
 }  // namespace rime

--- a/src/rime/gear/poet.h
+++ b/src/rime/gear/poet.h
@@ -44,14 +44,17 @@ class Poet {
   template <class TranslatorT>
   an<Translation> ContextualWeighted(an<Translation> translation,
                                      const string& input,
+                                     size_t start,
                                      TranslatorT* translator) {
     if (!translator->contextual_suggestions() || !grammar_) {
       return translation;
     }
-    return New<ContextualTranslation>(translation,
-                                      input,
-                                      translator->GetPrecedingText(),
-                                      grammar_.get());
+    auto preceding_text = translator->GetPrecedingText(start);
+    if (preceding_text.empty()) {
+      return translation;
+    }
+    return New<ContextualTranslation>(
+        translation, input, preceding_text, grammar_.get());
   }
 
  private:

--- a/src/rime/gear/poet.h
+++ b/src/rime/gear/poet.h
@@ -35,7 +35,9 @@ class Poet {
        Compare compare = CompareWeight);
   ~Poet();
 
-  an<Sentence> MakeSentence(const WordGraph& graph, size_t total_length);
+  an<Sentence> MakeSentence(const WordGraph& graph,
+                            size_t total_length,
+                            const string& preceding_text);
 
  private:
   const Language* language_;

--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -214,6 +214,11 @@ string ScriptTranslator::Spell(const Code& code) {
   return result;
 }
 
+string ScriptTranslator::GetPrecedingText() const {
+  return contextual_suggestions_ ?
+      engine_->context()->commit_history().latest_text() : string();
+}
+
 bool ScriptTranslator::Memorize(const CommitEntry& commit_entry) {
   bool update_elements = false;
   // avoid updating single character entries within a phrase which is
@@ -538,12 +543,14 @@ an<Sentence> ScriptTranslation::MakeSentence(Dictionary* dict,
       }
     }
   }
-  auto sentence = poet_->MakeSentence(graph, syllable_graph.interpreted_length);
-  if (sentence) {
+  if (auto sentence = poet_->MakeSentence(graph,
+                                          syllable_graph.interpreted_length,
+                                          translator_->GetPrecedingText())) {
     sentence->Offset(start_);
     sentence->set_syllabifier(syllabifier_);
+    return sentence;
   }
-  return sentence;
+  return nullptr;
 }
 
 }  // namespace rime

--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -194,7 +194,11 @@ an<Translation> ScriptTranslator::Query(const string& input,
                         enable_user_dict ? user_dict_.get() : NULL)) {
     return nullptr;
   }
-  return New<DistinctTranslation>(result);
+  auto deduped = New<DistinctTranslation>(result);
+  if (contextual_suggestions_) {
+    return poet_->ContextualWeighted(deduped, input, this);
+  }
+  return deduped;
 }
 
 string ScriptTranslator::FormatPreedit(const string& preedit) {

--- a/src/rime/gear/script_translator.h
+++ b/src/rime/gear/script_translator.h
@@ -37,6 +37,7 @@ class ScriptTranslator : public Translator,
 
   string FormatPreedit(const string& preedit);
   string Spell(const Code& code);
+  string GetPrecedingText() const;
 
   // options
   int max_homophones() const { return max_homophones_; }

--- a/src/rime/gear/script_translator.h
+++ b/src/rime/gear/script_translator.h
@@ -37,7 +37,7 @@ class ScriptTranslator : public Translator,
 
   string FormatPreedit(const string& preedit);
   string Spell(const Code& code);
-  string GetPrecedingText() const;
+  string GetPrecedingText(size_t start) const;
 
   // options
   int max_homophones() const { return max_homophones_; }

--- a/src/rime/gear/table_translator.cc
+++ b/src/rime/gear/table_translator.cc
@@ -221,7 +221,7 @@ TableTranslator::TableTranslator(const Ticket& ticket)
     config->GetInt(name_space_ + "/max_homographs",
                    &max_homographs_);
     if (enable_sentence_ || sentence_over_completion_) {
-      poet_.reset(new Poet(language(), config));
+      poet_.reset(new Poet(language(), config, Poet::LeftAssociateCompare));
     }
   }
   if (enable_encoder_ && user_dict_) {

--- a/src/rime/gear/table_translator.cc
+++ b/src/rime/gear/table_translator.cc
@@ -342,7 +342,9 @@ bool TableTranslator::Memorize(const CommitEntry& commit_entry) {
         }
         string phrase;
         for (; it != history.rend(); ++it) {
-          if (it->type != "table" && it->type != "sentence" && it->type != "uniquified")
+          if (it->type != "table" &&
+              it->type != "sentence" &&
+              it->type != "uniquified")
             break;
           if (phrase.empty()) {
             phrase = it->text;  // last word
@@ -360,6 +362,11 @@ bool TableTranslator::Memorize(const CommitEntry& commit_entry) {
     }
   }
   return true;
+}
+
+string TableTranslator::GetPrecedingText() const {
+  return contextual_suggestions_ ?
+      engine_->context()->commit_history().latest_text() : string();
 }
 
 // SentenceSyllabifier
@@ -680,7 +687,9 @@ TableTranslator::MakeSentence(const string& input, size_t start,
       }
     }
   }
-  if (auto sentence = poet_->MakeSentence(graph, input.length())) {
+  if (auto sentence = poet_->MakeSentence(graph,
+                                          input.length(),
+                                          GetPrecedingText())) {
     auto result = Cached<SentenceTranslation>(
         this,
         std::move(sentence),

--- a/src/rime/gear/table_translator.cc
+++ b/src/rime/gear/table_translator.cc
@@ -312,7 +312,7 @@ an<Translation> TableTranslator::Query(const string& input,
   }
   translation = New<DistinctTranslation>(translation);
   if (contextual_suggestions_) {
-    return poet_->ContextualWeighted(translation, input, this);
+    return poet_->ContextualWeighted(translation, input, segment.start, this);
   }
   return translation;
 }
@@ -366,9 +366,10 @@ bool TableTranslator::Memorize(const CommitEntry& commit_entry) {
   return true;
 }
 
-string TableTranslator::GetPrecedingText() const {
-  return contextual_suggestions_ ?
-      engine_->context()->commit_history().latest_text() : string();
+string TableTranslator::GetPrecedingText(size_t start) const {
+  return !contextual_suggestions_ ? string() :
+      start > 0 ? engine_->context()->composition().GetTextBefore(start) :
+      engine_->context()->commit_history().latest_text();
 }
 
 // SentenceSyllabifier
@@ -691,7 +692,7 @@ TableTranslator::MakeSentence(const string& input, size_t start,
   }
   if (auto sentence = poet_->MakeSentence(graph,
                                           input.length(),
-                                          GetPrecedingText())) {
+                                          GetPrecedingText(start))) {
     auto result = Cached<SentenceTranslation>(
         this,
         std::move(sentence),

--- a/src/rime/gear/table_translator.cc
+++ b/src/rime/gear/table_translator.cc
@@ -8,6 +8,7 @@
 #include <boost/range/adaptor/reversed.hpp>
 #include <utf8.h>
 #include <rime/candidate.h>
+#include <rime/common.h>
 #include <rime/composition.h>
 #include <rime/config.h>
 #include <rime/context.h>
@@ -17,7 +18,7 @@
 #include <rime/dict/dictionary.h>
 #include <rime/dict/user_dictionary.h>
 #include <rime/gear/charset_filter.h>
-#include <rime/gear/grammar.h>
+#include <rime/gear/poet.h>
 #include <rime/gear/table_translator.h>
 #include <rime/gear/translator_commons.h>
 #include <rime/gear/unity_table_encoder.h>
@@ -220,9 +221,7 @@ TableTranslator::TableTranslator(const Ticket& ticket)
     config->GetInt(name_space_ + "/max_homographs",
                    &max_homographs_);
     if (enable_sentence_ || sentence_over_completion_) {
-      if (auto* grammar_component = Grammar::Require("grammar")) {
-        grammar_.reset(grammar_component->Create(config));
-      }
+      poet_.reset(new Poet(language(), config));
     }
   }
   if (enable_encoder_ && user_dict_) {
@@ -558,20 +557,22 @@ TableTranslator::MakeSentence(const string& input, size_t start,
   const int max_entries = max_homographs_;
   DictEntryCollector collector;
   UserDictEntryCollector user_phrase_collector;
-  map<int, an<Sentence>> sentences;
-  sentences[0] = New<Sentence>(language());
+  WordGraph graph;
+  hash_set<int> vertices = {0};
   for (size_t start_pos = 0; start_pos < input.length(); ++start_pos) {
-    if (sentences.find(start_pos) == sentences.end())
+    // find next reachable vertex in word graph
+    if (vertices.find(start_pos) == vertices.end())
       continue;
     string active_input = input.substr(start_pos);
     string active_key = active_input + ' ';
-    UserDictEntryCollector collected_entries;
+    UserDictEntryCollector& collected_entries(graph[start_pos]);
     // lookup dictionaries
     if (user_dict_ && user_dict_->loaded()) {
       for (size_t len = 1; len <= active_input.length(); ++len) {
         size_t consumed_length =
             consume_trailing_delimiters(len, active_input, delimiters_);
-        auto& dest(collected_entries[consumed_length]);
+        size_t end_pos = start_pos + consumed_length;
+        auto& dest(collected_entries[end_pos]);
         if (dest.size() >= max_entries)
           continue;
         DLOG(INFO) << "active input: " << active_input << "[0, " << len << ")";
@@ -583,13 +584,14 @@ TableTranslator::MakeSentence(const string& input, size_t start,
           uter.AddFilter(CharsetFilter::FilterDictEntry);
         }
         if (!uter.exhausted()) {
+          vertices.insert(end_pos);
           if (start_pos == 0 && max_entries > 1) {
             UserDictEntryIterator uter_copy(uter);
             collect_entries(dest, uter_copy, max_entries);
           } else {
             collect_entries(dest, uter, max_entries);
           }
-          if (start_pos == 0) {
+          if (include_prefix_phrases && start_pos == 0) {
             // also provide words for manual composition
             // uter must not be consumed
             uter.Release(&user_phrase_collector[consumed_length]);
@@ -607,7 +609,8 @@ TableTranslator::MakeSentence(const string& input, size_t start,
       for (size_t len = 1; len <= active_input.length(); ++len) {
         size_t consumed_length =
             consume_trailing_delimiters(len, active_input, delimiters_);
-        auto& dest(collected_entries[consumed_length]);
+        size_t end_pos = start_pos + consumed_length;
+        auto& dest(collected_entries[end_pos]);
         if (!dest.empty())
           continue;
         DLOG(INFO) << "active input: " << active_input << "[0, " << len << ")";
@@ -619,13 +622,14 @@ TableTranslator::MakeSentence(const string& input, size_t start,
           uter.AddFilter(CharsetFilter::FilterDictEntry);
         }
         if (!uter.exhausted()) {
+          vertices.insert(end_pos);
           if (start_pos == 0 && max_entries > 1) {
             UserDictEntryIterator uter_copy(uter);
             collect_entries(dest, uter_copy, max_entries);
           } else {
             collect_entries(dest, uter, max_entries);
           }
-          if (start_pos == 0) {
+          if (include_prefix_phrases && start_pos == 0) {
             // also provide words for manual composition
             // uter must not be consumed
             uter.Release(&user_phrase_collector[consumed_length]);
@@ -648,7 +652,8 @@ TableTranslator::MakeSentence(const string& input, size_t start,
           continue;
         size_t consumed_length =
             consume_trailing_delimiters(m.length, active_input, delimiters_);
-        auto& dest(collected_entries[consumed_length]);
+        size_t end_pos = start_pos + consumed_length;
+        auto& dest(collected_entries[end_pos]);
         if (dest.size() >= max_entries)
           continue;
         DictEntryIterator iter;
@@ -657,13 +662,14 @@ TableTranslator::MakeSentence(const string& input, size_t start,
           iter.AddFilter(CharsetFilter::FilterDictEntry);
         }
         if (!iter.exhausted()) {
+          vertices.insert(end_pos);
           if (start_pos == 0 && max_entries - dest.size() > 1) {
             DictEntryIterator iter_copy = iter;
             collect_entries(dest, iter_copy, max_entries);
           } else {
             collect_entries(dest, iter, max_entries);
           }
-          if (start_pos == 0) {
+          if (include_prefix_phrases && start_pos == 0) {
             // also provide words for manual composition
             // iter must not be consumed
             collector[consumed_length] = std::move(iter);
@@ -673,38 +679,21 @@ TableTranslator::MakeSentence(const string& input, size_t start,
         }
       }
     }
-    for (size_t len = 1; len <= active_input.length(); ++len) {
-      const auto& entries(collected_entries[len]);
-      if (entries.empty())
-        continue;
-      size_t end_pos = start_pos + len;
-      bool is_rear = end_pos == input.length();
-      for (const auto& entry : entries) {
-        // create a new sentence
-        auto new_sentence = New<Sentence>(*sentences[start_pos]);
-        new_sentence->Extend(*entry, end_pos, is_rear, grammar_.get());
-        // compare and update sentences
-        if (sentences.find(end_pos) == sentences.end() ||
-            sentences[end_pos]->weight() <= new_sentence->weight()) {
-          sentences[end_pos] = std::move(new_sentence);
-        }
-      }
-    }
   }
-  an<Translation> result;
-  if (sentences.find(input.length()) != sentences.end()) {
-    result = Cached<SentenceTranslation>(
+  if (auto sentence = poet_->MakeSentence(graph, input.length())) {
+    auto result = Cached<SentenceTranslation>(
         this,
-        std::move(sentences[input.length()]),
-        include_prefix_phrases ? std::move(collector) : DictEntryCollector(),
-        include_prefix_phrases ? std::move(user_phrase_collector) : UserDictEntryCollector(),
+        std::move(sentence),
+        std::move(collector),
+        std::move(user_phrase_collector),
         input,
         start);
     if (result && filter_by_charset) {
-      result = New<CharsetFilterTranslation>(result);
+      return New<CharsetFilterTranslation>(result);
     }
+    return result;
   }
-  return result;
+  return nullptr;
 }
 
 }  // namespace rime

--- a/src/rime/gear/table_translator.h
+++ b/src/rime/gear/table_translator.h
@@ -29,13 +29,13 @@ class TableTranslator : public Translator,
   TableTranslator(const Ticket& ticket);
 
   virtual an<Translation> Query(const string& input,
-                                        const Segment& segment);
+                                const Segment& segment);
   virtual bool Memorize(const CommitEntry& commit_entry);
 
   an<Translation> MakeSentence(const string& input,
-                                       size_t start,
-                                       bool include_prefix_phrases = false);
-  string GetPrecedingText() const;
+                               size_t start,
+                               bool include_prefix_phrases = false);
+  string GetPrecedingText(size_t start) const;
   UnityTableEncoder* encoder() const { return encoder_.get(); }
 
  protected:

--- a/src/rime/gear/table_translator.h
+++ b/src/rime/gear/table_translator.h
@@ -19,7 +19,7 @@
 
 namespace rime {
 
-class Grammar;
+class Poet;
 class UnityTableEncoder;
 
 class TableTranslator : public Translator,
@@ -46,8 +46,8 @@ class TableTranslator : public Translator,
   bool encode_commit_history_ = true;
   int max_phrase_length_ = 5;
   int max_homographs_ = 1;
+  the<Poet> poet_;
   the<UnityTableEncoder> encoder_;
-  the<Grammar> grammar_;
 };
 
 class TableTranslation : public Translation {

--- a/src/rime/gear/table_translator.h
+++ b/src/rime/gear/table_translator.h
@@ -35,7 +35,7 @@ class TableTranslator : public Translator,
   an<Translation> MakeSentence(const string& input,
                                        size_t start,
                                        bool include_prefix_phrases = false);
-
+  string GetPrecedingText() const;
   UnityTableEncoder* encoder() const { return encoder_.get(); }
 
  protected:

--- a/src/rime/gear/translator_commons.cc
+++ b/src/rime/gear/translator_commons.cc
@@ -91,8 +91,10 @@ bool Spans::HasVertex(size_t vertex) const {
 void Sentence::Extend(const DictEntry& entry,
                       size_t end_pos,
                       bool is_rear,
+                      const string& preceding_text,
                       Grammar* grammar) {
-  entry_->weight += Grammar::Evaluate(text(), entry, is_rear, grammar);
+  const string& context = empty() ? preceding_text : text();
+  entry_->weight += Grammar::Evaluate(context, entry, is_rear, grammar);
   entry_->text.append(entry.text);
   entry_->code.insert(entry_->code.end(),
                       entry.code.begin(),
@@ -118,6 +120,8 @@ TranslatorOptions::TranslatorOptions(const Ticket& ticket) {
     config->GetString(ticket.name_space + "/delimiter", &delimiters_) ||
         config->GetString("speller/delimiter", &delimiters_);
     config->GetString(ticket.name_space + "/tag", &tag_);
+    config->GetBool(ticket.name_space + "/contextual_suggestions",
+                    &contextual_suggestions_);
     config->GetBool(ticket.name_space + "/enable_completion",
                     &enable_completion_);
     config->GetBool(ticket.name_space + "/strict_spelling",

--- a/src/rime/gear/translator_commons.cc
+++ b/src/rime/gear/translator_commons.cc
@@ -92,7 +92,7 @@ void Sentence::Extend(const DictEntry& entry,
                       size_t end_pos,
                       bool is_rear,
                       Grammar* grammar) {
-  entry_->weight += Grammar::Evaluate(entry_->text, entry, is_rear, grammar);
+  entry_->weight += Grammar::Evaluate(text(), entry, is_rear, grammar);
   entry_->text.append(entry.text);
   entry_->code.insert(entry_->code.end(),
                       entry.code.begin(),
@@ -101,7 +101,7 @@ void Sentence::Extend(const DictEntry& entry,
   syllable_lengths_.push_back(end_pos - end());
   set_end(end_pos);
   DLOG(INFO) << "extend sentence " << end_pos << ") "
-             << entry_->text << " : " << entry_->weight;
+             << text() << " weight: " << weight();
 }
 
 void Sentence::Offset(size_t offset) {

--- a/src/rime/gear/translator_commons.h
+++ b/src/rime/gear/translator_commons.h
@@ -71,7 +71,9 @@ class Language;
 class Phrase : public Candidate {
  public:
   Phrase(const Language* language,
-         const string& type, size_t start, size_t end,
+         const string& type,
+         size_t start,
+         size_t end,
          const an<DictEntry>& entry)
       : Candidate(type, start, end),
         language_(language),
@@ -112,9 +114,7 @@ class Grammar;
 class Sentence : public Phrase {
  public:
   Sentence(const Language* language)
-      : Phrase(language, "sentence", 0, 0, New<DictEntry>()) {
-    entry_->weight = 0.0;
-  }
+      : Phrase(language, "sentence", 0, 0, New<DictEntry>()) {}
   Sentence(const Sentence& other)
       : Phrase(other),
         components_(other.components_),
@@ -126,6 +126,14 @@ class Sentence : public Phrase {
               bool is_rear,
               Grammar* grammar);
   void Offset(size_t offset);
+
+  bool empty() const {
+    return components_.empty();
+  }
+
+  size_t size() const {
+    return components_.size();
+  }
 
   const vector<DictEntry>& components() const {
     return components_;

--- a/src/rime/gear/translator_commons.h
+++ b/src/rime/gear/translator_commons.h
@@ -124,6 +124,7 @@ class Sentence : public Phrase {
   void Extend(const DictEntry& entry,
               size_t end_pos,
               bool is_rear,
+              const string& preceding_text,
               Grammar* grammar);
   void Offset(size_t offset);
 
@@ -159,6 +160,10 @@ class TranslatorOptions {
   const string& delimiters() const { return delimiters_; }
   const string& tag() const { return tag_; }
   void set_tag(const string& tag) { tag_ = tag; }
+  bool contextual_suggestions() const { return contextual_suggestions_; }
+  void set_contextual_suggestions(bool enabled) {
+    contextual_suggestions_ = enabled;
+  }
   bool enable_completion() const { return enable_completion_; }
   void set_enable_completion(bool enabled) { enable_completion_ = enabled; }
   bool strict_spelling() const { return strict_spelling_; }
@@ -171,6 +176,7 @@ class TranslatorOptions {
  protected:
   string delimiters_;
   string tag_ = "abc";
+  bool contextual_suggestions_ = false;
   bool enable_completion_ = true;
   bool strict_spelling_ = false;
   double initial_quality_ = 0.;

--- a/src/rime/gear/translator_commons.h
+++ b/src/rime/gear/translator_commons.h
@@ -91,8 +91,8 @@ class Phrase : public Candidate {
   void set_syllabifier(an<PhraseSyllabifier> syllabifier) {
     syllabifier_ = syllabifier;
   }
-
   double weight() const { return entry_->weight; }
+  void set_weight(double weight) { entry_->weight = weight; }
   Code& code() const { return entry_->code; }
   const DictEntry& entry() const { return *entry_; }
   const Language* language() const { return language_; }


### PR DESCRIPTION
Closes #99

Usage:

with `script_translator`:
```yaml
patch:
  grammar:
    language: zh-hant-t-essay-bgw
  translator/contextual_suggestions: true
  translator/max_homophones: 7
```

with `table_translator`:
```yaml
patch:
  grammar:
    language: zh-hant-t-essay-bgc
    collocation_max_length: 2
    collocation_min_length: 2
  translator/contextual_suggestions: true
  translator/max_homographs: 5
```