### PR TITLE
Support native build on win arm64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/c_flag_over
 set(CMAKE_USER_MAKE_RULES_OVERRIDE_CXX ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cxx_flag_overrides.cmake)
 
 project(rime)
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 set(CMAKE_CXX_STANDARD 14)
 
 set(rime_version 1.7.3)

--- a/build.bat
+++ b/build.bat
@@ -35,6 +35,7 @@ set build_dir_suffix=
 set build_config=Release
 set build_boost=0
 set build_boost_x64=0
+set build_boost_arm64=0
 set boost_build_variant=release
 set build_deps=0
 set build_librime=0
@@ -49,6 +50,10 @@ if "%1" == "boost" set build_boost=1
 if "%1" == "boost_x64" (
   set build_boost=1
   set build_boost_x64=1
+)
+if "%1" == "boost_arm64" (
+  set build_boost=1
+  set build_boost_arm64=1
 )
 if "%1" == "deps" set build_deps=1
 rem `thirdparty` is deprecated in favor of `deps`
@@ -136,12 +141,21 @@ set bjam_options_x64=%bjam_options%^
  address-model=64^
  --stagedir=stage_x64
 
+set bjam_options_arm64=%bjam_options%^
+ define=BOOST_USE_WINAPI_VERSION=0x0A00^
+ architecture=arm^
+ address-model=64
+
 if %build_boost% == 1 (
   pushd %BOOST_ROOT%
   if not exist b2.exe call .\bootstrap.bat
   if errorlevel 1 goto error
 
-  b2 %bjam_options_x86% stage %boost_compiled_libs%
+  if %build_boost_arm64% == 1 (
+    b2 %bjam_options_arm64% stage %boost_compiled_libs%
+  ) else (
+    b2 %bjam_options_x86% stage %boost_compiled_libs%
+  )
   if errorlevel 1 goto error
 
   if %build_boost_x64% == 1 (


### PR DESCRIPTION
## Pull request

#### Issue tracker

#### Feature
I built librime on Windows Dev Kit 2023.
My `env.bat`:
```bat
rem Customize your build environment and save the modified copy to env.bat

set RIME_ROOT=%CD%
set BOOST_ROOT=[local git repo of boost]

rem REQUIRED: path to Boost source directory
if not defined BOOST_ROOT set BOOST_ROOT=%RIME_ROOT%\deps\boost_1_76_0

rem OPTIONAL: architecture, Visual Studio version and platform toolset
set ARCH=ARM64
set BJAM_TOOLSET=msvc-14.3
set CMAKE_GENERATOR="Visual Studio 17 2022"
set PLATFORM_TOOLSET=v143

rem OPTIONAL: path to additional build tools
rem set DEVTOOLS_PATH=%ProgramFiles%\Git\cmd;%ProgramFiles%\CMake\bin;C:\Python27;
```
Steps in a ARM64 Native Tools Command Prompt for VS 2022 Preview:
```batch
build.bat boost_arm64
build.bat deps
build.bat librime
```

#### Unit test
- [ ] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
Updated OpenCC to include https://github.com/BYVoid/OpenCC/pull/731
Updated minimal cmake version to avoid `Policy CMP0074 is not set: find_package uses <PackageName>_ROOT variables.` which is also seen on [current master's CI](https://github.com/rime/librime/actions/runs/3450065080/jobs/5758419495#step:11:31)