### PR TITLE
move db_pool_ to UserDbComponent

### DIFF
--- a/src/rime/dict/user_db.h
+++ b/src/rime/dict/user_db.h
@@ -108,10 +108,19 @@ class UserDbComponent : public UserDb::Component,
  public:
   using UserDbImpl = UserDbWrapper<BaseDb>;
   Db* Create(const string& name) override {
-    return new UserDbImpl(DbFilePath(name, extension()), name);
+    string  db_key= name + extension();
+    auto db = db_pool_[db_key];
+    if ( ! db ) {
+      db.reset( new UserDbImpl( DbFilePath(name, extension() ), name) ) ;
+      LOG(INFO) << "Create UserDb: " << db_key ;
+      db_pool_[db_key] = db;
+    }
+    return db.get();
   }
 
   string extension() const override;
+ private:
+  map<string, an<Db>> db_pool_;
 };
 
 class UserDbMerger : public Sink {

--- a/src/rime/dict/user_dictionary.cc
+++ b/src/rime/dict/user_dictionary.cc
@@ -498,17 +498,14 @@ UserDictionaryComponent::UserDictionaryComponent() {
 }
 
 UserDictionary* UserDictionaryComponent::Create(const string& dict_name, const string& db_class) {
-  auto db = db_pool_[dict_name].lock();
-  if (!db) {
-    auto component = Db::Require(db_class);
-    if (!component) {
-      LOG(ERROR) << "undefined db class '" << db_class << "'.";
-      return NULL;
+  if (auto component = Db::Require(db_class)) {
+    if ( an<Db> db =
+        std::shared_ptr<Db>(component->Create(dict_name) ) ){
+      return new UserDictionary(dict_name, db);
     }
-    db.reset(component->Create(dict_name));
-    db_pool_[dict_name] = db;
   }
-  return new UserDictionary(dict_name, db);
+  LOG(ERROR) << "undefind db class '" << db_class << "'.";
+  return NULL;
 }
 
 UserDictionary* UserDictionaryComponent::Create(const Ticket& ticket) {

--- a/src/rime/dict/user_dictionary.h
+++ b/src/rime/dict/user_dictionary.h
@@ -110,7 +110,6 @@ class UserDictionaryComponent : public UserDictionary::Component {
   UserDictionary* Create(const Ticket& ticket);
   UserDictionary* Create(const string& dict_name, const string& db_class);
  private:
-  map<string, weak<Db>> db_pool_;
 };
 
 }  // namespace rime


### PR DESCRIPTION
## Pull request
將 map<string, an<Db>> db_pool_ 移至 UserDbComponent 
#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request
擴展UserDb  key-value db  以便於 librime-lua 可再利用 ，但須要 db_pool  機制  
#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
