### PR TITLE
feat: chareset_filter allow emoji with option

### DIFF
--- a/src/rime/gear/charset_filter.cc
+++ b/src/rime/gear/charset_filter.cc
@@ -46,7 +46,7 @@ bool contains_extended_cjk(const string& text)
   return false;
 }
 
-bool is_emoji(uint32_t ch)
+static bool is_emoji(uint32_t ch)
 {
 
   if ((ch >= 0x0000 && ch <= 0x007F) || // C0 Controls and Basic Latin
@@ -81,7 +81,7 @@ bool is_emoji(uint32_t ch)
   return false;
 }
 
-bool is_all_emoji(const string& text)
+static bool is_all_emoji(const string& text)
 {
   const char *p = text.c_str();
   uint32_t ch;
@@ -99,7 +99,7 @@ bool is_all_emoji(const string& text)
 
 CharsetFilterTranslation::CharsetFilterTranslation(
     an<Translation> translation, const string& charset_with_parameter_)
-    : translation_(translation), charset_with_parameter_(charset_with_parameter_) { // XXX
+    : translation_(translation), charset_with_parameter_(charset_with_parameter_) {
   LocateNextCandidate();
 }
 
@@ -143,7 +143,7 @@ bool CharsetFilter::FilterText(const string& text, const string& charset_with_pa
   }
 
   try {
-    auto charset = charset_arguments_vector[0];
+    const auto& charset = charset_arguments_vector[0];
     boost::locale::conv::from_utf(text, charset, boost::locale::conv::method_type::stop);
   }
   catch(boost::locale::conv::conversion_error const& /*ex*/) {

--- a/src/rime/gear/charset_filter.cc
+++ b/src/rime/gear/charset_filter.cc
@@ -131,11 +131,9 @@ bool CharsetFilterTranslation::LocateNextCandidate() {
 // CharsetFilter
 
 bool CharsetFilter::FilterText(const string& text, const string& charset_with_parameter) {
+  if (charset_with_parameter.empty()) return !contains_extended_cjk(text);
   vector<string> charset_arguments_vector;
   boost::split(charset_arguments_vector, charset_with_parameter, boost::is_any_of("+"));
-  if (charset_arguments_vector.size() == 0) {
-    return !contains_extended_cjk(text);
-  }
   bool is_emoji_enabled = false;
   if (std::find(charset_arguments_vector.begin(), charset_arguments_vector.end(), "emoji") != charset_arguments_vector.end()) {
 	is_emoji_enabled = true;
@@ -145,7 +143,8 @@ bool CharsetFilter::FilterText(const string& text, const string& charset_with_pa
   }
 
   try {
-    boost::locale::conv::from_utf(text, charset_arguments_vector[0], boost::locale::conv::method_type::stop);
+    auto charset = charset_arguments_vector[0];
+    boost::locale::conv::from_utf(text, charset, boost::locale::conv::method_type::stop);
   }
   catch(boost::locale::conv::conversion_error const& /*ex*/) {
     return false;

--- a/src/rime/gear/charset_filter.cc
+++ b/src/rime/gear/charset_filter.cc
@@ -13,6 +13,8 @@
 #include <rime/dict/vocabulary.h>
 #include <rime/gear/charset_filter.h>
 #include <boost/locale/encoding.hpp>
+#include <boost/algorithm/string.hpp>
+
 
 namespace rime {
 
@@ -44,11 +46,60 @@ bool contains_extended_cjk(const string& text)
   return false;
 }
 
+bool is_emoji(uint32_t ch)
+{
+
+  if ((ch >= 0x0000 && ch <= 0x007F) || // C0 Controls and Basic Latin
+	  (ch >= 0x0080 && ch <= 0x00FF) || // C1 Controls and Latin-1 Supplement
+	  (ch >= 0x02B0 && ch <= 0x02FF) || // Spacing Modifier Letters
+	  (ch >= 0x0900 && ch <= 0x097F) || // Devanagari
+	  (ch >= 0x2000 && ch <= 0x203C) || // General Punctuation
+	  (ch >= 0x20A0 && ch <= 0x20CF) || // Currency Symbols
+	  (ch >= 0x2100 && ch <= 0x214F) || // Letterlike Symbols
+	  (ch >= 0x2150 && ch <= 0x218F) || // Number Forms
+	  (ch >= 0x2190 && ch <= 0x21FF) || // Arrows
+	  (ch >= 0x2200 && ch <= 0x22FF) || // Mathematical Operators
+	  (ch >= 0x2300 && ch <= 0x23FF) || // Miscellaneous Technical
+	  (ch >= 0x2460 && ch <= 0x24FF) || // Enclosed Alphanumerics
+	  (ch >= 0x25A0 && ch <= 0x25FF) || // Geometric Shapes
+	  (ch >= 0x2600 && ch <= 0x26FF) || // Miscellaneous Symbols
+	  (ch >= 0x2700 && ch <= 0x27BF) || // Dingbats
+	  (ch >= 0x2900 && ch <= 0x297F) || // Supplemental Arrows-B
+	  (ch >= 0x2B00 && ch <= 0x2BFF) || // Miscellaneous Symbols and Arrows
+	  (ch >= 0x3000 && ch <= 0x303F) || // CJK Symbols and Punctuation
+	  (ch >= 0x3200 && ch <= 0x32FF) || // Enclosed CJK Letters and Months
+	  (ch >= 0x1F100 && ch <= 0x1F1FF) || // Enclosed Alphanumeric Supplement
+	  (ch >= 0x1F200 && ch <= 0x1F2FF) || // Enclosed Ideographic Supplement
+	  (ch >= 0x1F000 && ch <= 0x1F02F) || // Mahjong Tiles
+	  (ch >= 0x1F0A0 && ch <= 0x1F0FF) || // Playing Cards
+	  (ch >= 0x1F300 && ch <= 0x1F5FF) || // Miscellaneous Symbols and Pictographs
+	  (ch >= 0x1F600 && ch <= 0x1F64F) || // Emoticons
+	  (ch >= 0x1F680 && ch <= 0x1F6FF) || // Transport and Map Symbols
+	  (ch >= 0x1F900 && ch <= 0x1F9FF)) // Supplemental Symbols and Pictographs)
+	return true;
+
+  return false;
+}
+
+bool is_all_emoji(const string& text)
+{
+  const char *p = text.c_str();
+  uint32_t ch;
+
+  while ((ch = utf8::unchecked::next(p)) != 0) {
+    if (!is_emoji(ch)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 // CharsetFilterTranslation
 
 CharsetFilterTranslation::CharsetFilterTranslation(
-    an<Translation> translation, const string& charset)
-    : translation_(translation), charset_(charset) {
+    an<Translation> translation, const string& charset_with_parameter_)
+    : translation_(translation), charset_with_parameter_(charset_with_parameter_) { // XXX
   LocateNextCandidate();
 }
 
@@ -69,7 +120,7 @@ an<Candidate> CharsetFilterTranslation::Peek() {
 bool CharsetFilterTranslation::LocateNextCandidate() {
   while (!translation_->exhausted()) {
     auto cand = translation_->Peek();
-    if (cand && CharsetFilter::FilterText(cand->text(), charset_))
+    if (cand && CharsetFilter::FilterText(cand->text(), charset_with_parameter_))
       return true;
     translation_->Next();
   }
@@ -79,10 +130,22 @@ bool CharsetFilterTranslation::LocateNextCandidate() {
 
 // CharsetFilter
 
-bool CharsetFilter::FilterText(const string& text, const string& charset) {
-  if (charset.empty()) return !contains_extended_cjk(text);
+bool CharsetFilter::FilterText(const string& text, const string& charset_with_parameter) {
+  vector<string> charset_arguments_vector;
+  boost::split(charset_arguments_vector, charset_with_parameter, boost::is_any_of("+"));
+  if (charset_arguments_vector.size() == 0) {
+    return !contains_extended_cjk(text);
+  }
+  bool is_emoji_enabled = false;
+  if (std::find(charset_arguments_vector.begin(), charset_arguments_vector.end(), "emoji") != charset_arguments_vector.end()) {
+	is_emoji_enabled = true;
+  }
+  if (is_emoji_enabled && is_all_emoji(text)) {
+	return true;
+  }
+
   try {
-    boost::locale::conv::from_utf(text, charset, boost::locale::conv::method_type::stop);
+    boost::locale::conv::from_utf(text, charset_arguments_vector[0], boost::locale::conv::method_type::stop);
   }
   catch(boost::locale::conv::conversion_error const& /*ex*/) {
     return false;

--- a/src/rime/gear/charset_filter.h
+++ b/src/rime/gear/charset_filter.h
@@ -7,6 +7,7 @@
 #ifndef RIME_CHARSET_FILTER_H_
 #define RIME_CHARSET_FILTER_H_
 
+#include <rime_api.h>
 #include <rime/filter.h>
 #include <rime/translation.h>
 #include <rime/gear/filter_commons.h>
@@ -40,7 +41,7 @@ class CharsetFilter : public Filter, TagMatching {
   }
 
   // return true to accept, false to reject the tested item
-  static bool FilterText(const string& text, const string& charset_with_argument = "");
+  RIME_API static bool FilterText(const string& text, const string& charset_with_argument = "");
   static bool FilterDictEntry(an<DictEntry> entry);
 };
 

--- a/src/rime/gear/charset_filter.h
+++ b/src/rime/gear/charset_filter.h
@@ -23,7 +23,7 @@ class CharsetFilterTranslation : public Translation {
   bool LocateNextCandidate();
 
   an<Translation> translation_;
-  string charset_;
+  string charset_with_parameter_;
 };
 
 struct DictEntry;
@@ -40,7 +40,7 @@ class CharsetFilter : public Filter, TagMatching {
   }
 
   // return true to accept, false to reject the tested item
-  static bool FilterText(const string& text, const string& charset = "");
+  static bool FilterText(const string& text, const string& charset_with_argument = "");
   static bool FilterDictEntry(an<DictEntry> entry);
 };
 

--- a/test/charset_filter_test.cc
+++ b/test/charset_filter_test.cc
@@ -1,0 +1,45 @@
+//
+// Copyright RIME Developers
+// Distributed under the BSD License
+//
+// 2012-01-17 GONG Chen <chen.sst@gmail.com>
+//
+#include <gtest/gtest.h>
+#include <rime/common.h>
+#include <rime/gear/charset_filter.h>
+#include <rime/translation.h>
+
+using namespace rime;
+
+
+TEST(RimeCharsetFilterTest, FilterText) {
+  Ticket ticket;
+  CharsetFilter filter (ticket);
+  EXPECT_TRUE(filter.FilterText("Hello", "utf8"));
+  EXPECT_TRUE(filter.FilterText("荣", "utf8"));
+  EXPECT_TRUE(filter.FilterText("𤘺", "utf8"));
+  EXPECT_TRUE(filter.FilterText("👋", "utf8"));
+  EXPECT_TRUE(filter.FilterText("👋", "utf8"));
+  EXPECT_TRUE(filter.FilterText("荣👋", "utf8"));
+  EXPECT_TRUE(filter.FilterText("鎔", "gbk"));
+  EXPECT_TRUE(filter.FilterText("𤘺", "utf8"));
+
+  EXPECT_TRUE(filter.FilterText("Hello", "gbk"));
+  EXPECT_TRUE(filter.FilterText("荣", "gbk"));
+  EXPECT_FALSE(filter.FilterText("𤘺", "gbk"));
+  EXPECT_FALSE(filter.FilterText("👋", "gbk"));
+  EXPECT_TRUE(filter.FilterText("👋", "gbk+emoji"));
+  EXPECT_FALSE(filter.FilterText("荣👋", "gbk+emoji"));
+  EXPECT_TRUE(filter.FilterText("鎔", "gbk"));
+  EXPECT_FALSE(filter.FilterText("𤘺", "gbk"));
+
+  EXPECT_TRUE(filter.FilterText("Hello", "gb2312"));
+  EXPECT_TRUE(filter.FilterText("荣", "gb2312"));
+  EXPECT_FALSE(filter.FilterText("𤘺", "gb2312"));
+  EXPECT_FALSE(filter.FilterText("👋", "gb2312"));
+  EXPECT_TRUE(filter.FilterText("👋", "gb2312+emoji"));
+  EXPECT_FALSE(filter.FilterText("荣👋", "gb2312+emoji"));
+  EXPECT_FALSE(filter.FilterText("鎔", "gb2312"));
+  EXPECT_FALSE(filter.FilterText("𤘺", "gb2312"));
+}
+

--- a/test/charset_filter_test.cc
+++ b/test/charset_filter_test.cc
@@ -13,31 +13,33 @@ using namespace rime;
 
 
 TEST(RimeCharsetFilterTest, FilterText) {
+  EXPECT_TRUE(CharsetFilter::FilterText("荣", "unkown"));
+  EXPECT_TRUE(CharsetFilter::FilterText("👋", "unkown"));
+
   EXPECT_TRUE(CharsetFilter::FilterText("Hello", "utf8"));
   EXPECT_TRUE(CharsetFilter::FilterText("荣", "utf8"));
+  EXPECT_TRUE(CharsetFilter::FilterText("鎔", "utf8"));
   EXPECT_TRUE(CharsetFilter::FilterText("𤘺", "utf8"));
-  EXPECT_TRUE(CharsetFilter::FilterText("👋", "utf8"));
   EXPECT_TRUE(CharsetFilter::FilterText("👋", "utf8"));
   EXPECT_TRUE(CharsetFilter::FilterText("荣👋", "utf8"));
-  EXPECT_TRUE(CharsetFilter::FilterText("鎔", "gbk"));
-  EXPECT_TRUE(CharsetFilter::FilterText("𤘺", "utf8"));
 
   EXPECT_TRUE(CharsetFilter::FilterText("Hello", "gbk"));
   EXPECT_TRUE(CharsetFilter::FilterText("荣", "gbk"));
-  EXPECT_FALSE(CharsetFilter::FilterText("𤘺", "gbk"));
-  EXPECT_FALSE(CharsetFilter::FilterText("👋", "gbk"));
-  EXPECT_TRUE(CharsetFilter::FilterText("👋", "gbk+emoji"));
-  EXPECT_FALSE(CharsetFilter::FilterText("荣👋", "gbk+emoji"));
   EXPECT_TRUE(CharsetFilter::FilterText("鎔", "gbk"));
   EXPECT_FALSE(CharsetFilter::FilterText("𤘺", "gbk"));
+  EXPECT_FALSE(CharsetFilter::FilterText("👋", "gbk"));
+  EXPECT_FALSE(CharsetFilter::FilterText("荣👋", "gbk"));
 
   EXPECT_TRUE(CharsetFilter::FilterText("Hello", "gb2312"));
   EXPECT_TRUE(CharsetFilter::FilterText("荣", "gb2312"));
-  EXPECT_FALSE(CharsetFilter::FilterText("𤘺", "gb2312"));
-  EXPECT_FALSE(CharsetFilter::FilterText("👋", "gb2312"));
-  EXPECT_TRUE(CharsetFilter::FilterText("👋", "gb2312+emoji"));
-  EXPECT_FALSE(CharsetFilter::FilterText("荣👋", "gb2312+emoji"));
   EXPECT_FALSE(CharsetFilter::FilterText("鎔", "gb2312"));
   EXPECT_FALSE(CharsetFilter::FilterText("𤘺", "gb2312"));
+  EXPECT_FALSE(CharsetFilter::FilterText("👋", "gb2312"));
+
+  EXPECT_TRUE(CharsetFilter::FilterText("👋", "gbk+emoji"));
+  EXPECT_FALSE(CharsetFilter::FilterText("荣👋", "gbk+emoji"));
+
+  EXPECT_TRUE(CharsetFilter::FilterText("👋", "gb2312+emoji"));
+  EXPECT_FALSE(CharsetFilter::FilterText("荣👋", "gb2312+emoji"));
 }
 

--- a/test/charset_filter_test.cc
+++ b/test/charset_filter_test.cc
@@ -13,33 +13,31 @@ using namespace rime;
 
 
 TEST(RimeCharsetFilterTest, FilterText) {
-  Ticket ticket;
-  CharsetFilter filter (ticket);
-  EXPECT_TRUE(filter.FilterText("Hello", "utf8"));
-  EXPECT_TRUE(filter.FilterText("荣", "utf8"));
-  EXPECT_TRUE(filter.FilterText("𤘺", "utf8"));
-  EXPECT_TRUE(filter.FilterText("👋", "utf8"));
-  EXPECT_TRUE(filter.FilterText("👋", "utf8"));
-  EXPECT_TRUE(filter.FilterText("荣👋", "utf8"));
-  EXPECT_TRUE(filter.FilterText("鎔", "gbk"));
-  EXPECT_TRUE(filter.FilterText("𤘺", "utf8"));
+  EXPECT_TRUE(CharsetFilter::FilterText("Hello", "utf8"));
+  EXPECT_TRUE(CharsetFilter::FilterText("荣", "utf8"));
+  EXPECT_TRUE(CharsetFilter::FilterText("𤘺", "utf8"));
+  EXPECT_TRUE(CharsetFilter::FilterText("👋", "utf8"));
+  EXPECT_TRUE(CharsetFilter::FilterText("👋", "utf8"));
+  EXPECT_TRUE(CharsetFilter::FilterText("荣👋", "utf8"));
+  EXPECT_TRUE(CharsetFilter::FilterText("鎔", "gbk"));
+  EXPECT_TRUE(CharsetFilter::FilterText("𤘺", "utf8"));
 
-  EXPECT_TRUE(filter.FilterText("Hello", "gbk"));
-  EXPECT_TRUE(filter.FilterText("荣", "gbk"));
-  EXPECT_FALSE(filter.FilterText("𤘺", "gbk"));
-  EXPECT_FALSE(filter.FilterText("👋", "gbk"));
-  EXPECT_TRUE(filter.FilterText("👋", "gbk+emoji"));
-  EXPECT_FALSE(filter.FilterText("荣👋", "gbk+emoji"));
-  EXPECT_TRUE(filter.FilterText("鎔", "gbk"));
-  EXPECT_FALSE(filter.FilterText("𤘺", "gbk"));
+  EXPECT_TRUE(CharsetFilter::FilterText("Hello", "gbk"));
+  EXPECT_TRUE(CharsetFilter::FilterText("荣", "gbk"));
+  EXPECT_FALSE(CharsetFilter::FilterText("𤘺", "gbk"));
+  EXPECT_FALSE(CharsetFilter::FilterText("👋", "gbk"));
+  EXPECT_TRUE(CharsetFilter::FilterText("👋", "gbk+emoji"));
+  EXPECT_FALSE(CharsetFilter::FilterText("荣👋", "gbk+emoji"));
+  EXPECT_TRUE(CharsetFilter::FilterText("鎔", "gbk"));
+  EXPECT_FALSE(CharsetFilter::FilterText("𤘺", "gbk"));
 
-  EXPECT_TRUE(filter.FilterText("Hello", "gb2312"));
-  EXPECT_TRUE(filter.FilterText("荣", "gb2312"));
-  EXPECT_FALSE(filter.FilterText("𤘺", "gb2312"));
-  EXPECT_FALSE(filter.FilterText("👋", "gb2312"));
-  EXPECT_TRUE(filter.FilterText("👋", "gb2312+emoji"));
-  EXPECT_FALSE(filter.FilterText("荣👋", "gb2312+emoji"));
-  EXPECT_FALSE(filter.FilterText("鎔", "gb2312"));
-  EXPECT_FALSE(filter.FilterText("𤘺", "gb2312"));
+  EXPECT_TRUE(CharsetFilter::FilterText("Hello", "gb2312"));
+  EXPECT_TRUE(CharsetFilter::FilterText("荣", "gb2312"));
+  EXPECT_FALSE(CharsetFilter::FilterText("𤘺", "gb2312"));
+  EXPECT_FALSE(CharsetFilter::FilterText("👋", "gb2312"));
+  EXPECT_TRUE(CharsetFilter::FilterText("👋", "gb2312+emoji"));
+  EXPECT_FALSE(CharsetFilter::FilterText("荣👋", "gb2312+emoji"));
+  EXPECT_FALSE(CharsetFilter::FilterText("鎔", "gb2312"));
+  EXPECT_FALSE(CharsetFilter::FilterText("𤘺", "gb2312"));
 }
 


### PR DESCRIPTION
通过配置 charset_filter 为 'gb2312+emoji' 方式允许 Emoji 出现在特定 charset。
Emoji 数据源来自于：https://github.com/rhdunn/espeak/blob/master/dictsource/en_emoji

相关 PR https://github.com/rime/librime/pull/213

配置范例：

```yaml
  switches:
...
    - options: [gb2312+emoji, gbk+emoji, utf8]
      states:
        - GB2312
        - GBK
        - UTF-8
      reset: 0

  engine/filters:
...
    - simplifier
    - charset_filter@gb2312+emoji
    - charset_filter@gbk+emoji
...

```