### PR TITLE
fix(cmake): libboost Windows XP compatibility fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ if(MSVC)
     # stdint.h is missing from VS2010
     include_directories(${PROJECT_SOURCE_DIR}/thirdparty/include/msvc)
   endif()
-  # Force Boost.Uuid to use wincrypt as random provider instead of bcrypt
+  # Force Boost.Uuid to use wincrypt as random provider instead of bcrypt for Windows XP compatibility
   add_definitions("/wd4244 /wd4996 /DBOOST_UUID_RANDOM_PROVIDER_FORCE_WINCRYPT")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,8 @@ if(MSVC)
     # stdint.h is missing from VS2010
     include_directories(${PROJECT_SOURCE_DIR}/thirdparty/include/msvc)
   endif()
-  add_definitions("/wd4244 /wd4996")
+  # Force Boost.Uuid to use wincrypt as random provider instead of bcrypt
+  add_definitions("/wd4244 /wd4996 /DBOOST_UUID_RANDOM_PROVIDER_FORCE_WINCRYPT")
 endif()
 
 if(UNIX)


### PR DESCRIPTION
Force Boost.Uuid to use obsolete CryptoAPI for Windows XP compatibility, as the new Cryptography API: Next Generation (CNG) requires minimum version of Windows Vista.