### PR TITLE
Fix #462.

### DIFF
--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -8,6 +8,7 @@
 //
 #include <algorithm>
 #include <stack>
+#include <cmath>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/reversed.hpp>
 #include <rime/composition.h>

--- a/src/rime/gear/table_translator.cc
+++ b/src/rime/gear/table_translator.cc
@@ -6,6 +6,7 @@
 //
 #include <boost/algorithm/string.hpp>
 #include <boost/range/adaptor/reversed.hpp>
+#include <cmath>
 #include <utf8.h>
 #include <rime/candidate.h>
 #include <rime/common.h>


### PR DESCRIPTION
Previous boost library (1.75) may implicitly include cmath, but the
latest version (1.76) does not, so the calls to exp are undefined. This
commit include cmath in script_translator.cc and table_translator.cc to
fix the issue (#462).