### PR TITLE
Replace iRime with Hamster [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Community:
   - [emacs-rime](https://github.com/DogLooksGood/emacs-rime): frontend for Emacs
   - [fcitx-rime](https://github.com/fcitx/fcitx-rime): Fcitx frontend for Linux
   - [fcitx5-rime](https://github.com/fcitx/fcitx5-rime): Fcitx5 frontend for Linux
-  - [iRime](https://github.com/jimmy54/iRime): frontend for iOS
+  - [Hamster](https://github.com/imfuxiao/Hamster): frontend for iOS
   - [PIME](https://github.com/EasyIME/PIME): frontend for Windows
   - [Trime](https://github.com/osfans/trime): frontend for Android
   - [XIME](https://github.com/stackia/XIME): frontend for macOS


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
iRime stopped updating source code long time ago, so the version on App Store is proprietary.
Instead, Hamster is real open source and becoming popular.

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
