### PR TITLE
fix #652: process whole conversion chain

### DIFF
--- a/src/rime/gear/simplifier.cc
+++ b/src/rime/gear/simplifier.cc
@@ -249,7 +249,7 @@ bool Simplifier::Convert(const an<Candidate>& original,
           string simplified;
           const bool success_converted =
               opencc_->ConvertText(original->text(), &simplified);
-          if (success_converted && original->text().compare(simplified) != 0) {
+          if (success_converted && original->text() != simplified) {
             PushBack(original, result, simplified);
           } else {
             PushBack(original, result, forms[i]);

--- a/src/rime/gear/simplifier.cc
+++ b/src/rime/gear/simplifier.cc
@@ -251,8 +251,8 @@ bool Simplifier::Convert(const an<Candidate>& original,
           result->push_back(original);
         } else {
           string simplified;
-          success = opencc_->ConvertText(forms[i], &simplified);
-          if (success && original->text().compare(simplified) != 0) {
+          const bool success_converted = opencc_->ConvertText(forms[i], &simplified);
+          if (success_converted && original->text().compare(simplified) != 0) {
             PushBack(original, result, simplified);
           } else {
             PushBack(original, result, forms[i]);

--- a/src/rime/gear/simplifier.cc
+++ b/src/rime/gear/simplifier.cc
@@ -250,7 +250,13 @@ bool Simplifier::Convert(const an<Candidate>& original,
         if (forms[i] == original->text()) {
           result->push_back(original);
         } else {
-          PushBack(original, result, forms[i]);
+          string simplified;
+          success = opencc_->ConvertText(forms[i], &simplified);
+          if (success && original->text().compare(simplified) != 0) {
+            PushBack(original, result, simplified);
+          } else {
+            PushBack(original, result, forms[i]);
+          }
         }
       }
     } else {

--- a/src/rime/gear/simplifier.cc
+++ b/src/rime/gear/simplifier.cc
@@ -251,7 +251,7 @@ bool Simplifier::Convert(const an<Candidate>& original,
           result->push_back(original);
         } else {
           string simplified;
-          const bool success_converted = opencc_->ConvertText(forms[i], &simplified);
+          const bool success_converted = opencc_->ConvertText(original->text(), &simplified);
           if (success_converted && original->text().compare(simplified) != 0) {
             PushBack(original, result, simplified);
           } else {

--- a/src/rime/gear/simplifier.cc
+++ b/src/rime/gear/simplifier.cc
@@ -247,7 +247,8 @@ bool Simplifier::Convert(const an<Candidate>& original,
           result->push_back(original);
         } else {
           string simplified;
-          const bool success_converted = opencc_->ConvertText(original->text(), &simplified);
+          const bool success_converted =
+              opencc_->ConvertText(original->text(), &simplified);
           if (success_converted && original->text().compare(simplified) != 0) {
             PushBack(original, result, simplified);
           } else {


### PR DESCRIPTION
* continue to process whole conversion chain for whole candidate matching except for the candidate original form

## Pull request

#### Issue tracker

Fixes #652 

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
