### PR TITLE
fix(charset_filter): Update `is_extended_cjk` to compatible with Unicode 15.

### DIFF
--- a/src/rime/gear/charset_filter.cc
+++ b/src/rime/gear/charset_filter.cc
@@ -25,6 +25,9 @@ bool is_extended_cjk(uint32_t ch)
       (ch >= 0x2B820 && ch <= 0x2CEAF) ||  // CJK Unified Ideographs Extension E
       (ch >= 0x2CEB0 && ch <= 0x2EBEF) ||  // CJK Unified Ideographs Extension F
       (ch >= 0x30000 && ch <= 0x3134F) ||  // CJK Unified Ideographs Extension G
+      (ch >= 0x31350 && ch <= 0x323AF) ||  // CJK Unified Ideographs Extension H
+      (ch >= 0x3300 && ch <= 0x33FF) ||    // CJK Compatibility
+      (ch >= 0xFE30 && ch <= 0xFE4F) ||    // CJK Compatibility Forms
       (ch >= 0xF900 && ch <= 0xFAFF) ||    // CJK Compatibility Ideographs
       (ch >= 0x2F800 && ch <= 0x2FA1F))    // CJK Compatibility Ideographs Supplement
     return true;


### PR DESCRIPTION
See also: 
[CJK Unified Ideographs Extension H](https://en.wikipedia.org/wiki/CJK_Unified_Ideographs?section=39#CJK_Unified_Ideographs_Extension_H)
[Other CJK ideographs in Unicode, not Unified](https://en.wikipedia.org/wiki/CJK_Unified_Ideographs?section=39#Other_CJK_ideographs_in_Unicode,_not_Unified)
