### PR TITLE
Allow simplifier to return empty comment

### DIFF
--- a/src/rime/candidate.h
+++ b/src/rime/candidate.h
@@ -88,16 +88,21 @@ class ShadowCandidate : public Candidate {
   ShadowCandidate(const an<Candidate>& item,
                   const string& type,
                   const string& text = string(),
-                  const string& comment = string())
+                  const string& comment = string(),
+                  const bool allow_erase_comment = false)
       : Candidate(type, item->start(), item->end(), item->quality()),
         text_(text), comment_(comment),
-        item_(item) {}
+        item_(item), allow_erase_comment_(allow_erase_comment) {}
 
   const string& text() const {
     return text_.empty() ? item_->text() : text_;
   }
   string comment() const {
-    return comment_.empty() ? item_->comment() : comment_;
+    if (allow_erase_comment_) {
+      return comment_;
+    } else {
+      return comment_.empty() ? item_->comment() : comment_;
+    }
   }
   string preedit() const {
     return item_->preedit();
@@ -109,6 +114,7 @@ class ShadowCandidate : public Candidate {
   string text_;
   string comment_;
   an<Candidate> item_;
+  bool allow_erase_comment_;
 };
 
 class UniquifiedCandidate : public Candidate {

--- a/src/rime/candidate.h
+++ b/src/rime/candidate.h
@@ -89,16 +89,16 @@ class ShadowCandidate : public Candidate {
                   const string& type,
                   const string& text = string(),
                   const string& comment = string(),
-                  const bool allow_erase_comment = false)
+                  const bool overwrite_comment = false)
       : Candidate(type, item->start(), item->end(), item->quality()),
         text_(text), comment_(comment),
-        item_(item), allow_erase_comment_(allow_erase_comment) {}
+        item_(item), overwrite_comment_(overwrite_comment) {}
 
   const string& text() const {
     return text_.empty() ? item_->text() : text_;
   }
   string comment() const {
-    if (allow_erase_comment_) {
+    if (overwrite_comment_) {
       return comment_;
     } else {
       return comment_.empty() ? item_->comment() : comment_;
@@ -114,7 +114,7 @@ class ShadowCandidate : public Candidate {
   string text_;
   string comment_;
   an<Candidate> item_;
-  bool allow_erase_comment_;
+  bool overwrite_comment_;
 };
 
 class UniquifiedCandidate : public Candidate {

--- a/src/rime/candidate.h
+++ b/src/rime/candidate.h
@@ -89,20 +89,16 @@ class ShadowCandidate : public Candidate {
                   const string& type,
                   const string& text = string(),
                   const string& comment = string(),
-                  const bool overwrite_comment = false)
+                  const bool inherit_comment = true)
       : Candidate(type, item->start(), item->end(), item->quality()),
         text_(text), comment_(comment),
-        item_(item), overwrite_comment_(overwrite_comment) {}
+        item_(item), inherit_comment_(inherit_comment) {}
 
   const string& text() const {
     return text_.empty() ? item_->text() : text_;
   }
   string comment() const {
-    if (overwrite_comment_) {
-      return comment_;
-    } else {
-      return comment_.empty() ? item_->comment() : comment_;
-    }
+    return inherit_comment_ && comment_.empty() ? item_->comment() : comment_;
   }
   string preedit() const {
     return item_->preedit();
@@ -114,7 +110,7 @@ class ShadowCandidate : public Candidate {
   string text_;
   string comment_;
   an<Candidate> item_;
-  bool overwrite_comment_;
+  bool inherit_comment_;
 };
 
 class UniquifiedCandidate : public Candidate {

--- a/src/rime/gear/simplifier.cc
+++ b/src/rime/gear/simplifier.cc
@@ -108,7 +108,7 @@ Simplifier::Simplifier(const Ticket& ticket) : Filter(ticket),
                     (tips == "char") ? kTipsChar : kTipsNone;
     }
     config->GetBool(name_space_ + "/show_in_comment", &show_in_comment_);
-    config->GetBool(name_space_ + "/allow_erase_comment", &allow_erase_comment_);
+    config->GetBool(name_space_ + "/overwrite_comment", &overwrite_comment_);
     comment_formatter_.Load(config->GetList(name_space_ + "/comment_format"));
     config->GetBool(name_space_ + "/random", &random_);
     config->GetString(name_space_ + "/option_name", &option_name_);
@@ -227,7 +227,7 @@ void Simplifier::PushBack(const an<Candidate>& original,
           "simplified",
           text,
           tips,
-          allow_erase_comment_));
+          overwrite_comment_));
 }
 
 bool Simplifier::Convert(const an<Candidate>& original,

--- a/src/rime/gear/simplifier.cc
+++ b/src/rime/gear/simplifier.cc
@@ -108,7 +108,7 @@ Simplifier::Simplifier(const Ticket& ticket) : Filter(ticket),
                     (tips == "char") ? kTipsChar : kTipsNone;
     }
     config->GetBool(name_space_ + "/show_in_comment", &show_in_comment_);
-    config->GetBool(name_space_ + "/overwrite_comment", &overwrite_comment_);
+    config->GetBool(name_space_ + "/inherit_comment", &inherit_comment_);
     comment_formatter_.Load(config->GetList(name_space_ + "/comment_format"));
     config->GetBool(name_space_ + "/random", &random_);
     config->GetString(name_space_ + "/option_name", &option_name_);
@@ -227,7 +227,7 @@ void Simplifier::PushBack(const an<Candidate>& original,
           "simplified",
           text,
           tips,
-          overwrite_comment_));
+          inherit_comment_));
 }
 
 bool Simplifier::Convert(const an<Candidate>& original,

--- a/src/rime/gear/simplifier.cc
+++ b/src/rime/gear/simplifier.cc
@@ -108,6 +108,7 @@ Simplifier::Simplifier(const Ticket& ticket) : Filter(ticket),
                     (tips == "char") ? kTipsChar : kTipsNone;
     }
     config->GetBool(name_space_ + "/show_in_comment", &show_in_comment_);
+    config->GetBool(name_space_ + "/allow_erase_comment", &allow_erase_comment_);
     comment_formatter_.Load(config->GetList(name_space_ + "/comment_format"));
     config->GetBool(name_space_ + "/random", &random_);
     config->GetString(name_space_ + "/option_name", &option_name_);
@@ -225,7 +226,8 @@ void Simplifier::PushBack(const an<Candidate>& original,
           original,
           "simplified",
           text,
-          tips));
+          tips,
+          allow_erase_comment_));
 }
 
 bool Simplifier::Convert(const an<Candidate>& original,

--- a/src/rime/gear/simplifier.h
+++ b/src/rime/gear/simplifier.h
@@ -46,7 +46,7 @@ class Simplifier : public Filter, TagMatching {
   string opencc_config_;
   set<string> excluded_types_;
   bool show_in_comment_ = false;
-  bool overwrite_comment_ = false;
+  bool inherit_comment_ = true;
   Projection comment_formatter_;
   bool random_ = false;
 };

--- a/src/rime/gear/simplifier.h
+++ b/src/rime/gear/simplifier.h
@@ -46,7 +46,7 @@ class Simplifier : public Filter, TagMatching {
   string opencc_config_;
   set<string> excluded_types_;
   bool show_in_comment_ = false;
-  bool allow_erase_comment_ = false;
+  bool overwrite_comment_ = false;
   Projection comment_formatter_;
   bool random_ = false;
 };

--- a/src/rime/gear/simplifier.h
+++ b/src/rime/gear/simplifier.h
@@ -46,6 +46,7 @@ class Simplifier : public Filter, TagMatching {
   string opencc_config_;
   set<string> excluded_types_;
   bool show_in_comment_ = false;
+  bool allow_erase_comment_ = false;
   Projection comment_formatter_;
   bool random_ = false;
 };


### PR DESCRIPTION
by adding "allow_erase_comment" argument

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Allow simplifier to return empty comment. There are situations that I want simplifier to erase comment and return empty comment. For example in emoji conversion, I don't want converted emoji to have readings from reverse_look_up filter.

#### Unit test
- [ ] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
