### PR TITLE
No "thru" punct when composing

### DIFF
--- a/src/rime/gear/punctuator.cc
+++ b/src/rime/gear/punctuator.cc
@@ -72,7 +72,8 @@ ProcessResult Punctuator::ProcessKeyEvent(const KeyEvent& key_event) {
   if (!use_space_ && ch == XK_space && ctx->IsComposing()) {
     return kNoop;
   }
-  if (ch == '.' || ch == ':') {  // 3.14, 12:30
+  if ((ch == '.' || ch == ':' || ch == ',' || ch == '\'') &&
+      !(ctx->IsComposing())) {  // 3.14  12:30  4'999,95
     const CommitHistory& history(ctx->commit_history());
     if (!history.empty()) {
       const CommitRecord& cr(history.back());


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #670 fixes rime/squirrel#785

#### Feature
Do not use ascii punctuators after numerals when user is already composing (but have not yet committed any input), in which case the punctuator should actually commit the composing.

In addition to `.` (decimal point / grouping separator) and `:` (time separator), two similar punctuators are also included — `,` (grouping separator / decimal comma) and `'` (another form of grouping separator).

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
