### PR TITLE
add OnProperty() for Navigator

### DIFF
--- a/src/rime/gear/navigator.h
+++ b/src/rime/gear/navigator.h
@@ -23,6 +23,7 @@ class Navigator : public Processor, public KeyBindingProcessor<Navigator, 2> {
   };
 
   explicit Navigator(const Ticket& ticket);
+  ~Navigator();
 
   ProcessResult ProcessKeyEvent(const KeyEvent& key_event) override;
 
@@ -42,9 +43,12 @@ class Navigator : public Processor, public KeyBindingProcessor<Navigator, 2> {
   bool MoveRight(Context* ctx);
   bool GoHome(Context* ctx);
   bool GoToEnd(Context* ctx);
+  void OnPropertyUpdate(Context *ctx, const string& property);
+
 
   string input_;
   Spans spans_;
+  connection property_update_connection_;
 };
 
 }  // namespace rime


### PR DESCRIPTION
## Pull request
add property to control  Navigator 
property name : 
_navigator :  [right|left]_by_[char|syllable] , [left|right] [home|end]   rewind
move_by_syllable:    [-num|num]  -left | +right 
 
 

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
