### PR TITLE
fix: Make cmake default to release build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,13 @@ if(WIN32)
   set(ext ".exe")
 endif(WIN32)
 
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release")
+    message (
+      STATUS "No CMAKE_BUILD_TYPE selected, defaulting to ${CMAKE_BUILD_TYPE}"
+    )
+endif(NOT CMAKE_BUILD_TYPE)
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "${PROJECT_SOURCE_DIR}/thirdparty")
 


### PR DESCRIPTION
Closes #254 

Related ticket: https://bugs.archlinux.org/task/66584#comment189187

该 PR 修改 CMakeLists.txt 文件，使其默认使用 Release build