### PR TITLE
用快捷键切换单选状态组 (work in progress)

### DIFF
--- a/src/rime/engine.cc
+++ b/src/rime/engine.cc
@@ -387,17 +387,17 @@ void ConcreteEngine::InitializeOptions() {
   // reset custom switches
   Config* config = schema_->config();
   Switches switches(config);
-  switches.ForEachOption([this](Switches::SwitchOption option) {
-    if (option.reset_value < 0)  // unspecified
-      return;
-    if (option.type == Switches::kToggleOption) {
-      context_->set_option(option.option_name, (option.reset_value != 0));
+  switches.FindOption([this](Switches::SwitchOption option) {
+    if (option.reset_value >= 0) {
+      if (option.type == Switches::kToggleOption) {
+        context_->set_option(option.option_name, (option.reset_value != 0));
+      } else if (option.type == Switches::kRadioGroup) {
+        context_->set_option(
+            option.option_name,
+            static_cast<int>(option.option_index) == option.reset_value);
+      }
     }
-    else if (option.type == Switches::kRadioGroup) {
-      context_->set_option(
-          option.option_name,
-          static_cast<int>(option.option_index) == option.reset_value);
-    }
+    return Switches::kContinue;
   });
 }
 

--- a/src/rime/gear/chord_composer.cc
+++ b/src/rime/gear/chord_composer.cc
@@ -85,9 +85,9 @@ ProcessResult ChordComposer::ProcessChordingKey(const KeyEvent& key_event) {
   if (key_event.ctrl() || key_event.alt()) {
     raw_sequence_.clear();
   }
-  if (key_event.ctrl() && !use_control_ ||
-      key_event.alt() && !use_alt_ ||
-      key_event.shift() && !use_shift_) {
+  if ((key_event.ctrl() && !use_control_) ||
+      (key_event.alt() && !use_alt_) ||
+      (key_event.shift() && !use_shift_)) {
     ClearChord();
     return kNoop;
   }

--- a/src/rime/switches.cc
+++ b/src/rime/switches.cc
@@ -1,0 +1,91 @@
+#include <rime/config.h>
+#include <rime/switches.h>
+
+namespace rime {
+
+void Switches::ForEachOption(function<void (SwitchOption option)> callback) {
+  auto switches = (*config_)["switches"];
+  if (!switches.IsList())
+    return;
+  for (size_t i = 0; i < switches.size(); ++i) {
+    auto item = switches[i];
+    if (!item.IsMap())
+      continue;
+    auto reset = item["reset"];
+    int reset_value = reset.IsValue() ? reset.ToInt() : -1;
+    auto name = item["name"];
+    if (name.IsValue()) {
+      callback(
+          SwitchOption{
+            As<ConfigMap>(*item),
+            kToggleOption,
+            name.ToString(),
+            reset_value,
+            i
+          });
+      continue;
+    }
+    auto options = item["options"];
+    if (options.IsList()) {
+      for (size_t j = 0; j < options.size(); ++j) {
+        callback(
+            SwitchOption{
+              As<ConfigMap>(*item),
+              kRadioGroup,
+              options[j].ToString(),
+              reset_value,
+              i,
+              j
+            });
+      }
+    }
+  }
+}
+
+Switches::SwitchOption Switches::OptionByName(const string& option_name) {
+  ForEachOption([&option_name](SwitchOption option) {
+    if (option.option_name == option_name)
+      return option;
+  });
+  return {};
+}
+
+an<ConfigMap> Switches::ByIndex(size_t switch_index) {
+  auto switches = (*config_)["switches"];
+  if (!switches.IsList())
+    return nullptr;
+  if (switches.size() <= switch_index)
+    return nullptr;
+  auto item = switches[switch_index];
+  return As<ConfigMap>(*item);
+}
+
+an<ConfigValue> Switches::GetStateLabel(an<ConfigMap> the_switch,
+                                        size_t state_index) {
+  if (!the_switch)
+    return nullptr;
+  auto states = As<ConfigList>(the_switch->Get("states"));
+  if (!states)
+    return nullptr;
+  return states->GetValueAt(state_index);
+}
+
+an<ConfigValue> Switches::GetStateLabel(const string& option_name, int state) {
+  auto the_option = OptionByName(option_name);
+  if (!the_option.found())
+    return nullptr;
+  if (the_option.type == kToggleOption) {
+    size_t state_index = static_cast<size_t>(state);
+    return GetStateLabel(the_option.the_switch, state_index);
+  }
+  if (the_option.type == kRadioGroup) {
+    // if the query is a deselected option among the radio group, do not
+    // display its state label; only show the selected option.
+    return state
+        ? GetStateLabel(the_option.the_switch, the_option.option_index)
+        : nullptr;
+  }
+  return nullptr;
+}
+
+}  // namespace rime

--- a/src/rime/switches.cc
+++ b/src/rime/switches.cc
@@ -3,51 +3,54 @@
 
 namespace rime {
 
-void Switches::ForEachOption(function<void (SwitchOption option)> callback) {
+Switches::SwitchOption Switches::FindOption(
+    function<FindResult (SwitchOption option)> callback) {
   auto switches = (*config_)["switches"];
   if (!switches.IsList())
-    return;
+    return {};
   for (size_t i = 0; i < switches.size(); ++i) {
     auto item = switches[i];
     if (!item.IsMap())
       continue;
+    auto the_switch = As<ConfigMap>(*item);
     auto reset = item["reset"];
     int reset_value = reset.IsValue() ? reset.ToInt() : -1;
     auto name = item["name"];
     if (name.IsValue()) {
-      callback(
-          SwitchOption{
-            As<ConfigMap>(*item),
-            kToggleOption,
-            name.ToString(),
-            reset_value,
-            i
-          });
+      SwitchOption option{
+        the_switch,
+        kToggleOption,
+        name.ToString(),
+        reset_value,
+        i,
+      };
+      if (callback(option) == kFound)
+        return option;
       continue;
     }
     auto options = item["options"];
     if (options.IsList()) {
       for (size_t j = 0; j < options.size(); ++j) {
-        callback(
-            SwitchOption{
-              As<ConfigMap>(*item),
-              kRadioGroup,
-              options[j].ToString(),
-              reset_value,
-              i,
-              j
-            });
+        SwitchOption option{
+          the_switch,
+          kRadioGroup,
+          options[j].ToString(),
+          reset_value,
+          i,
+          j,
+        };
+        if (callback(option) == kFound)
+          return option;
       }
     }
   }
+  return {};
 }
 
 Switches::SwitchOption Switches::OptionByName(const string& option_name) {
-  ForEachOption([&option_name](SwitchOption option) {
-    if (option.option_name == option_name)
-      return option;
+  return FindOption([&option_name](SwitchOption option) {
+    return option.option_name == option_name ? kFound : kContinue;
   });
-  return {};
 }
 
 an<ConfigMap> Switches::ByIndex(size_t switch_index) {
@@ -58,6 +61,60 @@ an<ConfigMap> Switches::ByIndex(size_t switch_index) {
     return nullptr;
   auto item = switches[switch_index];
   return As<ConfigMap>(*item);
+}
+
+Switches::SwitchOption Switches::Cycle(const SwitchOption& current) {
+  if (auto options = As<ConfigList>(current.the_switch->Get("options"))) {
+    size_t next_option_index = (current.option_index + 1) % options->size();
+    if (next_option_index != current.option_index) {
+      return {
+        current.the_switch,
+        current.type,
+        options->GetValueAt(next_option_index)->str(),
+        current.reset_value,
+        current.switch_index,
+        next_option_index,
+      };
+    }
+  }
+  return {};
+}
+
+Switches::SwitchOption Switches::Reset(const SwitchOption& current) {
+  size_t default_state = (current.reset_value >= 0) ? current.reset_value : 0;
+  if (auto options = As<ConfigList>(current.the_switch->Get("options"))) {
+    if (default_state >= options->size() ||
+        default_state == current.option_index)
+      return {};
+    return {
+      current.the_switch,
+      current.type,
+      options->GetValueAt(default_state)->str(),
+      current.reset_value,
+      current.switch_index,
+      default_state,
+    };
+  }
+}
+
+Switches::SwitchOption Switches::FindRadioGroupOption(
+    an<ConfigMap> the_switch,
+    function<FindResult (SwitchOption option)> callback) {
+  if (auto options = As<ConfigList>(the_switch->Get("options"))) {
+    for (size_t j = 0; j < options->size(); ++j) {
+      SwitchOption option{
+        the_switch,
+        kRadioGroup,
+        options->GetValueAt(j)->str(),
+        0,  // unknown
+        0,  // unknown
+        j,
+      };
+      if (callback(option) == kFound)
+        return option;
+    }
+  }
+  return {};
 }
 
 an<ConfigValue> Switches::GetStateLabel(an<ConfigMap> the_switch,

--- a/src/rime/switches.h
+++ b/src/rime/switches.h
@@ -34,14 +34,28 @@ public:
     }
   };
 
-  void ForEachOption(function<void (SwitchOption option)> callback);
+  enum FindResult {
+    kContinue,
+    kFound,
+  };
+
+  SwitchOption FindOption(function<FindResult (SwitchOption option)> callback);
 
   SwitchOption OptionByName(const string& option_name);
 
   an<ConfigMap> ByIndex(size_t switch_index);
 
+  static SwitchOption Cycle(const SwitchOption& option);
+
+  static SwitchOption Reset(const SwitchOption& option);
+
+  static SwitchOption FindRadioGroupOption(
+      an<ConfigMap> the_switch,
+      function<FindResult (SwitchOption option)> callback);
+
   static an<ConfigValue> GetStateLabel(
       an<ConfigMap> the_switch, size_t state_index);
+
   an<ConfigValue> GetStateLabel(const string& option_name, int state);
 
  private:

--- a/src/rime/switches.h
+++ b/src/rime/switches.h
@@ -1,0 +1,53 @@
+#ifndef RIME_SWITCHES_H_
+#define RIME_SWITCHES_H_
+
+#include <rime/common.h>
+
+namespace rime {
+
+class Config;
+class ConfigMap;
+class ConfigValue;
+
+class Switches {
+public:
+  explicit Switches(Config* config) : config_(config) {}
+
+  enum SwitchType {
+    kToggleOption,
+    kRadioGroup,
+  };
+
+  struct SwitchOption {
+    an<ConfigMap> the_switch = nullptr;
+    SwitchType type = kToggleOption;
+    string option_name;
+    // reset state value on initialize. -1 if unspecified.
+    int reset_value = -1;
+    // index of the switch configuration.
+    size_t switch_index = 0;
+    // the index of the option in the radio group.
+    size_t option_index = 0;
+
+    bool found() const {
+      return bool(the_switch);
+    }
+  };
+
+  void ForEachOption(function<void (SwitchOption option)> callback);
+
+  SwitchOption OptionByName(const string& option_name);
+
+  an<ConfigMap> ByIndex(size_t switch_index);
+
+  static an<ConfigValue> GetStateLabel(
+      an<ConfigMap> the_switch, size_t state_index);
+  an<ConfigValue> GetStateLabel(const string& option_name, int state);
+
+ private:
+  Config* config_;
+};
+
+}  // namespace rime
+
+#endif // RIME_SWITCHES_H_

--- a/src/rime_api.cc
+++ b/src/rime_api.cc
@@ -20,6 +20,7 @@
 #include <rime/service.h>
 #include <rime/setup.h>
 #include <rime/signature.h>
+#include <rime/switches.h>
 #include <rime_api.h>
 
 using namespace rime;
@@ -989,40 +990,9 @@ const char* RimeGetStateLabel(RimeSessionId session_id,
   Config* config = session->schema()->config();
   if (!config)
     return nullptr;
-  auto switches = (*config)["switches"];
-  if (!switches.IsList())
-    return nullptr;
-  string query = option_name;
-  for (size_t i = 0; i < switches.size(); ++i) {
-    auto item = switches[i];
-    if (!item.IsMap())
-      continue;
-    auto states = item["states"];
-    if (!states.IsList())
-      continue;
-    auto name = item["name"];
-    if (name.IsValue() && name.ToString() == query) {
-      size_t j = static_cast<size_t>(state);
-      return states.size() > j
-          ? As<ConfigValue>(*states[j])->str().c_str()
-          : nullptr;
-    }
-    auto options = item["options"];
-    if (options.IsList()) {
-      // if the query is a deselected option among the radio group, do not
-      // display its state label; only show the selected option.
-      if (!state)
-        return nullptr;
-      for (size_t j = 0; j < options.size(); ++j) {
-        if (options[j].IsValue() && options[j].ToString() == query) {
-          return states.size() > j
-              ? As<ConfigValue>(*states[j])->str().c_str()
-              : nullptr;
-        }
-      }
-    }
-  }
-  return nullptr;
+  Switches switches(config);
+  an<ConfigValue> label = switches.GetStateLabel(option_name, state);
+  return label ? label->str().c_str() : nullptr;
 }
 
 RIME_API RimeApi* rime_get_api() {

--- a/test/corrector_test.cc
+++ b/test/corrector_test.cc
@@ -62,8 +62,7 @@ class RimeCorrectorTest : public ::testing::Test {
     corrector_.reset(new rime::NearSearchCorrector);
   }
 
-  virtual void TearDown() {
-  }
+  void TearDown() override {}
 
  protected:
   rime::map<rime::string, rime::SyllableId> syllable_id_;


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #554

#### Feature
Describe feature of pull request

*DONE:*

状态选项里的[单选状态组](https://github.com/rime/librime/blob/8f9e9c7cbd0ecf8761540d1db9d2c8ab9473f8dc/data/minimal/luna_pinyin.schema.yaml#L28)现在不支持通过快捷键切换，用不上这么好的文字提示，我准备把快捷键单选功能做好。

*TODO:*

另外，我打算把 `Control+Shift+2` 等快捷键
https://github.com/rime/rime-prelude/blob/master/key_bindings.yaml#L45
```yaml
    - { when: always, accept: Control+Shift+2, toggle: ascii_mode }
    - { when: always, accept: Control+Shift+3, toggle: full_shape }
    - { when: always, accept: Control+Shift+4, toggle: simplification }
    - { when: always, accept: Control+Shift+5, toggle: extended_charset }
```
重新定义为
```yaml
    - { when: always, accept: Control+Shift+2, toggle: '@0' }
    - { when: always, accept: Control+Shift+3, toggle: '@1' }
    - { when: always, accept: Control+Shift+4, toggle: '@2' }
    - { when: always, accept: Control+Shift+5, toggle: '@3' }
```
指改变方案中 `switches/@0` 等处定义的状态。这样的配置就通用了。兼容方案自定义的状态。

`@x` 如果不是开关而是单项选择状态组，最好不必改动词 `toggle`，让他轮换到下一个状态。免得还得专门改快捷键配置。

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
