### PR TITLE
feat(switches): abbreviate state labels

### DIFF
--- a/data/minimal/cangjie5.schema.yaml
+++ b/data/minimal/cangjie5.schema.yaml
@@ -4,7 +4,7 @@
 schema:
   schema_id: cangjie5
   name: 倉頡五代
-  version: "1.1.test"
+  version: "1.2.test"
   author:
     - 發明人 朱邦復先生
   description: |
@@ -17,13 +17,18 @@ schema:
 switches:
   - name: ascii_mode
     reset: 0
-    states: [ 中文, 西文 ]
+    states: [ 中文, ABC ]
+    abbrev: [ 中, Ａ ]
   - name: full_shape
-    states: [ 半角, 全角 ]
+    states: [ 半寬文字, 全寬文字 ]
   - name: simplification
-    states: [ 漢字, 汉字 ]
+    states: [ 傳統漢字, 简化字 ]
+    abbrev: [ 繁, 简 ]
   - name: extended_charset
-    states: [ 通用, 增廣 ]
+    states: [ 常用字彙, 增廣字彙 ]
+  - name: ascii_punct
+    states: [ 中文標點, 西文標點 ]
+    abbrev: [ '。', '．' ]
 
 engine:
   processors:

--- a/data/minimal/luna_pinyin.schema.yaml
+++ b/data/minimal/luna_pinyin.schema.yaml
@@ -4,7 +4,7 @@
 schema:
   schema_id: luna_pinyin
   name: 朙月拼音
-  version: "0.14.test"
+  version: "0.15.test"
   author:
     - 佛振 <chen.sst@gmail.com>
   description: |
@@ -18,19 +18,23 @@ schema:
 switches:
   - name: ascii_mode
     reset: 0
-    states: [ 中文, 西文 ]
+    states: [ 中文, ABC ]
+    abbrev: [ 中, Ａ ]
   - name: full_shape
-    states: [ 半角, 全角 ]
-  - name: ascii_punct
-    states: [ 句讀, 符號 ]
+    states: [ 半寬文字, 全寬文字 ]
 #  - name: simplification
-#    states: [ 漢字, 汉字 ]
-  - options: [ zh_trad, zh_tw, zh_simp ]
+#    states: [ 傳統漢字, 简化字 ]
+#    abbrev: [ 繁, 简 ]
+  - options: [ zh_trad, zh_simp, zh_hk, zh_tw ]
     states:
       - 傳統漢字
-      - 臺灣正體
-      - 簡化字
-    reset: 0
+      - 简化字
+      - 香港字形
+      - 臺灣字形
+    abbrev: [ 繁, 简, 港, 臺 ]
+  - name: ascii_punct
+    states: [ 中文標點, 西文標點 ]
+    abbrev: [ '。', '．' ]
 
 engine:
   processors:

--- a/src/rime/gear/switch_translator.cc
+++ b/src/rime/gear/switch_translator.cc
@@ -4,13 +4,14 @@
 //
 // 2013-05-26 GONG Chen <chen.sst@gmail.com>
 //
-#include <utf8.h>
+#include <boost/algorithm/string.hpp>
 #include <rime/candidate.h>
 #include <rime/common.h>
 #include <rime/config.h>
 #include <rime/context.h>
 #include <rime/schema.h>
 #include <rime/switcher.h>
+#include <rime/switches.h>
 #include <rime/translation.h>
 #include <rime/gear/switch_translator.h>
 
@@ -20,20 +21,30 @@ static const char* kRadioSelected = " \xe2\x9c\x93";  // U+2713 CHECK MARK
 
 namespace rime {
 
+using SwitchOption = Switches::SwitchOption;
+
+inline static string get_state_label(const SwitchOption& option,
+                                     size_t state_index,
+                                     bool abbreviate = false) {
+  return string(Switches::GetStateLabel(option.the_switch,
+                                        state_index,
+                                        abbreviate));
+}
+
 class Switch : public SimpleCandidate, public SwitcherCommand {
  public:
-  Switch(const string& current_state_label,
-         const string& next_state_label,
-         const string& option_name,
+  Switch(const SwitchOption& option,
          bool current_state,
          bool auto_save)
       : SimpleCandidate("switch", 0, 0,
-                        current_state_label, kRightArrow + next_state_label),
-        SwitcherCommand(option_name),
+                        get_state_label(option, current_state),
+                        kRightArrow +
+                        get_state_label(option, 1 - current_state)),
+        SwitcherCommand(option.option_name),
         target_state_(!current_state),
         auto_save_(auto_save) {
   }
-  virtual void Apply(Switcher* switcher);
+  void Apply(Switcher* switcher) override;
 
  protected:
   bool target_state_;
@@ -59,8 +70,8 @@ class RadioGroup : public std::enable_shared_from_this<RadioGroup> {
   RadioGroup(Context* context, Switcher* switcher)
       : context_(context), switcher_(switcher) {
   }
-  an<RadioOption> CreateOption(const string& state_label,
-                                       const string& option_name);
+  an<RadioOption> CreateOption(const SwitchOption& option,
+                               size_t option_index);
   void SelectOption(RadioOption* option);
   RadioOption* GetSelectedOption() const;
 
@@ -79,7 +90,7 @@ class RadioOption : public SimpleCandidate, public SwitcherCommand {
         SwitcherCommand(option_name),
         group_(group) {
   }
-  virtual void Apply(Switcher* switcher);
+  void Apply(Switcher* switcher) override;
   void UpdateState(bool selected);
   bool selected() const { return selected_; }
 
@@ -99,13 +110,12 @@ void RadioOption::UpdateState(bool selected) {
 }
 
 an<RadioOption>
-RadioGroup::CreateOption(const string& state_label,
-                         const string& option_name) {
-  auto option = New<RadioOption>(shared_from_this(),
-                                 state_label,
-                                 option_name);
-  options_.push_back(option.get());
-  return option;
+RadioGroup::CreateOption(const SwitchOption& option, size_t option_index) {
+  auto radio_option = New<RadioOption>(shared_from_this(),
+                                       get_state_label(option, option_index),
+                                       option.option_name);
+  options_.push_back(radio_option.get());
+  return radio_option;
 }
 
 void RadioGroup::SelectOption(RadioOption* option) {
@@ -142,14 +152,13 @@ class FoldedOptions : public SimpleCandidate, public SwitcherCommand {
         SwitcherCommand("_fold_options") {
     LoadConfig(config);
   }
-  virtual void Apply(Switcher* switcher);
-  void Append(const string& label) {
-    labels_.push_back(label);
-  }
+  void Apply(Switcher* switcher) override;
+  void Append(const SwitchOption& option, size_t state_index);
+  void Finish();
+
   size_t size() const {
     return labels_.size();
   }
-  void Finish();
 
  private:
   void LoadConfig(Config* config);
@@ -178,30 +187,13 @@ void FoldedOptions::Apply(Switcher* switcher) {
   switcher->RefreshMenu();
 }
 
-static string FirstCharOf(const string& str) {
-  if (str.empty()) {
-    return str;
-  }
-  string first_char;
-  const char* start = str.c_str();
-  const char* end = start;
-  utf8::unchecked::next(end);
-  return string(start, end - start);
+void FoldedOptions::Append(const SwitchOption& option, size_t state_index) {
+  labels_.push_back(
+    get_state_label(option, state_index, abbreviate_options_));
 }
 
 void FoldedOptions::Finish() {
-  text_ = prefix_;
-  bool first = true;
-  for (const auto& label : labels_) {
-    if (first) {
-      first = false;
-    }
-    else {
-      text_ += separator_;
-    }
-    text_ += abbreviate_options_ ? FirstCharOf(label) : label;
-  }
-  text_ += suffix_;
+  text_ = prefix_ + boost::algorithm::join(labels_, separator_) + suffix_;
 }
 
 class SwitchTranslation : public FifoTranslation {
@@ -220,54 +212,49 @@ void SwitchTranslation::LoadSwitches(Switcher* switcher) {
   Config* config = engine->schema()->config();
   if (!config)
     return;
-  auto switches = config->GetList("switches");
-  if (!switches)
-    return;
   Context* context = engine->context();
-  for (size_t i = 0; i < switches->size(); ++i) {
-    auto item = As<ConfigMap>(switches->GetAt(i));
-    if (!item)
-      continue;
-    auto states = As<ConfigList>(item->Get("states"));
-    if (!states)
-      continue;
-    if (auto option_name = item->GetValue("name")) {
-      // toggle
-      if (states->size() != 2)
-        continue;
-      bool current_state = context->get_option(option_name->str());
-      Append(New<Switch>(
-          states->GetValueAt(current_state)->str(),
-          states->GetValueAt(1 - current_state)->str(),
-          option_name->str(),
-          current_state,
-          switcher->IsAutoSave(option_name->str())));
-    }
-    else if (auto options = As<ConfigList>(item->Get("options"))) {
-      // radio
-      if (states->size() < 2)
-        continue;
-      if (states->size() != options->size())
-        continue;
-      auto group = New<RadioGroup>(context, switcher);
-      for (size_t i = 0; i < options->size(); ++i) {
-        auto option_name = options->GetValueAt(i);
-        auto state_label = states->GetValueAt(i);
-        if (!option_name || !state_label)
-          continue;
-        Append(group->CreateOption(state_label->str(), option_name->str()));
+  vector<an<RadioGroup>> groups;
+  Switches switches(config);
+  switches.FindOption(
+    [this, switcher, context, &groups]
+    (Switches::SwitchOption option) -> Switches::FindResult {
+      if (option.type == Switches::kToggleOption) {
+        bool current_state = context->get_option(option.option_name);
+        Append(
+          New<Switch>(option,
+                      current_state,
+                      switcher->IsAutoSave(option.option_name)));
+      } else if (option.type == Switches::kRadioGroup) {
+        an<RadioGroup> group;
+        if (option.option_index == 0) {
+          group = New<RadioGroup>(context, switcher);
+          groups.push_back(group);
+        } else {
+          group = groups.back();
+        }
+        Append(
+          group->CreateOption(option, option.option_index));
       }
-      group->SelectOption(group->GetSelectedOption());
-    }
+      return Switches::kContinue;
+    });
+  for (auto& group : groups) {
+    group->SelectOption(group->GetSelectedOption());
   }
   if (switcher->context()->get_option("_fold_options")) {
     auto folded_options = New<FoldedOptions>(switcher->schema()->config());
-    for (auto x : candies_) {
-      if (Is<Switch>(x) ||
-          (Is<RadioOption>(x) && As<RadioOption>(x)->selected())) {
-        folded_options->Append(x->text());
-      }
-    }
+    switches.FindOption(
+      [context, &folded_options]
+      (Switches::SwitchOption option) -> Switches::FindResult {
+        bool current_state = context->get_option(option.option_name);
+        if (option.type == Switches::kToggleOption) {
+          folded_options->Append(option, current_state);
+        } else if (option.type == Switches::kRadioGroup) {
+          if (current_state) {
+            folded_options->Append(option, option.option_index);
+          }
+        }
+        return Switches::kContinue;
+      });
     if (folded_options->size() > 1) {
       folded_options->Finish();
       candies_.clear();

--- a/src/rime/gear/switch_translator.h
+++ b/src/rime/gear/switch_translator.h
@@ -15,8 +15,7 @@ class SwitchTranslator : public Translator {
  public:
   SwitchTranslator(const Ticket& ticket);
 
-  virtual an<Translation> Query(const string& input,
-                                        const Segment& segment);
+  an<Translation> Query(const string& input, const Segment& segment) override;
 };
 
 }  // namespace rime

--- a/src/rime/switcher.cc
+++ b/src/rime/switcher.cc
@@ -117,14 +117,14 @@ void Switcher::HighlightNextSchema() {
     schema: wubi_pinyin
   - case: [mode/wubi]
     schema: wubi86
-    - case: [mode/default]
+  - case: [mode/default]
     schema: pinyin
 
-    mode:
+  mode:
     wubi: false
     wubi_pinyin: false
     default: true
-    ```
+  ```
 */
 
 static an<ConfigValue> ParseSchemaListEntry(Config* config,

--- a/src/rime/switches.h
+++ b/src/rime/switches.h
@@ -10,6 +10,15 @@ class ConfigItemRef;
 class ConfigMap;
 class ConfigValue;
 
+struct StringSlice {
+  const char* str;
+  size_t length;
+
+  operator string() const {
+    return str && length ? string(str, length) : string();
+  }
+};
+
 class Switches {
 public:
   explicit Switches(Config* config) : config_(config) {}
@@ -56,10 +65,12 @@ public:
       an<ConfigMap> the_switch,
       function<FindResult (SwitchOption option)> callback);
 
-  static an<ConfigValue> GetStateLabel(
-      an<ConfigMap> the_switch, size_t state_index);
+  static StringSlice GetStateLabel(
+      an<ConfigMap> the_switch, size_t state_index, bool abbreviated);
 
-  an<ConfigValue> GetStateLabel(const string& option_name, int state);
+  StringSlice GetStateLabel(const string& option_name,
+                            int state,
+                            bool abbreviated);
 
  private:
   SwitchOption FindOptionFromConfigItem(

--- a/src/rime_api.cc
+++ b/src/rime_api.cc
@@ -1002,18 +1002,26 @@ void RimeSetCaretPos(RimeSessionId session_id, size_t caret_pos) {
   return ctx->set_caret_pos(caret_pos);
 }
 
+RimeStringSlice RimeGetStateLabelAbbreviated(RimeSessionId session_id,
+                                             const char* option_name,
+                                             Bool state,
+                                             Bool abbreviated) {
+  an<Session> session(Service::instance().GetSession(session_id));
+  if (!session)
+    return {nullptr, 0};
+  Config* config = session->schema()->config();
+  if (!config)
+    return {nullptr, 0};
+  Switches switches(config);
+  StringSlice label =
+      switches.GetStateLabel(option_name, state, abbreviated);
+  return {label.str, label.length};
+}
+
 const char* RimeGetStateLabel(RimeSessionId session_id,
                               const char* option_name,
                               Bool state) {
-  an<Session> session(Service::instance().GetSession(session_id));
-  if (!session)
-    return nullptr;
-  Config* config = session->schema()->config();
-  if (!config)
-    return nullptr;
-  Switches switches(config);
-  an<ConfigValue> label = switches.GetStateLabel(option_name, state);
-  return label ? label->str().c_str() : nullptr;
+  return RimeGetStateLabelAbbreviated(session_id, option_name, state, False).str;
 }
 
 RIME_API RimeApi* rime_get_api() {
@@ -1108,6 +1116,7 @@ RIME_API RimeApi* rime_get_api() {
     s_api.get_state_label = &RimeGetStateLabel;
     s_api.delete_candidate = &RimeDeleteCandidate;
     s_api.delete_candidate_on_current_page = &RimeDeleteCandidateOnCurrentPage;
+    s_api.get_state_label_abbreviated = &RimeGetStateLabelAbbreviated;
   }
   return &s_api;
 }

--- a/src/rime_api.h
+++ b/src/rime_api.h
@@ -193,6 +193,11 @@ typedef void (*RimeNotificationHandler)(void* context_object,
                                         const char* message_type,
                                         const char* message_value);
 
+typedef struct rime_string_slice_t {
+  const char* str;
+  size_t length;
+} RimeStringSlice;
+
 // Setup
 
 /*!
@@ -552,10 +557,16 @@ typedef struct rime_api_t {
   void (*status_proto)(RimeSessionId session_id, RIME_PROTO_BUILDER* status_builder);
 
   const char* (*get_state_label)(RimeSessionId session_id, const char *option_name, Bool state);
+
   //! delete a candidate at the given index in candidate list.
   Bool (*delete_candidate)(RimeSessionId session_id, size_t index);
   //! delete a candidate from current page.
   Bool (*delete_candidate_on_current_page)(RimeSessionId session_id, size_t index);
+
+  RimeStringSlice (*get_state_label_abbreviated)(RimeSessionId session_id,
+                                                 const char *option_name,
+                                                 Bool state,
+                                                 Bool abbreviated);
 } RimeApi;
 
 //! API entry


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature

YAML config: a switch can have optional string array `abbrev` to define
short state labels which do not have to take the first character of the
full state labels.

(switch_translator): folded options now make use of the short labels
defined in the `switches` configuration.

(rime_api): add function `get_state_label_abbreviated`, which returns
`RimeStringSlice` type since the short label can be the first character
of the full label string.

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
