### PR TITLE
CMakeLists.txt: Use GNUinstalldirs module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,14 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/c_flag_over
 set(CMAKE_USER_MAKE_RULES_OVERRIDE_CXX ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cxx_flag_overrides.cmake)
 
 project(rime)
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.0.2)
 
 set(rime_version 1.5.3)
 set(rime_soversion 1)
 
 add_definitions(-DRIME_VERSION="${rime_version}")
+
+include(GNUInstallDirs)
 
 option(BUILD_SHARED_LIBS "Build Rime as shared library" ON)
 option(BUILD_MERGED_PLUGINS "Merge plugins into one Rime library" ON)
@@ -161,11 +163,11 @@ if(UNIX)
 endif()
 
 if(NOT DEFINED LIB_INSTALL_DIR)
-    set(LIB_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX})
+    set(LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
 endif()
 
 if(NOT DEFINED BIN_INSTALL_DIR)
-    set(BIN_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/bin)
+    set(BIN_INSTALL_DIR ${CMAKE_INSTALL_BINDIR})
 endif()
 
 # uninstall target
@@ -179,10 +181,10 @@ add_custom_target(uninstall
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD|DragonFly")
   set(prefix "${CMAKE_INSTALL_PREFIX}")
   set(exec_prefix "${CMAKE_INSTALL_PREFIX}")
-  set(bindir "${exec_prefix}/bin")
+  set(bindir "${BIN_INSTALL_DIR}")
   set(libdir "${LIB_INSTALL_DIR}")
   set(pkgdatadir "${prefix}${rime_data_dir}")
-  set(includedir "${CMAKE_INSTALL_PREFIX}/include")
+  set(includedir "${CMAKE_INSTALL_INCLUDEDIR}")
   configure_file(
       ${PROJECT_SOURCE_DIR}/rime.pc.in
       ${PROJECT_BINARY_DIR}/rime.pc


### PR DESCRIPTION
Debian's packger of librime here. This patch would introduce the GNUInstallDirs module into the project's top-level CMakeLists.txt.

[GNUInstalldirs](https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html) is available since CMake 3.0.2. It provides standard install directory variables as defined for GNU software. Using this module would provides standard variable names for bindir, libdir, includedir and datadir, etc., which would be beneficial. There's no needs for manual string concatenation anymore.

This module is especially useful for Debian-based Linux distributions since they are using `/usr/lib/<arch-triplet>/` as libdir instead of `/usr/lib/` and `/usr/lib64/`. The GNUInstallDirs module can elegantly suit such needs.

CMake >= 3.0.2 has been available for many years. It is at least available since Ubuntu 16.04 and Debian 8, which covers all supported Debian and Ubuntu versions (Ubuntu 14.04 LTS has reached End-Of-Life already). As a result, such version bump should not cause much troubles even for users of old systems. I would admit that CMake 3.x is not available on CentOS 7 but at least it is available through [epel](https://fedoraproject.org/wiki/EPEL).

This patch modifies the top-level CMakeLists.txt and applies the standard variables accordingly. The minimal CMake version requirement is also bumped to 3.0.2. I'm wondering if you find it okay to merge it. Thanks!

* * *
Edit 1: I see that the currrent Travis CI config still uses Trusty (14.04). I would expect build failures with current settings. Maybe it's time to bump the testbed version?