### PR TITLE
add name_space of translator to LOG(INFO)

### DIFF
--- a/src/rime/engine.cc
+++ b/src/rime/engine.cc
@@ -201,7 +201,7 @@ void ConcreteEngine::TranslateSegments(Segmentation* segments) {
       if (!translation)
         continue;
       if (translation->exhausted()) {
-        LOG(INFO) << "Oops, got a futile translation.";
+        LOG(INFO) << translator->name_space() << " Oops, got a futile translation.";
         continue;
       }
       menu->AddTranslation(translation);


### PR DESCRIPTION
## Pull request

 translator->name_space() << " Oops, got a futile translation.";



#### Manual test
- [x ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
