### PR TITLE
allow single thread deployment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(BOOST_USE_SIGNALS2 "Boost use signals2 instead of signals" ON)
 option(ENABLE_ASAN "Enable Address Sanitizer (Unix Only)" OFF)
 option(INSTALL_PRIVATE_HEADERS "Install private headers (usually needed for externally built Rime plugins)" OFF)
 option(ENABLE_EXTERNAL_PLUGINS "Enable loading of externally built Rime plugins (from directory set by RIME_PLUGINS_DIR variable)" OFF)
+option(ENABLE_THREADING "Enable threading for deployer" ON)
 
 set(RIME_DATA_DIR "${CMAKE_INSTALL_FULL_DATADIR}/rime-data" CACHE STRING "Target directory for Rime data")
 set(RIME_PLUGINS_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/rime-plugins" CACHE STRING "Target directory for externally built Rime plugins")
@@ -96,6 +97,10 @@ if(ENABLE_LOGGING)
 endif()
 
 find_package(Threads)
+
+if(NOT ENABLE_THREADING)
+  add_definitions(-DRIME_NO_THREADING)
+endif()
 
 if(BUILD_TEST)
   find_package(GTest REQUIRED)

--- a/src/rime/deployer.cc
+++ b/src/rime/deployer.cc
@@ -106,10 +106,15 @@ bool Deployer::StartWork(bool maintenance_mode) {
   if (pending_tasks_.empty()) {
     return false;
   }
+#ifdef RIME_NO_THREADING
+  LOG(INFO) << "running " << pending_tasks_.size() << " tasks in main thread.";
+  return Run();
+#else
   LOG(INFO) << "starting work thread for " << pending_tasks_.size()
             << " tasks.";
   work_ = std::async(std::launch::async, [this] { Run(); });
   return work_.valid();
+#endif
 }
 
 bool Deployer::StartMaintenance() {


### PR DESCRIPTION
## Pull request

#### Issue tracker

#### Feature

Upstream a [patch](https://github.com/LibreService/my_rime/blob/a42f35e08b45120a082c1a95d33877cff55a9af1/librime_patch#L13-L24) to a CMake option.
This is necessary for deploying in wasm. Ref: https://github.com/emscripten-core/emscripten/issues/8988

#### Unit test
- [ ] Done

#### Manual test
- [x] Done on both Linux x64 and wasm.

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
