### PR TITLE
Set custom code when code is empty but input contains custom_code

### DIFF
--- a/src/rime/gear/memory.cc
+++ b/src/rime/gear/memory.cc
@@ -29,6 +29,10 @@ void CommitEntry::AppendPhrase(const an<Phrase>& phrase) {
   text += phrase->text();
   code.insert(code.end(),
               phrase->code().begin(), phrase->code().end());
+  if (code.empty())
+    custom_code = phrase->entry().custom_code;
+  else
+    custom_code = "";
   if (auto sentence = As<Sentence>(phrase)) {
     for (const DictEntry& e : sentence->components()) {
       elements.push_back(&e);


### PR DESCRIPTION
This happens when candidates are built from plugins like librime-lua. Setting custom_code makes the candidate recorded in userdict. This is for https://github.com/hchunhui/librime-cloud/issues/1 .