### PR TITLE
CMakeLists.txt: Ensure path in pkgconfig file to be absolute

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,10 +181,10 @@ add_custom_target(uninstall
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD|DragonFly")
   set(prefix "${CMAKE_INSTALL_PREFIX}")
   set(exec_prefix "${CMAKE_INSTALL_PREFIX}")
-  set(bindir "${BIN_INSTALL_DIR}")
-  set(libdir "${LIB_INSTALL_DIR}")
+  set(bindir "${exec_prefix}/${BIN_INSTALL_DIR}")
+  set(libdir "${exec_prefix}/${LIB_INSTALL_DIR}")
   set(pkgdatadir "${prefix}${rime_data_dir}")
-  set(includedir "${CMAKE_INSTALL_INCLUDEDIR}")
+  set(includedir "${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
   configure_file(
       ${PROJECT_SOURCE_DIR}/rime.pc.in
       ${PROJECT_BINARY_DIR}/rime.pc


### PR DESCRIPTION
This fixes the regression introduced in the last commit. The `${CMAKE_INSTALL_*DIR}` variables are not absolute and we must prepend them with `${prefix}` or `${exec_prefix}` to make it fully working.

There are also `${CMAKE_INSTALL_FULL_*DIR}` variables available but we are not using them for now since librime is still using custom `${LIB_INSTALL_DIR}` and `${BIN_INSTALL_DIR}`.