### PR TITLE
Remove optional dependency library specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ Build dependencies
   - cmake>=2.8
   - libboost>=1.48
   - libcapnp>=0.7.0
-  - libglog (optional)
+  - libglog
   - libleveldb
   - libmarisa
   - libopencc>=1.0.2
   - libyaml-cpp>=0.5
-  - libgtest (optional)
+  - libgtest
 
 Runtime dependencies
 ---


### PR DESCRIPTION
I cannot compile properly without these libraries.

If I didn't install libgtest:
```
CMake Error at /usr/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:146 (message):
  Could NOT find GTest (missing: GTEST_LIBRARY GTEST_INCLUDE_DIR
  GTEST_MAIN_LIBRARY)
```

If I didn't install libglog:
```
CMake Error at cmake/FindGlog.cmake:22 (message):
  Could not find glog library.
```