### PR TITLE
Recude Memory Comsumption When Compiling Dictionaries (2)

### DIFF
--- a/src/rime/dict/dict_compiler.cc
+++ b/src/rime/dict/dict_compiler.cc
@@ -225,6 +225,8 @@ bool DictCompiler::BuildTable(int table_index,
       for (const auto& s : r->raw_code) {
         code.push_back(syllable_to_id[s]);
       }
+      // release memory in time to reduce memory usage
+      RawCode().swap(r->raw_code);
       auto ls = vocabulary.LocateEntries(code);
       if (!ls) {
         LOG(ERROR) << "Error locating entries in vocabulary.";
@@ -236,7 +238,7 @@ bool DictCompiler::BuildTable(int table_index,
       e->weight = log(r->weight > 0 ? r->weight : DBL_EPSILON);
       ls->push_back(e);
     }
-    // release memory in time to reduce peak memory usage
+    // release memory in time to reduce memory usage
     vector<of<RawDictEntry>>().swap(collector.entries);
     if (settings->sort_order() != "original") {
       vocabulary.SortHomophones();


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes # N/A

#### Feature
Describe feature of pull request

Recude Memory Comsumption When Compiling Dictionaries. Yes, again.

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
