### PR TITLE
added option feature for reverse_lookup_filter

### DIFF
--- a/src/rime/gear/reverse_lookup_filter.cc
+++ b/src/rime/gear/reverse_lookup_filter.cc
@@ -41,14 +41,15 @@ ReverseLookupFilter::ReverseLookupFilter(const Ticket& ticket)
     name_space_ = "reverse_lookup";
   }
   if (Config* config = engine_->schema()->config()) {
-   config->GetBool(name_space_ + "/enable_option", &enable_option_);
-   config->GetString(name_space_ + "/option_name", &option_name_);
-   if (option_name_.empty())
-     option_name_ = name_space_;
+    config->GetBool(name_space_ + "/enable_option", &enable_option_);
+    if (enable_option_) {
+      option_name_ = name_space_;
+      config->GetString(name_space_ + "/option_name", &option_name_);
+    }
   }
 }
 
-bool ReverseLookupFilter::get_option(){
+bool ReverseLookupFilter::get_option() {
   return enable_option_ && engine_->context()->get_option(option_name_);
 }
 

--- a/src/rime/gear/reverse_lookup_filter.cc
+++ b/src/rime/gear/reverse_lookup_filter.cc
@@ -7,6 +7,7 @@
 #include <rime/candidate.h>
 #include <rime/engine.h>
 #include <rime/schema.h>
+#include <rime/context.h>
 #include <rime/translation.h>
 #include <rime/dict/reverse_lookup_dictionary.h>
 #include <rime/gear/reverse_lookup_filter.h>
@@ -39,6 +40,16 @@ ReverseLookupFilter::ReverseLookupFilter(const Ticket& ticket)
   if (ticket.name_space == "filter") {
     name_space_ = "reverse_lookup";
   }
+  if (Config* config = engine_->schema()->config()) {
+   config->GetBool(name_space_ + "/enable_option", &enable_option_);
+   config->GetString(name_space_ + "/option_name", &option_name_);
+   if (option_name_.empty())
+     option_name_ = name_space_;
+  }
+}
+
+bool ReverseLookupFilter::get_option(){
+  return enable_option_ && engine_->context()->get_option(option_name_);
 }
 
 void ReverseLookupFilter::Initialize() {

--- a/src/rime/gear/reverse_lookup_filter.h
+++ b/src/rime/gear/reverse_lookup_filter.h
@@ -41,7 +41,7 @@ class ReverseLookupFilter : public Filter, TagMatching {
   bool overwrite_comment_ = false;
   Projection comment_formatter_;
   bool enable_option_ = false;
-  string option_name_ = "";
+  string option_name_;
 };
 
 }  // namespace rime

--- a/src/rime/gear/reverse_lookup_filter.h
+++ b/src/rime/gear/reverse_lookup_filter.h
@@ -24,10 +24,13 @@ class ReverseLookupFilter : public Filter, TagMatching {
                                         CandidateList* candidates);
 
   virtual bool AppliesToSegment(Segment* segment) {
-    return TagsMatch(segment);
+    return TagsMatch(segment)
+      && ( !enable_option_ or get_option() );
   }
 
   void Process(const an<Candidate>& cand);
+  bool get_option();
+
 
  protected:
   void Initialize();
@@ -37,6 +40,8 @@ class ReverseLookupFilter : public Filter, TagMatching {
   // settings
   bool overwrite_comment_ = false;
   Projection comment_formatter_;
+  bool enable_option_ = false;
+  string option_name_ = "";
 };
 
 }  // namespace rime


### PR DESCRIPTION
增加Signed-off-by: Shewer Lu <shewer@gmail.com>

## Pull request

#### Feature
Describe feature of pull request
增加 reverse_lookup_filter 開關(option)機制
1. enable_option 為此機制開關 ，OFF: TagsMatch(segment)  ON:  TegsMatch(segment) && get_option()
2. option_name: 以 option_name 取得 Bool 狀態   
#### Unit test
- [ ] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
3. GitHub Action CI pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Additional Info
<schema>.schema.yaml
1. <name_space>/enable_option: bool  # default false
2. <name_space>/option_name: string # enable : default name_space



