### PR TITLE
doc: fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,7 +143,7 @@
 
 ### Bug Fixes
 
-* **ascii_composer:** do not comsume Shift key release ([debc2c0](https://github.com/rime/librime/commit/debc2c0))
+* **ascii_composer:** do not consume Shift key release ([debc2c0](https://github.com/rime/librime/commit/debc2c0))
 * **ascii_composer:** first read ascii_composer/good_old_caps_lock from schema config ([3fc56c4](https://github.com/rime/librime/commit/3fc56c4))
 * **chord_composer:** commit raw input with uppercase letters ([cc983d5](https://github.com/rime/librime/commit/cc983d5))
 * **CMakeLists.txt:** ensure paths in pkgconfig file are absolute ([0e96e51](https://github.com/rime/librime/commit/0e96e51))
@@ -498,14 +498,14 @@ known to be in use by osfans/trime.
   while source code compatibility is largely maintained with the exception
   of the aforementioned `RimeTraits` structure, rime 1.0 introduces a version
   controlled `RimeApi` structure which provides all the api functions.
-* **module:** suppport adding modules; modularize `gears` and `levers`.
-* **ticket:** used to instantiate compnents and to associate the instance with
+* **module:** support adding modules; modularize `gears` and `levers`.
+* **ticket:** used to instantiate components and to associate the instance with
   a name space in the configuration.
 * **encoder:** encode new phrases for `table_translator` and `script_translator`
   using different rules.
 * **affix_segmentor:** strip optional prefix and suffix from a code segment.
 * **reverse_lookup_filter:** lookup candidate text for code in a specified
-  dictonary.
+  dictionary.
 * **shape:** add full-shape support.
 * **key_binder:** switch input schemata and toggle options with hotkeys.
 * **switcher:** list input schemata ordered by recency; support radio options.
@@ -551,7 +551,7 @@ known to be in use by osfans/trime.
   properties when loading a different schema.
   `chord_composer` sets `_chord_typing` so that the input method program would
   know that a chord-typing schema is in use.
-* **deployment_tasks.cc(BackupConfigFiles::Run):** while synching user data,
+* **deployment_tasks.cc(BackupConfigFiles::Run):** while syncing user data,
   backup user created / modified YAML files.
 * **deployer.cc(Deployer::JoinMaintenanceThread):** fix a boost-related crash.
 
@@ -578,9 +578,9 @@ known to be in use by osfans/trime.
   `--add-schema`, `--set-active-schema`
 * **rime_dict_manager:** add command line option `--sync`
 * **rime_api.h (RimeSyncUserData):**
-  add API function to start a data synching task in maintenance thread.
+  add API function to start a data syncing task in maintenance thread.
 * **rime_api.h (RimeSetNotificationHandler):**
-  setup a callback function to receive notifcations from librime.
+  setup a callback function to receive notifications from librime.
 * **rime_api.h (RimeGetProperty, RimeSetProperty):**
   add API functions to access session specific string properties.
 * **config:** support subscript, assignment operators and simplified value accessors.

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1074,7 +1074,7 @@ HTML_STYLESHEET        =
 # defined cascading style sheet that is included after the standard style sheets
 # created by doxygen. Using this option one can overrule certain style aspects.
 # This is preferred over using HTML_STYLESHEET since it does not replace the
-# standard style sheet and is therefor more robust against future updates.
+# standard style sheet and is therefore more robust against future updates.
 # Doxygen will copy the style sheet file to the output directory. For an example
 # see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
@@ -1399,7 +1399,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are not
 # supported properly for IE 6.0, but are supported on all modern browsers.
 #

--- a/include/darts.h
+++ b/include/darts.h
@@ -62,7 +62,7 @@ class DoubleArrayUnit {
     return static_cast<value_type>(unit_ & ((1U << 31) - 1));
   }
 
-  // label() returns the label associted with the unit. Note that a leaf unit
+  // label() returns the label associated with the unit. Note that a leaf unit
   // always returns an invalid label. For this feature, leaf unit's label()
   // returns an <id_type> that has the MSB of 1.
   id_type label() const {

--- a/src/rime/algo/calculus.h
+++ b/src/rime/algo/calculus.h
@@ -31,7 +31,7 @@ class Calculus {
  public:
   RIME_API Calculus();
   void Register(const string& token, Calculation::Factory* factory);
-  RIME_API Calculation* Parse(const string& defintion);
+  RIME_API Calculation* Parse(const string& definition);
 
  private:
   map<string, Calculation::Factory*> factories_;

--- a/src/rime/algo/syllabifier.cc
+++ b/src/rime/algo/syllabifier.cc
@@ -189,7 +189,7 @@ int Syllabifier::BuildSyllableGraph(const string &input,
       graph->edges.erase(i);
       continue;
     }
-    // keep the valid vetex
+    // keep the valid vertex
     good.insert(i);
   }
 

--- a/src/rime/candidate.h
+++ b/src/rime/candidate.h
@@ -55,7 +55,7 @@ class Candidate {
 using CandidateQueue = list<of<Candidate>>;
 using CandidateList = vector<of<Candidate>>;
 
-// useful implimentations
+// useful implementations
 
 class SimpleCandidate : public Candidate {
  public:

--- a/src/rime/config/legacy_preset_config_plugin.cc
+++ b/src/rime/config/legacy_preset_config_plugin.cc
@@ -42,7 +42,7 @@ bool LegacyPresetConfigPlugin::ReviewLinkOutput(
   // NOTE: in the following cases, Cow() is not strictly necessary because
   // we know for sure that no other ConfigResource is going to reference the
   // root map node that will be modified. But other than the root node of the
-  // resource being linked, it's possbile a map or list has multiple references
+  // resource being linked, it's possible a map or list has multiple references
   // in the node tree, therefore Cow() is recommended to make sure the
   // modifications only happen to one place.
   if (auto preset = resource->data->Traverse("punctuator/import_preset")) {

--- a/src/rime/dict/corrector.cc
+++ b/src/rime/dict/corrector.cc
@@ -108,7 +108,7 @@ void EditDistanceCorrector::ToleranceSearch(const Prism &prism,
         auto origin = accessor.properties().tips;
         auto current_input = key.substr(0, point);
         if (origin == current_input) {
-          continue; // early termination: this comparision is O(n)
+          continue; // early termination: this comparison is O(n)
         }
         auto distance = RestrictedDistance(origin, current_input, threshold);
         if (distance <= threshold) { // only trace near words

--- a/src/rime/dict/dictionary.cc
+++ b/src/rime/dict/dictionary.cc
@@ -317,7 +317,7 @@ bool Dictionary::Remove() {
 bool Dictionary::Load() {
   LOG(INFO) << "loading dictionary '" << name_ << "'.";
   if (tables_.empty()) {
-    LOG(ERROR) << "Cannnot load dictionary '" << name_
+    LOG(ERROR) << "Cannot load dictionary '" << name_
                << "'; it contains no tables.";
     return false;
   }

--- a/src/rime/dict/level_db.cc
+++ b/src/rime/dict/level_db.cc
@@ -109,7 +109,7 @@ struct LevelDbWrapper {
 
 };
 
-// LevelDbAccessor memebers
+// LevelDbAccessor members
 
 LevelDbAccessor::LevelDbAccessor() {
 }

--- a/src/rime/dict/text_db.cc
+++ b/src/rime/dict/text_db.cc
@@ -9,7 +9,7 @@
 
 namespace rime {
 
-// TextDbAccessor memebers
+// TextDbAccessor members
 
 TextDbAccessor::TextDbAccessor(const TextDbData& data,
                                const string& prefix)

--- a/src/rime/dict/user_db_recovery_task.cc
+++ b/src/rime/dict/user_db_recovery_task.cc
@@ -39,7 +39,7 @@ bool UserDbRecoveryTask::Run(Deployer* deployer) {
   if (r && r->Recover()) {
     return true;
   }
-  // repair didn't work on the damanged db file; remove and recreate it
+  // repair didn't work on the damaged db file; remove and recreate it
   LOG(INFO) << "recreating db file.";
   if (db_->Exists()) {
     boost::system::error_code ec;

--- a/src/rime/dict/user_dictionary.cc
+++ b/src/rime/dict/user_dictionary.cc
@@ -173,7 +173,7 @@ bool UserDictionary::readonly() const {
 // there may be multiple edges that start at current_pos, and ends at different
 // positions after current_pos. on each edge, there can be multiple syllables
 // the spelling on the edge maps to.
-// in order to enable forward scaning and to avoid backdating, our strategy is:
+// in order to enable forward scanning and to avoid backdating, our strategy is:
 // sort all those syllables from edges that starts at current_pos, so that
 // the syllables are in the same alphabetical order as the user db's.
 // this having been done by transposing the syllable graph into

--- a/src/rime/gear/abc_segmentor.cc
+++ b/src/rime/gear/abc_segmentor.cc
@@ -51,7 +51,7 @@ bool AbcSegmentor::Proceed(Segmentation* segmentation) {
     bool is_initial = initials_.find(input[k]) != string::npos;
     bool is_final = finals_.find(input[k]) != string::npos;
     if (expecting_an_initial && !is_initial && !is_delimiter) {
-      break;  // not a valid seplling.
+      break;  // not a valid spelling.
     }
     // for the next character.
     expecting_an_initial = is_final || is_delimiter;

--- a/src/rime/gear/ascii_composer.cc
+++ b/src/rime/gear/ascii_composer.cc
@@ -131,7 +131,7 @@ ProcessResult AsciiComposer::ProcessCapsLock(const KeyEvent& key_event) {
   if (ch == XK_Caps_Lock) {
     if (!key_event.release()) {
       shift_key_pressed_ = ctrl_key_pressed_ = false;
-      // temprarily disable good-old (uppercase) Caps Lock as mode switch key
+      // temporarily disable good-old (uppercase) Caps Lock as mode switch key
       // in case the user switched to ascii mode with other keys, eg. with Shift
       if (good_old_caps_lock_ && !toggle_with_caps_) {
         Context* ctx = engine_->context();

--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -435,7 +435,7 @@ static bool ConfigNeedsUpdate(Config* config) {
 bool ConfigFileUpdate::Run(Deployer* deployer) {
   const fs::path shared_data_path(deployer->shared_data_dir);
   const fs::path user_data_path(deployer->user_data_dir);
-  // trash depecated user copy created by an older version of Rime
+  // trash deprecated user copy created by an older version of Rime
   fs::path source_config_path(shared_data_path / file_name_);
   fs::path dest_config_path(user_data_path / file_name_);
   fs::path trash = user_data_path / "trash";

--- a/src/rime/lever/user_dict_manager.h
+++ b/src/rime/lever/user_dict_manager.h
@@ -28,9 +28,9 @@ class UserDictManager {
   bool Backup(const string& dict_name);
   bool Restore(const string& snapshot_file);
   bool UpgradeUserDict(const string& dict_name);
-  // returns num of exported entires, -1 denotes failure
+  // returns num of exported entries, -1 denotes failure
   int Export(const string& dict_name, const string& text_file);
-  // returns num of imported entires, -1 denotes failure
+  // returns num of imported entries, -1 denotes failure
   int Import(const string& dict_name, const string& text_file);
 
   bool Synchronize(const string& dict_name);

--- a/src/rime/switches.h
+++ b/src/rime/switches.h
@@ -54,7 +54,7 @@ public:
   SwitchOption OptionByName(const string& option_name);
 
   // Returns the switch option defined at switch_index.
-  // If the swtich is a radio group, return the first option in the group.
+  // If the switch is a radio group, return the first option in the group.
   SwitchOption ByIndex(size_t switch_index);
 
   static SwitchOption Cycle(const SwitchOption& option);

--- a/src/rime_api.h
+++ b/src/rime_api.h
@@ -519,7 +519,7 @@ typedef struct rime_api_t {
    */
   const char* (*get_input)(RimeSessionId session_id);
 
-  //! caret posistion in terms of raw input
+  //! caret position in terms of raw input
   size_t (*get_caret_pos)(RimeSessionId session_id);
 
   //! select a candidate at the given index in candidate list.
@@ -528,7 +528,7 @@ typedef struct rime_api_t {
   //! get the version of librime
   const char* (*get_version)(void);
 
-  //! set caret posistion in terms of raw input
+  //! set caret position in terms of raw input
   void (*set_caret_pos)(RimeSessionId session_id, size_t caret_pos);
 
   //! select a candidate from current page.


### PR DESCRIPTION
Found via `codespell -S data,*.js -L rime,te,teh,lamda,fo,ue,seh,vew`

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
