### PR TITLE
Fix a potential race condition of MaybeCreateDirectory

### DIFF
--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -258,14 +258,16 @@ SchemaUpdate::SchemaUpdate(TaskInitializer arg) : verbose_(false) {
 }
 
 static bool MaybeCreateDirectory(fs::path dir) {
-  if (!fs::exists(dir)) {
-    boost::system::error_code ec;
-    if (!fs::create_directories(dir, ec)) {
-      LOG(ERROR) << "error creating directory '" << dir.string() << "'.";
-      return false;
-    }
+  boost::system::error_code ec;
+  if (fs::create_directories(dir, ec)) {
+    return true;
   }
-  return true;
+  
+  if (fs::exists(dir)) {
+    return true;
+  }
+  LOG(ERROR) << "error creating directory '" << dir.string() << "'.";
+  return false;
 }
 
 static bool RemoveVersionSuffix(string* version, const string& suffix) {

--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -262,7 +262,7 @@ static bool MaybeCreateDirectory(fs::path dir) {
   if (fs::create_directories(dir, ec)) {
     return true;
   }
-  
+
   if (fs::exists(dir)) {
     return true;
   }


### PR DESCRIPTION
If a directory is being created by two threads at the same time, it is possible that one succeed while the other fails. This change the order of create & check, so no matter which thread create the directory first, it will always succeed in the end.

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
