### PR TITLE
CMakeLists.txt: Add proper support for GNU/Hurd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ configure_file(
 add_custom_target(uninstall
   COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD|DragonFly")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD|DragonFly|GNU")
   set(prefix "${CMAKE_INSTALL_PREFIX}")
   set(exec_prefix "${CMAKE_INSTALL_PREFIX}")
   set(bindir "${BIN_INSTALL_DIR}")


### PR DESCRIPTION
[GNU/Hurd](https://hurd.gnu.org) has a `CMAKE_SYSTEM_NAME` of "GNU". Adding this name to the list of matches like Linux/FreeBSD/DragonFly since they are all unix-like. This fixes the build failure of librime in Debian under hurd-i386 architecture.