### PR TITLE
fixed Config::GetListSize(path) when object not a ConfigList then ret…

### DIFF
--- a/src/rime/config/config_component.cc
+++ b/src/rime/config/config_component.cc
@@ -83,10 +83,10 @@ bool Config::GetString(const string& path, string* value) {
   return p && p->GetString(value);
 }
 
-size_t Config::GetListSize(const string& path) {
+int Config::GetListSize(const string& path) {
   DLOG(INFO) << "read: " << path;
   auto list = GetList(path);
-  return list ? list->size() : 0;
+  return list ? list->size() : -1;
 }
 
 an<ConfigItem> Config::GetItem(const string& path) {

--- a/src/rime/config/config_component.h
+++ b/src/rime/config/config_component.h
@@ -42,7 +42,7 @@ class Config : public Class<Config, const string&>, public ConfigItemRef {
   RIME_API bool GetInt(const string& path, int* value);
   RIME_API bool GetDouble(const string& path, double* value);
   RIME_API bool GetString(const string& path, string* value);
-  RIME_API size_t GetListSize(const string& path);
+  RIME_API int GetListSize(const string& path);
 
   an<ConfigItem> GetItem(const string& path);
   an<ConfigValue> GetValue(const string& path);


### PR DESCRIPTION

Signed-off-by: Shewer Lu <shewer@gmail.com>

## Pull request
fixed Config::GetListSize(path) when object not a ConfigList then return -1
#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Config::GetListSize 當 path 不是 ConfigList 時 return -1

#### Unit test
- [ ] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
