### PR TITLE
Fix reinterpret period key

### DIFF
--- a/src/rime/gear/key_binder.cc
+++ b/src/rime/gear/key_binder.cc
@@ -309,7 +309,7 @@ bool KeyBinder::ReinterpretPagingKey(const KeyEvent& key_event) {
   // reinterpret period key followed by alphabetic keys
   // unless period/comma key has been used multiple times
   if (ch == '.' && (last_key_ == '.' || last_key_ == ',')) {
-    last_key_ = 0;
+    last_key_ = ',';
     return ret;
   }
   if (last_key_ == '.' && ch >= 'a' && ch <= 'z') {


### PR DESCRIPTION
Fix a bug that odd ordinal positioned period key followed by alphabetic keys are all interpret as period. Such behavior is only expected on the 1st period key, but not on the 3rd, 5th, … period keys

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
