### PR TITLE
Better Option Update Display

### DIFF
--- a/src/rime/context.cc
+++ b/src/rime/context.cc
@@ -247,9 +247,30 @@ void Context::set_input(const string& value) {
   update_notifier_(this);
 }
 
+void Context::set_option_state(const string& name, int order, const string& value) {
+  option_states_[name][order] = value;
+}
+
+string Context::get_option_state(const string& name, int order) {
+  if (option_states_.count(name) > 0) {
+    auto states = option_states_[name];
+    if (states.size() == 1) {
+      return states[1];
+    } else if (states.size() == 2) {
+      if ((order <= 1) && (order >= 0)) {
+        return states[order];
+      }
+    }
+  }
+  return "";
+}
+
 void Context::set_option(const string& name, bool value) {
   options_[name] = value;
-  option_update_notifier_(this, name);
+  const string& state = get_option_state(name, int(value));
+  if (state != "") {
+    option_update_notifier_(this, state);
+  }
 }
 
 bool Context::get_option(const string& name) const {

--- a/src/rime/context.cc
+++ b/src/rime/context.cc
@@ -255,7 +255,11 @@ string Context::get_option_state(const string& name, int order) {
   if (option_states_.count(name) > 0) {
     auto states = option_states_[name];
     if (states.size() == 1) {
-      return states[1];
+        if (order == 1) {
+            return states[0];
+        } else {
+            return "";
+        }
     } else if (states.size() == 2) {
       if ((order <= 1) && (order >= 0)) {
         return states[order];

--- a/src/rime/context.h
+++ b/src/rime/context.h
@@ -69,6 +69,8 @@ class Context {
   const CommitHistory& commit_history() const { return commit_history_; }
 
   void set_option(const string& name, bool value);
+  void set_option_state(const string& name, int order, const string& value);
+  string get_option_state(const string& name, int order);
   bool get_option(const string& name) const;
   void set_property(const string& name, const string& value);
   string get_property(const string& name) const;
@@ -98,6 +100,7 @@ class Context {
   Composition composition_;
   CommitHistory commit_history_;
   map<string, bool> options_;
+  map<string, map<int, string>> option_states_;
   map<string, string> properties_;
 
   Notifier commit_notifier_;

--- a/src/rime/engine.cc
+++ b/src/rime/engine.cc
@@ -395,14 +395,18 @@ void ConcreteEngine::InitializeOptions() {
         continue;
       int value = 0;
       reset_value->GetInt(&value);
+      auto states = As<ConfigList>(item->Get("states"));
       if (auto option_name = item->GetValue("name")) {
         // toggle
+        context_->set_option_state(option_name->str(), 0, states->GetValueAt(0)->str());
+        context_->set_option_state(option_name->str(), 1, states->GetValueAt(1)->str());
         context_->set_option(option_name->str(), (value != 0));
       }
       else if (auto options = As<ConfigList>(item->Get("options"))) {
         // radio
         for (size_t i = 0; i < options->size(); ++i) {
           if (auto option_name = options->GetValueAt(i)) {
+            context_->set_option_state(option_name->str(), 1, states->GetValueAt(i)->str());
             context_->set_option(option_name->str(),
                                  static_cast<int>(i) == value);
           }

--- a/src/rime/engine.cc
+++ b/src/rime/engine.cc
@@ -406,7 +406,7 @@ void ConcreteEngine::InitializeOptions() {
         // radio
         for (size_t i = 0; i < options->size(); ++i) {
           if (auto option_name = options->GetValueAt(i)) {
-            context_->set_option_state(option_name->str(), 1, states->GetValueAt(i)->str());
+            context_->set_option_state(option_name->str(), 0, states->GetValueAt(i)->str());
             context_->set_option(option_name->str(),
                                  static_cast<int>(i) == value);
           }


### PR DESCRIPTION
Option updates will use the `states` string as display string. Thus users who customize switches can see the proper switch message.
Also eliminates localization need.

Known issue: the message will start with a "!", since I couldn't find the source of it, currently I handle it in frontend.