### PR TITLE
feat: Add support to format the input after caret_pos

### DIFF
--- a/src/rime/composition.cc
+++ b/src/rime/composition.cc
@@ -79,7 +79,9 @@ Preedit Composition::GetPreedit(const string& full_input,
     preedit.caret_pos = preedit.text.length();
   }
   if (end < full_input.length()) {
-    preedit.text += full_input.substr(end);
+    string result = full_input.substr(end);
+    const_cast<Composition *>(this)->preedit_formatter().Apply(&result);
+    preedit.text += result;
   }
   // insert soft cursor and prompt string.
   auto prompt = caret + GetPrompt();

--- a/src/rime/composition.h
+++ b/src/rime/composition.h
@@ -8,6 +8,7 @@
 #define RIME_COMPOSITION_H_
 
 #include <rime/segmentation.h>
+#include <rime/algo/algebra.h>
 
 namespace rime {
 
@@ -32,6 +33,10 @@ class Composition : public Segmentation {
   string GetDebugText() const;
   // Returns text of the last segment before the given position.
   string GetTextBefore(size_t pos) const;
+  void set_preedit_format(an<ConfigList> patterns){ preedit_formatter_.Load(patterns); }
+  Projection preedit_formatter() { return preedit_formatter_; }
+protected:
+  Projection preedit_formatter_;
 };
 
 }  // namespace rime

--- a/src/rime/context.cc
+++ b/src/rime/context.cc
@@ -292,4 +292,8 @@ void Context::ClearTransientOptions() {
   }
 }
 
+void Context::SetPreeditFormat(an<ConfigList> patterns) {
+  composition_.set_preedit_format(patterns);
+}
+
 }  // namespace rime

--- a/src/rime/context.h
+++ b/src/rime/context.h
@@ -88,6 +88,8 @@ class Context {
   }
   KeyEventNotifier& unhandled_key_notifier() { return unhandled_key_notifier_; }
 
+  void SetPreeditFormat(an<ConfigList> patterns);
+
  private:
   string GetSoftCursor() const;
   bool DeleteCandidate(function<an<Candidate>(Segment& seg)> get_candidate);

--- a/src/rime_api.cc
+++ b/src/rime_api.cc
@@ -239,6 +239,12 @@ RIME_API Bool RimeGetContext(RimeSessionId session_id, RimeContext* context) {
   if (!ctx)
     return False;
   if (ctx->IsComposing()) {
+    Schema* schema = session->schema();
+    if (schema) {
+      Config* config = schema->config();
+      an<ConfigList> preedit_format = config->GetList("input/preedit_format");
+      ctx->SetPreeditFormat(preedit_format);
+    }
     Preedit preedit = ctx->GetPreedit();
     context->composition.length = preedit.text.length();
     context->composition.preedit = new char[preedit.text.length() + 1];


### PR DESCRIPTION
Log: Add support to format the input after caret_pos,
     add a set of parameter in schema, input/preedit_format

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #454 

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
