### PR TITLE
使用文件大小和修改时间（而非文件内容）作为判断词库是否修改的依据，从而提升 rime 启动速度

### DIFF
--- a/src/rime/algo/utilities.cc
+++ b/src/rime/algo/utilities.cc
@@ -5,6 +5,7 @@
 // 2013-01-30 GONG Chen <chen.sst@gmail.com>
 //
 #include <fstream>
+#include <boost/filesystem/operations.hpp>
 #include <boost/algorithm/string.hpp>
 #include <rime/algo/utilities.h>
 
@@ -34,10 +35,10 @@ ChecksumComputer::ChecksumComputer(uint32_t initial_remainder)
     : crc_(initial_remainder) {}
 
 void ChecksumComputer::ProcessFile(const string& file_name) {
-  std::ifstream fin(file_name.c_str());
-  string file_content((std::istreambuf_iterator<char>(fin)),
-                           std::istreambuf_iterator<char>());
-  crc_.process_bytes(file_content.data(), file_content.length());
+    auto ftime = boost::filesystem::last_write_time(file_name);
+    auto fsize = boost::filesystem::file_size(file_name);
+    crc_.process_bytes((const void*) &ftime, sizeof(ftime));
+    crc_.process_bytes((const void*) &fsize, sizeof(fsize));
 }
 
 uint32_t ChecksumComputer::Checksum() {


### PR DESCRIPTION
## Pull request

#### Feature
即使在词库已经 build 完成的状态下，启动 rime 仍需耗费较长时间，尤其是在树莓派等低性能设备上。我使用 [rime-ice](https://github.com/iDvel/rime-ice) 配置，在词库已经 build 完成的情况下，再次启动 rime-api-console 程序，并在启动时对其进行 Profile 分析，可以得到如下结果：

![Screenshot from 2023-03-15 12-59-14](https://user-images.githubusercontent.com/8972552/225217924-ba9a342b-4b3a-4809-b93b-b6d6fe75c4a9.png)

由图可见，最耗费时间的函数是 `compute_dict_file_checksum` 函数。究其原因，rime engine 每次启动时，DictCompiler 会检查词库是否变化，如果词库发生变化则需重新 build 词库。目前使用的检测方法，是对词库源文件做 crc32 哈希操作，并将计算好的哈希值存入数据库。由于此方法需要完整读取词库文件内容，如果词库的体积较大 且设备的 IO 性能较差，rime 的启动就会变得非常慢。

以下是在我的 Ryzen 7 5700G 台式机上，使用 Debug 模式编译的 rime-api-console 的启动速度：

![Screenshot from 2023-03-15 12-59-55](https://user-images.githubusercontent.com/8972552/225218444-aa73446c-87a6-412c-a076-54586619f6ae.png)
![Screenshot from 2023-03-15 12-59-46](https://user-images.githubusercontent.com/8972552/225218436-3d87c902-5ab7-4486-9a5d-c1ea0297bbb2.png)

可以看到，rime-api-console 使用了 5.6 秒才进入可使用的状态。当然，如果用 Release 模式，性能会有所提升，但在 checksum 上花费大量时间的事实仍然成立。

我提交的 Pull Request 将“文件是否修改”的判断方法进行了调整，改为读取“文件大小+文件修改时间”并进行哈希。这样，rime 无需读取完整的词库也可以启动。

以下是使用同样的配置，应用我的修改后，rime-api-console 的启动速度。可以看到，只花费了 0.13 秒，相比原来提升了 30 倍。

![Screenshot from 2023-03-15 13-35-18](https://user-images.githubusercontent.com/8972552/225219006-e2e93467-f176-4a9d-8c75-f8cd206e9301.png)
![Screenshot from 2023-03-15 13-35-13](https://user-images.githubusercontent.com/8972552/225219001-7104e048-5e6b-4f11-acb4-7c5fc8c01d69.png)

运行 Profile，也提示瓶颈不再是 checksum 的计算。

![Screenshot from 2023-03-15 13-53-01](https://user-images.githubusercontent.com/8972552/225219551-9e85aadd-6873-456a-b7e5-a8eeb97b48f6.png)


#### Unit test
- [ ] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
