### PR TITLE
replace call to rime_get_api

### DIFF
--- a/src/rime_api.h
+++ b/src/rime_api.h
@@ -597,7 +597,7 @@ RIME_MODULE_INITIALIZER(rime_register_module_##name) { \
     module.initialize = rime_##name##_initialize; \
     module.finalize = rime_##name##_finalize; \
   } \
-  rime_get_api()->register_module(&module); \
+  RimeRegisterModule(&module); \
 }
 
 /*!
@@ -615,7 +615,7 @@ RIME_MODULE_INITIALIZER(rime_register_module_##name) { \
     module.finalize = rime_##name##_finalize; \
     rime_customize_module_##name(&module); \
   } \
-  rime_get_api()->register_module(&module); \
+  RimeRegisterModule(&module); \
 } \
 static void rime_customize_module_##name(RimeModule* module)
 


### PR DESCRIPTION
## Pull request

#### Issue tracker

#### Feature
Describe feature of pull request

Upstream a patch I use at https://github.com/LibreService/my_rime
* It can reduce some overhead.
* Moreover, `rime_get_api` stores many function pointers. If I don't use `rime_get_api` at all, the compiler may optimize out many unused functions to reduce binary library size.
#### Unit test
- [ ] Done

#### Manual test
- [x] Done at my site

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
