### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ matrix:
     sudo: required
     install: "./travis-install.sh"
     script: make test
+  - os: linux
+    arch: ppc64le
+    compiler: gcc
+    dist: focal
+    sudo: required
+    install: "./travis-install.sh"
+    script: make test
   - &osx_build
     os: osx
     compiler: clang


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.