### PR TITLE
fix: fix missing control paths issue

### DIFF
--- a/src/rime/switches.cc
+++ b/src/rime/switches.cc
@@ -114,6 +114,7 @@ Switches::SwitchOption Switches::Reset(const SwitchOption& current) {
       default_state,
     };
   }
+  return {};
 }
 
 Switches::SwitchOption Switches::FindRadioGroupOption(


### PR DESCRIPTION
Fix regression issue in commit: 5e8aca2756eed71b65ec821c1bf18d10d10fc25b

```
trime/app/src/main/jni/librime/src/rime/switches.cc:117:1: error: non-void function does not return a value in all control paths [-Werror,-Wreturn-type]
  }
  ^
  1 error generated.
```

We can add more compiler option in CI to avoid issue like this.

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
