### PR TITLE
General support for navigating in vertical mode

### DIFF
--- a/src/rime/gear/navigator.cc
+++ b/src/rime/gear/navigator.cc
@@ -52,7 +52,42 @@ ProcessResult Navigator::ProcessKeyEvent(const KeyEvent& key_event) {
   Context* ctx = engine_->context();
   if (!ctx->IsComposing())
     return kNoop;
-  return KeyBindingProcessor::ProcessKeyEvent(key_event, ctx);
+  if (ctx->get_option("_vertical")) {
+    int ch = key_event.keycode();
+    const int mod = key_event.modifier();
+    switch (ch) {
+      case XK_Up:
+        ch = XK_Left;
+        break;
+      case XK_KP_Up:
+        ch = XK_KP_Left;
+        break;
+      case XK_Down:
+        ch = XK_Right;
+        break;
+      case XK_KP_Down:
+        ch = XK_KP_Right;
+        break;
+      case XK_Left:
+        ch = XK_Down;
+        break;
+      case XK_KP_Left:
+        ch = XK_KP_Down;
+        break;
+      case XK_Right:
+        ch = XK_Up;
+        break;
+      case XK_KP_Right:
+        ch = XK_KP_Up;
+        break;
+      default:
+        break;
+    }
+    const KeyEvent key_event_mod = KeyEvent(ch, mod);
+    return KeyBindingProcessor::ProcessKeyEvent(key_event_mod, ctx);
+  } else {
+    return KeyBindingProcessor::ProcessKeyEvent(key_event, ctx);
+  }
 }
 
 void Navigator::LeftBySyllable(Context* ctx) {


### PR DESCRIPTION
The previous patch is not complete, for example

1. There's no way to navigate backwards in preedit text field
2. Up and down are still working as if not in vertical mode
3. Does not support the 4th combination with both horizontal and vertical modes on.

My fix is more general, but the patch in `navigator.cc` may not be idea, you may want to change it.

A known issue is that in inline preediting vertical (whether horizontal on or off) mode, preedit text on screen **may** be horizontal and reads left-to-right, contradicting the up and down navigating direction. But this is a conceptual conflict, where in vertical mode, reading order is right-to-left, there is no good way to support both navigating candidates right-to-left, while navigating preedit field left-to-right.