### PR TITLE
feat(api): get_state_label returns the state label for UI display

### DIFF
--- a/src/rime_api.h
+++ b/src/rime_api.h
@@ -550,6 +550,8 @@ typedef struct rime_api_t {
   void (*commit_proto)(RimeSessionId session_id, RIME_PROTO_BUILDER* commit_builder);
   void (*context_proto)(RimeSessionId session_id, RIME_PROTO_BUILDER* context_builder);
   void (*status_proto)(RimeSessionId session_id, RIME_PROTO_BUILDER* status_builder);
+
+  const char* (*get_state_label)(RimeSessionId session_id, const char *option_name, Bool state);
 } RimeApi;
 
 //! API entry

--- a/tools/rime_api_console.cc
+++ b/tools/rime_api_console.cc
@@ -167,6 +167,17 @@ void on_message(void* context_object,
                 const char* message_type,
                 const char* message_value) {
   printf("message: [%lu] [%s] %s\n", session_id, message_type, message_value);
+  RimeApi* rime = rime_get_api();
+  if (RIME_API_AVAILABLE(rime, get_state_label) &&
+      !strcmp(message_type, "option")) {
+    Bool state = message_value[0] != '!';
+    const char* option_name = message_value + !state;
+    const char* state_label =
+        rime->get_state_label(session_id, option_name, state);
+    if (state_label) {
+      printf("updated option: %s = %d // %s\n", option_name, state, state_label);
+    }
+  }
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
enable the frontend to display a message when an arbitrary option defined in the
schema is updated.

Closes #447

the option name eg. ascii_mode is passed to the notification handler function,
there, get_state_label gives IME frontend the access to the human readable label
for the current state of the option defined in *.schema:/switches/@*/states.

when selection is changed in a radio group, more than one option in the group is
updated so it only returns a non-empty label while querying the selected option.

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
