### PR TITLE
added Create() method without ticket in UserDictionar and ReverseLook…

### DIFF
--- a/src/rime/dict/reverse_lookup_dictionary.cc
+++ b/src/rime/dict/reverse_lookup_dictionary.cc
@@ -73,6 +73,9 @@ bool ReverseDb::Load() {
 
 bool ReverseDb::Lookup(const string& text, string* result) {
   if (!key_trie_ || !value_trie_ || !metadata_->index.size) {
+    // trace
+
+    std::cout <<( (key_trie_) ? "key_trie_" : "false") << "---" << ((value_trie_) ? "value_trie_" : "fales")  << "----" << ((metadata_) ? "metadata_" : "false") << "\n" ;
     return false;
   }
   StringId key_id = key_trie_->Lookup(text);
@@ -250,6 +253,17 @@ ReverseLookupDictionaryComponent::ReverseLookupDictionaryComponent()
 }
 
 ReverseLookupDictionary*
+ReverseLookupDictionaryComponent::Create(const string& dict_name) {
+  auto db = db_pool_[dict_name].lock();
+  if (!db) {
+    auto file_path = resource_resolver_->ResolvePath(dict_name).string();
+    db = New<ReverseDb>(file_path);
+    db_pool_[dict_name] = db;
+  }
+  return new ReverseLookupDictionary(db);
+};
+
+ReverseLookupDictionary*
 ReverseLookupDictionaryComponent::Create(const Ticket& ticket) {
   if (!ticket.schema) return NULL;
   Config* config = ticket.schema->config();
@@ -259,13 +273,7 @@ ReverseLookupDictionaryComponent::Create(const Ticket& ticket) {
     // missing!
     return NULL;
   }
-  auto db = db_pool_[dict_name].lock();
-  if (!db) {
-    auto file_path = resource_resolver_->ResolvePath(dict_name).string();
-    db = New<ReverseDb>(file_path);
-    db_pool_[dict_name] = db;
-  }
-  return new ReverseLookupDictionary(db);
+  return Create(dict_name);
 }
 
 }  // namespace rime

--- a/src/rime/dict/reverse_lookup_dictionary.cc
+++ b/src/rime/dict/reverse_lookup_dictionary.cc
@@ -73,9 +73,6 @@ bool ReverseDb::Load() {
 
 bool ReverseDb::Lookup(const string& text, string* result) {
   if (!key_trie_ || !value_trie_ || !metadata_->index.size) {
-    // trace
-
-    std::cout <<( (key_trie_) ? "key_trie_" : "false") << "---" << ((value_trie_) ? "value_trie_" : "fales")  << "----" << ((metadata_) ? "metadata_" : "false") << "\n" ;
     return false;
   }
   StringId key_id = key_trie_->Lookup(text);

--- a/src/rime/dict/reverse_lookup_dictionary.h
+++ b/src/rime/dict/reverse_lookup_dictionary.h
@@ -79,6 +79,7 @@ class ReverseLookupDictionaryComponent
  public:
   ReverseLookupDictionaryComponent();
   ReverseLookupDictionary* Create(const Ticket& ticket);
+  ReverseLookupDictionary* Create(const string& dict_name);
  private:
   map<string, weak<ReverseDb>> db_pool_;
   the<ResourceResolver> resource_resolver_;

--- a/src/rime/dict/user_dictionary.cc
+++ b/src/rime/dict/user_dictionary.cc
@@ -496,6 +496,7 @@ an<DictEntry> UserDictionary::CreateDictEntry(const string& key,
 
 UserDictionaryComponent::UserDictionaryComponent() {
 }
+
 UserDictionary* UserDictionaryComponent::Create(const string& dict_name, const string& db_class) {
   auto db = db_pool_[dict_name].lock();
   if (!db) {
@@ -509,6 +510,7 @@ UserDictionary* UserDictionaryComponent::Create(const string& dict_name, const s
   }
   return new UserDictionary(dict_name, db);
 }
+
 UserDictionary* UserDictionaryComponent::Create(const Ticket& ticket) {
   if (!ticket.schema)
     return NULL;

--- a/src/rime/dict/user_dictionary.cc
+++ b/src/rime/dict/user_dictionary.cc
@@ -496,7 +496,19 @@ an<DictEntry> UserDictionary::CreateDictEntry(const string& key,
 
 UserDictionaryComponent::UserDictionaryComponent() {
 }
-
+UserDictionary* UserDictionaryComponent::Create(const string& dict_name, const string& db_class) {
+  auto db = db_pool_[dict_name].lock();
+  if (!db) {
+    auto component = Db::Require(db_class);
+    if (!component) {
+      LOG(ERROR) << "undefined db class '" << db_class << "'.";
+      return NULL;
+    }
+    db.reset(component->Create(dict_name));
+    db_pool_[dict_name] = db;
+  }
+  return new UserDictionary(dict_name, db);
+}
 UserDictionary* UserDictionaryComponent::Create(const Ticket& ticket) {
   if (!ticket.schema)
     return NULL;
@@ -523,17 +535,7 @@ UserDictionary* UserDictionaryComponent::Create(const Ticket& ticket) {
     // user specified db class
   }
   // obtain userdb object
-  auto db = db_pool_[dict_name].lock();
-  if (!db) {
-    auto component = Db::Require(db_class);
-    if (!component) {
-      LOG(ERROR) << "undefined db class '" << db_class << "'.";
-      return NULL;
-    }
-    db.reset(component->Create(dict_name));
-    db_pool_[dict_name] = db;
-  }
-  return new UserDictionary(dict_name, db);
+  return Create(dict_name, db_class);
 }
 
 }  // namespace rime

--- a/src/rime/dict/user_dictionary.h
+++ b/src/rime/dict/user_dictionary.h
@@ -108,6 +108,7 @@ class UserDictionaryComponent : public UserDictionary::Component {
  public:
   UserDictionaryComponent();
   UserDictionary* Create(const Ticket& ticket);
+  UserDictionary* Create(const string& dict_name, const string& db_class);
  private:
   map<string, weak<Db>> db_pool_;
 };


### PR DESCRIPTION
…upDictionary

Signed-off-by: Shewer Lu <shewer@gmail.com>

## Pull request
added
 ReverseLookupDictionary::Create(const string dict_name)
 UserDictionaryComponent::Create(const string& dict_name, const string& db_class) 
#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
增加 以 dict_name , 建立 ReverseLookupDictionary  UserDictionary
librime-lua Reverdb  是直接調用 ReverseDb 會造成 重覆載入
改成 ReverseLookupDictionary 可以減少載入時間及內存
UserDictionary 如果 使用Leveldb 可避免無法開啓的問題

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
