### PR TITLE
docs: add info about build with bottled icu4c

### DIFF
--- a/README-mac.md
+++ b/README-mac.md
@@ -45,6 +45,8 @@ export BOOST_ROOT="$(pwd)/thirdparty/src/boost_1_75_0"
 
 ``` sh
 brew install boost
+# if you want build with icu4c, you should add icu4c path to the LIBRARY_PATH
+export LIBRARY_PATH=${LIBRARY_PATH}:/usr/local/opt/icu4c/lib
 ```
 
 This is a time-saving option if you are building and installing Rime only for your


### PR DESCRIPTION
Fix `make xcode/release-with-icu` error

```
ld: library not found for -licudata
clang: error: linker command failed with exit code 1 (use -v to see invocation)

** BUILD FAILED **


The following build commands failed:
        Ld /Users/alswl/dev/myproject/squirrel/librime/build/lib/Release/librime.1.7.3.dylib normal
```

same issue:

[按照 "INSTALL.md" 尝试编译 squirrel，执行到 make deps 这一步时提示以下内容 不会编程，所以看不懂，希望有大佬帮我看看怎么回事 · Issue #544 · rime/squirrel](https://github.com/rime/squirrel/issues/544)
[After upgrade to Boost 1.75, compilation fails with ld: library not found for -licudata · Issue #67427 · Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core/issues/67427)

Solution via https://github.com/Homebrew/homebrew-core/issues/67427#issuecomment-754187345:

```
export LIBRARY_PATH=${LIBRARY_PATH}:/usr/local/opt/icu4c/lib
```