### PR TITLE
Ensure std::exp can be found after including <cmath>

### DIFF
--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -32,6 +32,8 @@
 
 namespace rime {
 
+using std::exp;
+
 namespace {
 
 struct SyllabifyTask {

--- a/src/rime/gear/table_translator.cc
+++ b/src/rime/gear/table_translator.cc
@@ -26,6 +26,8 @@
 
 namespace rime {
 
+using std::exp;
+
 static const char* kUnitySymbol = " \xe2\x98\xaf ";
 
 // TableTranslation


### PR DESCRIPTION
As noted in #462, including `<cmath>` only guarantees that `std::exp` is
declared, so calling `exp(double)` unqualified is not portable. This adds
a using-declaration for `std::exp` so that unqualified calls are
guaranteed to work.