### PR TITLE
add schema opinion "translator/candidate_sort_by"

### DIFF
--- a/src/rime/dict/user_dictionary.h
+++ b/src/rime/dict/user_dictionary.h
@@ -82,9 +82,16 @@ class UserDictionary : public Class<UserDictionary, const Ticket&> {
   const string& name() const { return name_; }
   TickCount tick() const { return tick_; }
 
+  enum SortBy {
+    recency = 0,
+    commit = 1
+  };
+  void set_lookup_sort_by(SortBy sort_by){ lookup_sort_by_ = sort_by; }
+
   static an<DictEntry> CreateDictEntry(const string& key,
                                        const string& value,
                                        TickCount present_tick,
+                                       SortBy sort_by = recency,
                                        double credibility = 0.0,
                                        string* full_code = NULL);
 
@@ -103,6 +110,7 @@ class UserDictionary : public Class<UserDictionary, const Ticket&> {
   an<Prism> prism_;
   TickCount tick_ = 0;
   time_t transaction_time_ = 0;
+  SortBy lookup_sort_by_ = recency;
 };
 
 class UserDictionaryComponent : public UserDictionary::Component {

--- a/src/rime/gear/schema_list_translator.cc
+++ b/src/rime/gear/schema_list_translator.cc
@@ -129,7 +129,7 @@ void SchemaListTranslation::LoadSchemaList(Switcher* switcher) {
   config->GetBool("switcher/fix_schema_list_order", &fix_order);
   if (fix_order)
     return;
-  // reorder schema list by recency
+  // reorder schema list by recency default
   std::stable_sort(candies_.begin() + fixed, candies_.end(),
       [](const an<Candidate>& x, const an<Candidate>& y) {
         return x->quality() > y->quality();

--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -160,6 +160,8 @@ ScriptTranslator::ScriptTranslator(const Ticket& ticket)
                     &always_show_comments_);
     config->GetBool(name_space_ + "/enable_correction", &enable_correction_);
     config->GetInt(name_space_ + "/max_homophones", &max_homophones_);
+    config->GetInt(name_space_ + "/candidate_sort_by", &candidate_sort_by_);
+    user_dict_->set_lookup_sort_by((UserDictionary::SortBy)candidate_sort_by_);
     poet_.reset(new Poet(language(), config));
   }
   if (enable_correction_) {

--- a/src/rime/gear/script_translator.h
+++ b/src/rime/gear/script_translator.h
@@ -49,8 +49,10 @@ class ScriptTranslator : public Translator,
   int spelling_hints_ = 0;
   bool always_show_comments_ = false;
   bool enable_correction_ = false;
+  int candidate_sort_by_ = 0;
   the<Corrector> corrector_;
   the<Poet> poet_;
+
 };
 
 }  // namespace rime

--- a/src/rime/gear/table_translator.cc
+++ b/src/rime/gear/table_translator.cc
@@ -218,6 +218,9 @@ TableTranslator::TableTranslator(const Ticket& ticket)
                    &max_phrase_length_);
     config->GetInt(name_space_ + "/max_homographs",
                    &max_homographs_);
+    config->GetInt(name_space_ + "/candidate_sort_by",
+                   &candidate_sort_by_);
+    user_dict_->set_lookup_sort_by((UserDictionary::SortBy)candidate_sort_by_);
     if (enable_sentence_ || sentence_over_completion_ ||
         contextual_suggestions_) {
       poet_.reset(new Poet(language(), config, Poet::LeftAssociateCompare));

--- a/src/rime/gear/table_translator.h
+++ b/src/rime/gear/table_translator.h
@@ -44,6 +44,7 @@ class TableTranslator : public Translator,
   bool enable_sentence_ = true;
   bool sentence_over_completion_ = false;
   bool encode_commit_history_ = true;
+  int candidate_sort_by_ = 0;
   int max_phrase_length_ = 5;
   int max_homographs_ = 1;
   the<Poet> poet_;


### PR DESCRIPTION
在我提出的问题之后， https://github.com/rime/librime/issues/377
我修改了代码，增加了一个方案的配置选项 translator/candidate_sort_by ，该选项对 table_translator 和 script_translator 生效
为 0 表示按最近使用排序（默认）
为 1 表示按使用频率排序
后续可以根据不同需求添加 2、3 等等扩展多种排序方式
这个功能的添加在我的机子上测试通过。