### PR TITLE
Replace boost filesystem with std filesystem

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -141,6 +141,7 @@ jobs:
       - name: Setup msys2 and install dependencies
         uses: msys2/setup-msys2@v2
         with:
+          release: false
           update: true
           msystem: UCRT64
           install: >-

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -138,26 +138,31 @@ jobs:
         shell: msys2 {0}
 
     steps:
-      - name: Setup MSYS2
+      - name: Setup msys2 and install dependencies
         uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          msystem: UCRT64
+          install: >-
+            git
+            base-devel
+            mingw-w64-ucrt-x86_64-boost
+            mingw-w64-ucrt-x86_64-glog
+            mingw-w64-ucrt-x86_64-gtest
+            mingw-w64-ucrt-x86_64-yaml-cpp
+            mingw-w64-ucrt-x86_64-leveldb
+            mingw-w64-ucrt-x86_64-marisa
+            mingw-w64-ucrt-x86_64-opencc
+          pacboy: >-
+            toolchain:p
+            cmake:p
+            ninja:p
 
       - name: Checkout last commit
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repository }}
-
-      - name: Install dependencies
-        run: |
-          pacman -S --noconfirm git base-devel mingw-w64-x86_64-toolchain ninja \
-            mingw64/mingw-w64-x86_64-cmake \
-            mingw-w64-x86_64-boost \
-            mingw-w64-x86_64-glog \
-            mingw-w64-x86_64-gtest \
-            mingw-w64-x86_64-yaml-cpp \
-            mingw-w64-x86_64-leveldb \
-            mingw-w64-x86_64-marisa \
-            mingw-w64-x86_64-opencc
-
+            
       - name: Configure build environment
         run: |
           echo git_ref_name="$(git describe --always)" >> $GITHUB_ENV

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -138,7 +138,7 @@ jobs:
         shell: msys2 {0}
 
     steps:
-      - name: Setup msys2 and install dependencies
+      - name: Install dependencies with MSYS2
         uses: msys2/setup-msys2@v2
         with:
           release: false
@@ -159,6 +159,7 @@ jobs:
             cmake:p
             ninja:p
 
+      - run: git config --global core.autocrlf input
       - name: Checkout last commit
         uses: actions/checkout@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ find_package(Boost 1.74.0 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 if(Boost_FOUND)
   include_directories(${Boost_INCLUDE_DIRS})
   link_directories(${Boost_LIBRARY_DIRS})
+  add_definitions(-DBOOST_DLL_USE_STD_FS)
 endif()
 
 if(ENABLE_LOGGING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if(MSVC)
   set(Boost_USE_STATIC_RUNTIME ON)
 endif()
 
-set(BOOST_COMPONENTS filesystem regex)
+set(BOOST_COMPONENTS regex)
 
 if(BOOST_USE_SIGNALS2)
   set(RIME_BOOST_SIGNALS2 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE_CXX ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cxx_fla
 
 cmake_minimum_required(VERSION 3.12)
 project(rime)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 set(rime_version 1.9.0)
 set(rime_soversion 1)
@@ -161,7 +161,7 @@ if(MSVC)
 endif()
 
 if(UNIX)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 endif()
 
 if (NOT CMAKE_BUILD_PARALLEL_LEVEL)

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,11 @@ WORKDIR /librime/plugins
 RUN git clone https://github.com/rime/librime-charcode charcode && \
   git clone https://github.com/hchunhui/librime-lua lua && \
   git clone https://github.com/lotem/librime-octagram octagram
+  
+WORKDIR /librime/plugins/lua
+RUN apt install -y curl
+RUN curl -LO https://github.com/hchunhui/librime-lua/pull/275.patch
+RUN git apply 275.patch
 
 WORKDIR /librime
 RUN cmake -B build -G Ninja \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN apt update && apt install -y \
   cmake \
   ninja-build \
   libboost-dev \
-  libboost-filesystem-dev \
   libboost-regex-dev \
   libboost-locale-dev \
   libgoogle-glog-dev \

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 export SDKROOT ?= $(shell xcrun --sdk macosx --show-sdk-path)
 
 # https://cmake.org/cmake/help/latest/envvar/MACOSX_DEPLOYMENT_TARGET.html
-export MACOSX_DEPLOYMENT_TARGET ?= 10.13
+export MACOSX_DEPLOYMENT_TARGET ?= 10.15
 
 ifdef BUILD_UNIVERSAL
 # https://cmake.org/cmake/help/latest/envvar/CMAKE_OSX_ARCHITECTURES.html

--- a/action-install-linux.sh
+++ b/action-install-linux.sh
@@ -2,7 +2,6 @@
 
 dep_packages=(
     doxygen
-    libboost-filesystem-dev
     libboost-locale-dev
     libboost-regex-dev
     libgoogle-glog-dev

--- a/build.bat
+++ b/build.bat
@@ -117,7 +117,6 @@ rem set curl=%RIME_ROOT%\bin\curl.exe
 rem set download="%curl%" --remote-name-all
 
 set boost_compiled_libs=--with-date_time^
- --with-filesystem^
  --with-locale^
  --with-regex^
  --with-thread

--- a/install-boost.sh
+++ b/install-boost.sh
@@ -23,7 +23,7 @@ download_boost_source() {
     [[ -f "${BOOST_ROOT}/bootstrap.sh" ]]
 }
 
-boost_libs="${boost_libs=filesystem,regex}"
+boost_libs="${boost_libs=regex}"
 boost_cxxflags='-arch arm64 -arch x86_64'
 
 build_boost_macos() {

--- a/plugins/plugins_module.cc
+++ b/plugins/plugins_module.cc
@@ -5,7 +5,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/dll.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <rime/build_config.h>
 #include <rime/common.h>
 #include <rime/component.h>
@@ -13,7 +13,7 @@
 #include <rime/registry.h>
 #include <rime_api.h>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 namespace rime {
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,9 @@ set(rime_gears_deps
 set(rime_levers_deps "")
 
 if(MINGW)
-  set(rime_core_deps ${rime_core_deps} wsock32 ws2_32)
+  # fix: bcrypt for boost uuid issue
+  # https://github.com/boostorg/uuid/issues/68
+  set(rime_core_deps ${rime_core_deps} wsock32 ws2_32 bcrypt)
 endif()
 
 if(BUILD_SEPARATE_LIBS)

--- a/src/rime/algo/fs.h
+++ b/src/rime/algo/fs.h
@@ -1,0 +1,20 @@
+#ifndef RIME_FS_H_
+#define RIME_FS_H_
+
+#include <chrono>
+
+namespace rime {
+namespace filesystem {
+
+template <typename TP>
+inline std::time_t to_time_t(TP tp) {
+  using namespace std::chrono;
+  auto sctp = time_point_cast<system_clock::duration>(tp - TP::clock::now() +
+                                                      system_clock::now());
+  return system_clock::to_time_t(sctp);
+}
+
+}  // namespace filesystem
+}  // namespace rime
+
+#endif  // RIME_FS_H_

--- a/src/rime/config/build_info_plugin.cc
+++ b/src/rime/config/build_info_plugin.cc
@@ -2,8 +2,9 @@
 // Copyright RIME Developers
 // Distributed under the BSD License
 //
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <rime/service.h>
+#include <rime/algo/fs.h>
 #include <rime/config/config_compiler.h>
 #include <rime/config/config_types.h>
 #include <rime/config/plugins.h>
@@ -36,7 +37,7 @@ bool BuildInfoPlugin::ReviewLinkOutput(ConfigCompiler* compiler,
     }
     // TODO: store as 64-bit number to avoid the year 2038 problem
     timestamps[resource->resource_id] =
-        (int)boost::filesystem::last_write_time(file_name);
+        (int)filesystem::to_time_t(std::filesystem::last_write_time(file_name));
   });
 #endif
   return true;

--- a/src/rime/config/config_data.cc
+++ b/src/rime/config/config_data.cc
@@ -6,7 +6,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <boost/format.hpp>
 #include <yaml-cpp/yaml.h>
 #include <rime/config/config_compiler.h>
@@ -62,7 +62,7 @@ bool ConfigData::LoadFromFile(const string& file_name,
   file_name_ = file_name;
   modified_ = false;
   root.reset();
-  if (!boost::filesystem::exists(file_name)) {
+  if (!std::filesystem::exists(file_name)) {
     LOG(WARNING) << "nonexistent config file '" << file_name << "'.";
     return false;
   }

--- a/src/rime/config/save_output_plugin.cc
+++ b/src/rime/config/save_output_plugin.cc
@@ -2,7 +2,7 @@
 // Copyright RIME Developers
 // Distributed under the BSD License
 //
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <rime/resource.h>
 #include <rime/service.h>
 #include <rime/config/config_compiler.h>

--- a/src/rime/deployer.cc
+++ b/src/rime/deployer.cc
@@ -8,7 +8,7 @@
 #include <exception>
 #include <utility>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <rime/deployer.h>
 
 namespace rime {
@@ -148,7 +148,7 @@ void Deployer::JoinMaintenanceThread() {
 }
 
 string Deployer::user_data_sync_dir() const {
-  return (boost::filesystem::path(sync_dir) / user_id).string();
+  return (std::filesystem::path(sync_dir) / user_id).string();
 }
 
 }  // namespace rime

--- a/src/rime/dict/db.cc
+++ b/src/rime/dict/db.cc
@@ -5,7 +5,7 @@
 // 2011-11-02 GONG Chen <chen.sst@gmail.com>
 //
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <rime/common.h>
 #include <rime/resource.h>
 #include <rime/service.h>
@@ -40,7 +40,7 @@ Db::Db(const string& file_name, const string& name)
     : name_(name), file_name_(file_name) {}
 
 bool Db::Exists() const {
-  return boost::filesystem::exists(file_name());
+  return std::filesystem::exists(file_name());
 }
 
 bool Db::Remove() {
@@ -48,7 +48,7 @@ bool Db::Remove() {
     LOG(ERROR) << "attempt to remove opened db '" << name_ << "'.";
     return false;
   }
-  return boost::filesystem::remove(file_name());
+  return std::filesystem::remove(file_name());
 }
 
 bool Db::CreateMetadata() {

--- a/src/rime/dict/dict_compiler.cc
+++ b/src/rime/dict/dict_compiler.cc
@@ -4,7 +4,7 @@
 //
 // 2011-11-27 GONG Chen <chen.sst@gmail.com>
 //
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <cfloat>
 #include <cmath>
 #include <fstream>
@@ -22,7 +22,7 @@
 #include <rime/resource.h>
 #include <rime/service.h>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 namespace rime {
 
@@ -84,7 +84,7 @@ bool DictCompiler::Compile(const string& schema_file) {
   bool build_table_from_source = true;
   DictSettings settings;
   auto dict_file = source_resolver_->ResolvePath(dict_name_ + ".dict.yaml");
-  if (!boost::filesystem::exists(dict_file)) {
+  if (!std::filesystem::exists(dict_file)) {
     LOG(ERROR) << "source file '" << dict_file << "' does not exist.";
     build_table_from_source = false;
   } else if (!load_dict_settings_from_file(&settings, dict_file)) {

--- a/src/rime/dict/dictionary.cc
+++ b/src/rime/dict/dictionary.cc
@@ -4,7 +4,7 @@
 //
 // 2011-07-05 GONG Chen <chen.sst@gmail.com>
 //
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <rime/algo/syllabifier.h>
 #include <rime/common.h>
 #include <rime/dict/dictionary.h>
@@ -306,8 +306,8 @@ bool Dictionary::Decode(const Code& code, vector<string>* result) {
 }
 
 bool Dictionary::Exists() const {
-  return boost::filesystem::exists(prism_->file_name()) && !tables_.empty() &&
-         boost::filesystem::exists(tables_[0]->file_name());
+  return std::filesystem::exists(prism_->file_name()) && !tables_.empty() &&
+         std::filesystem::exists(tables_[0]->file_name());
 }
 
 bool Dictionary::Remove() {

--- a/src/rime/dict/level_db.cc
+++ b/src/rime/dict/level_db.cc
@@ -5,7 +5,7 @@
 // 2014-12-04 Chen Gong <chen.sst@gmail.com>
 //
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <leveldb/db.h>
 #include <leveldb/write_batch.h>
 #include <rime/common.h>

--- a/src/rime/dict/mapped_file.cc
+++ b/src/rime/dict/mapped_file.cc
@@ -7,7 +7,7 @@
 // 2011-06-30 GONG Chen <chen.sst@gmail.com>
 //
 #include <fstream>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <boost/interprocess/file_mapping.hpp>
 #include <boost/interprocess/mapped_region.hpp>
 #include <rime/dict/mapped_file.h>
@@ -101,7 +101,7 @@ void MappedFile::Close() {
 }
 
 bool MappedFile::Exists() const {
-  return boost::filesystem::exists(file_name_);
+  return std::filesystem::exists(file_name_);
 }
 
 bool MappedFile::IsOpen() const {
@@ -130,7 +130,7 @@ bool MappedFile::Resize(size_t capacity) {
   if (IsOpen())
     Close();
   try {
-    boost::filesystem::resize_file(file_name_.c_str(), capacity);
+    std::filesystem::resize_file(file_name_.c_str(), capacity);
   } catch (...) {
     return false;
   }

--- a/src/rime/dict/preset_vocabulary.cc
+++ b/src/rime/dict/preset_vocabulary.cc
@@ -4,7 +4,7 @@
 //
 // 2011-11-27 GONG Chen <chen.sst@gmail.com>
 //
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <boost/lexical_cast.hpp>
 #include <utf8.h>
 #include <rime/resource.h>

--- a/src/rime/dict/reverse_lookup_dictionary.cc
+++ b/src/rime/dict/reverse_lookup_dictionary.cc
@@ -9,7 +9,7 @@
 #include <cstdlib>
 #include <sstream>
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <boost/lexical_cast.hpp>
 #include <rime/resource.h>
 #include <rime/schema.h>

--- a/src/rime/dict/user_db_recovery_task.cc
+++ b/src/rime/dict/user_db_recovery_task.cc
@@ -5,14 +5,14 @@
 // 2013-04-22 GONG Chen <chen.sst@gmail.com>
 //
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <boost/scope_exit.hpp>
 #include <rime/deployer.h>
 #include <rime/dict/db.h>
 #include <rime/dict/user_db.h>
 #include <rime/dict/user_db_recovery_task.h>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 namespace rime {
 
@@ -42,8 +42,8 @@ bool UserDbRecoveryTask::Run(Deployer* deployer) {
   // repair didn't work on the damaged db file; remove and recreate it
   LOG(INFO) << "recreating db file.";
   if (db_->Exists()) {
-    boost::system::error_code ec;
-    boost::filesystem::rename(db_->file_name(), db_->file_name() + ".old", ec);
+    std::error_code ec;
+    std::filesystem::rename(db_->file_name(), db_->file_name() + ".old", ec);
     if (ec && !db_->Remove()) {
       LOG(ERROR) << "Error removing db file '" << db_->file_name() << "'.";
       return false;
@@ -65,7 +65,7 @@ void UserDbRecoveryTask::RestoreUserDataFromSnapshot(Deployer* deployer) {
   string dict_name(db_->name());
   boost::erase_last(dict_name, component->extension());
   // locate snapshot file
-  boost::filesystem::path dir(deployer->user_data_sync_dir());
+  std::filesystem::path dir(deployer->user_data_sync_dir());
   // try *.userdb.txt
   fs::path snapshot_path = dir / (dict_name + UserDb::snapshot_extension());
   if (!fs::exists(snapshot_path)) {

--- a/src/rime/gear/simplifier.cc
+++ b/src/rime/gear/simplifier.cc
@@ -5,7 +5,7 @@
 // 2011-12-12 GONG Chen <chen.sst@gmail.com>
 //
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <stdint.h>
 #include <utf8.h>
 #include <utility>
@@ -27,7 +27,7 @@
 
 #ifdef _MSC_VER
 #include <opencc/UTF8Util.hpp>
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 #endif
 
 static const char* quote_left = "\xe3\x80\x94";   //"\xef\xbc\x88";
@@ -178,7 +178,7 @@ Simplifier::Simplifier(const Ticket& ticket)
 }
 
 void Simplifier::Initialize() {
-  using namespace boost::filesystem;
+  using namespace std::filesystem;
   initialized_ = true;  // no retry
   path opencc_config_path = opencc_config_;
   if (opencc_config_path.extension().string() == ".ini") {

--- a/src/rime/lever/custom_settings.cc
+++ b/src/rime/lever/custom_settings.cc
@@ -5,13 +5,13 @@
 // 2012-02-26 GONG Chen <chen.sst@gmail.com>
 //
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <rime/config.h>
 #include <rime/deployer.h>
 #include <rime/signature.h>
 #include <rime/lever/custom_settings.h>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 namespace rime {
 

--- a/src/rime/lever/customizer.cc
+++ b/src/rime/lever/customizer.cc
@@ -11,7 +11,7 @@
 #include <rime/algo/utilities.h>
 #include <rime/lever/customizer.h>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 namespace rime {
 

--- a/src/rime/lever/customizer.h
+++ b/src/rime/lever/customizer.h
@@ -5,14 +5,14 @@
 #ifndef RIME_CUSTOMIZER_H_
 #define RIME_CUSTOMIZER_H_
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 namespace rime {
 
 class Customizer {
  public:
-  Customizer(const boost::filesystem::path& source_path,
-             const boost::filesystem::path& dest_path,
+  Customizer(const std::filesystem::path& source_path,
+             const std::filesystem::path& dest_path,
              const string& version_key)
       : source_path_(source_path),
         dest_path_(dest_path),
@@ -22,8 +22,8 @@ class Customizer {
   bool UpdateConfigFile();
 
  protected:
-  boost::filesystem::path source_path_;
-  boost::filesystem::path dest_path_;
+  std::filesystem::path source_path_;
+  std::filesystem::path dest_path_;
   string version_key_;
 };
 

--- a/src/rime/lever/switcher_settings.cc
+++ b/src/rime/lever/switcher_settings.cc
@@ -6,12 +6,12 @@
 //
 #include <utility>
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <rime/config.h>
 #include <rime/deployer.h>
 #include <rime/lever/switcher_settings.h>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 namespace rime {
 

--- a/src/rime/lever/switcher_settings.h
+++ b/src/rime/lever/switcher_settings.h
@@ -7,7 +7,7 @@
 #ifndef RIME_SWITCHER_SETTINGS_H_
 #define RIME_SWITCHER_SETTINGS_H_
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include "custom_settings.h"
 
 namespace rime {
@@ -37,7 +37,7 @@ class SwitcherSettings : public CustomSettings {
   const string& hotkeys() const { return hotkeys_; }
 
  private:
-  void GetAvailableSchemasFromDirectory(const boost::filesystem::path& dir);
+  void GetAvailableSchemasFromDirectory(const std::filesystem::path& dir);
   void GetSelectedSchemasFromConfig();
   void GetHotkeysFromConfig();
 

--- a/src/rime/lever/user_dict_manager.cc
+++ b/src/rime/lever/user_dict_manager.cc
@@ -6,7 +6,7 @@
 //
 #include <fstream>
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <boost/scope_exit.hpp>
 #include <rime/common.h>
 #include <rime/deployer.h>
@@ -16,7 +16,7 @@
 #include <rime/dict/user_db.h>
 #include <rime/lever/user_dict_manager.h>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 namespace rime {
 
@@ -59,9 +59,9 @@ bool UserDictManager::Backup(const string& dict_name) {
       return false;
     }
   }
-  boost::filesystem::path dir(deployer_->user_data_sync_dir());
-  if (!boost::filesystem::exists(dir)) {
-    if (!boost::filesystem::create_directories(dir)) {
+  std::filesystem::path dir(deployer_->user_data_sync_dir());
+  if (!std::filesystem::exists(dir)) {
+    if (!std::filesystem::create_directories(dir)) {
       LOG(ERROR) << "error creating directory '" << dir.string() << "'.";
       return false;
     }
@@ -163,7 +163,7 @@ bool UserDictManager::UpgradeUserDict(const string& dict_name) {
   LOG(INFO) << "upgrading user dict '" << dict_name << "'.";
   fs::path trash = fs::path(deployer_->user_data_dir) / "trash";
   if (!fs::exists(trash)) {
-    boost::system::error_code ec;
+    std::error_code ec;
     if (!fs::create_directories(trash, ec)) {
       LOG(ERROR) << "error creating directory '" << trash.string() << "'.";
       return false;
@@ -180,7 +180,7 @@ bool UserDictManager::Synchronize(const string& dict_name) {
   bool success = true;
   fs::path sync_dir(deployer_->sync_dir);
   if (!fs::exists(sync_dir)) {
-    boost::system::error_code ec;
+    std::error_code ec;
     if (!fs::create_directories(sync_dir, ec)) {
       LOG(ERROR) << "error creating directory '" << sync_dir.string() << "'.";
       return false;

--- a/src/rime/lever/user_dict_manager.h
+++ b/src/rime/lever/user_dict_manager.h
@@ -7,7 +7,7 @@
 #ifndef RIME_USER_DICT_MANAGER_H_
 #define RIME_USER_DICT_MANAGER_H_
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <rime/dict/user_db.h>
 
 namespace rime {
@@ -38,7 +38,7 @@ class RIME_API UserDictManager {
 
  protected:
   Deployer* deployer_;
-  boost::filesystem::path path_;
+  std::filesystem::path path_;
   UserDb::Component* user_db_component_;
 };
 

--- a/src/rime/resource.cc
+++ b/src/rime/resource.cc
@@ -4,13 +4,13 @@
 //
 
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <rime/resource.h>
 
 namespace rime {
 
 string ResourceResolver::ToResourceId(const string& file_path) const {
-  string path_string = boost::filesystem::path(file_path).generic_string();
+  string path_string = std::filesystem::path(file_path).generic_string();
   bool has_prefix = boost::starts_with(path_string, type_.prefix);
   bool has_suffix = boost::ends_with(path_string, type_.suffix);
   size_t start = (has_prefix ? type_.prefix.length() : 0);
@@ -19,7 +19,7 @@ string ResourceResolver::ToResourceId(const string& file_path) const {
 }
 
 string ResourceResolver::ToFilePath(const string& resource_id) const {
-  boost::filesystem::path file_path(resource_id);
+  std::filesystem::path file_path(resource_id);
   bool missing_prefix = !file_path.has_parent_path() &&
                         !boost::starts_with(resource_id, type_.prefix);
   bool missing_suffix = !boost::ends_with(resource_id, type_.suffix);
@@ -27,21 +27,20 @@ string ResourceResolver::ToFilePath(const string& resource_id) const {
          (missing_suffix ? type_.suffix : "");
 }
 
-boost::filesystem::path ResourceResolver::ResolvePath(
-    const string& resource_id) {
-  return boost::filesystem::absolute(
-      boost::filesystem::path(type_.prefix + resource_id + type_.suffix),
-      root_path_);
+std::filesystem::path ResourceResolver::ResolvePath(const string& resource_id) {
+  return std::filesystem::absolute(
+      root_path_ /
+      std::filesystem::path(type_.prefix + resource_id + type_.suffix));
 }
 
-boost::filesystem::path FallbackResourceResolver::ResolvePath(
+std::filesystem::path FallbackResourceResolver::ResolvePath(
     const string& resource_id) {
   auto default_path = ResourceResolver::ResolvePath(resource_id);
-  if (!boost::filesystem::exists(default_path)) {
-    auto fallback_path = boost::filesystem::absolute(
-        boost::filesystem::path(type_.prefix + resource_id + type_.suffix),
-        fallback_root_path_);
-    if (boost::filesystem::exists(fallback_path)) {
+  if (!std::filesystem::exists(default_path)) {
+    auto fallback_path = std::filesystem::absolute(
+        fallback_root_path_ /
+        std::filesystem::path(type_.prefix + resource_id + type_.suffix));
+    if (std::filesystem::exists(fallback_path)) {
       return fallback_path;
     }
   }

--- a/src/rime/resource.h
+++ b/src/rime/resource.h
@@ -6,7 +6,7 @@
 #ifndef RIME_RESOURCE_H_
 #define RIME_RESOURCE_H_
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <rime_api.h>
 #include <rime/common.h>
 
@@ -24,17 +24,17 @@ class RIME_API ResourceResolver {
  public:
   explicit ResourceResolver(const ResourceType type) : type_(type) {}
   virtual ~ResourceResolver() {}
-  virtual boost::filesystem::path ResolvePath(const string& resource_id);
+  virtual std::filesystem::path ResolvePath(const string& resource_id);
   string ToResourceId(const string& file_path) const;
   string ToFilePath(const string& resource_id) const;
-  void set_root_path(boost::filesystem::path root_path) {
+  void set_root_path(std::filesystem::path root_path) {
     root_path_ = root_path;
   }
-  boost::filesystem::path root_path() const { return root_path_; }
+  std::filesystem::path root_path() const { return root_path_; }
 
  protected:
   const ResourceType type_;
-  boost::filesystem::path root_path_;
+  std::filesystem::path root_path_;
 };
 
 // try fallback path if target file doesn't exist in root path
@@ -42,13 +42,13 @@ class RIME_API FallbackResourceResolver : public ResourceResolver {
  public:
   explicit FallbackResourceResolver(const ResourceType& type)
       : ResourceResolver(type) {}
-  boost::filesystem::path ResolvePath(const string& resource_id) override;
-  void set_fallback_root_path(boost::filesystem::path fallback_root_path) {
+  std::filesystem::path ResolvePath(const string& resource_id) override;
+  void set_fallback_root_path(std::filesystem::path fallback_root_path) {
     fallback_root_path_ = fallback_root_path;
   }
 
  private:
-  boost::filesystem::path fallback_root_path_;
+  std::filesystem::path fallback_root_path_;
 };
 
 }  // namespace rime

--- a/src/rime/setup.cc
+++ b/src/rime/setup.cc
@@ -14,14 +14,14 @@
 #include <glog/logging.h>
 #endif  // RIME_ENABLE_LOGGING
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <rime_api.h>
 #include <rime/deployer.h>
 #include <rime/module.h>
 #include <rime/service.h>
 #include <rime/setup.h>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 namespace rime {
 

--- a/test/resource_resolver_test.cc
+++ b/test/resource_resolver_test.cc
@@ -1,9 +1,9 @@
 #include <fstream>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <gtest/gtest.h>
 #include <rime/resource.h>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 using namespace rime;
 
 static const ResourceType kMineralsType = ResourceType{
@@ -17,7 +17,7 @@ TEST(RimeResourceResolverTest, ResolvePath) {
   rr.set_root_path("/starcraft");
   auto actual = rr.ResolvePath("enough");
   fs::path expected =
-      fs::system_complete(fs::current_path()).root_name().string() +
+      fs::absolute(fs::current_path()).root_name().string() +
       "/starcraft/not_enough.minerals";
   EXPECT_TRUE(actual.is_absolute());
   EXPECT_TRUE(expected == actual);

--- a/tools/rime_deployer.cc
+++ b/tools/rime_deployer.cc
@@ -5,7 +5,7 @@
 // 2012-07-07 GONG Chen <chen.sst@gmail.com>
 //
 #include <iostream>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <rime/config.h>
 #include <rime/deployer.h>
 #include <rime/service.h>
@@ -13,7 +13,7 @@
 #include <rime/lever/deployment_tasks.h>
 #include "codepage.h"
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 using namespace rime;
 


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes # N/A

#### Feature
Describe feature of pull request

Replace boost filesystem with std filesystem, since there is a filesystem library in the STL since C++17.

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
