### PR TITLE
Always show comment at peek

### DIFF
--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -447,7 +447,9 @@ an<Candidate> ScriptTranslation::Peek() {
   }
   if (candidate_->comment().empty()) {
     auto spelling = syllabifier_->GetOriginalSpelling(*candidate_);
-    if (!spelling.empty() && spelling != candidate_->preedit()) {
+    if (!spelling.empty() &&
+        (translator_->always_show_comments() ||
+          spelling != candidate_->preedit())) {
       candidate_->set_comment(/*quote_left + */spelling/* + quote_right*/);
     }
   }


### PR DESCRIPTION
### Related issue
translator/always_show_comments: true始终显示候选词注解，在地球拼音中失效！！ [#272](https://github.com/rime/librime/issues/272)

### Related PR
feat: always_show_comments option #220 