### PR TITLE
perf: replace rbtree with vector of pair

### DIFF
--- a/src/rime/dict/entry_collector.h
+++ b/src/rime/dict/entry_collector.h
@@ -23,8 +23,10 @@ struct RawDictEntry {
 
 // code -> weight
 using WeightMap = map<string, double>;
-// word -> { code -> weight }
-using WordMap = hash_map<string, WeightMap>;
+// word -> [ { code, weight } ]
+// For the sake of memory usage, don't use word -> { code -> weight } as there
+// may be many words, but may not be many representations for a word
+using WordMap = hash_map<string, vector<pair<string, double>>>;
 // [ (word, weight), ... ]
 using EncodeQueue = std::queue<pair<string, string>>;
 


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature

There are many words, but for each word there aren't many representations. Using map is correct in algorithm but bad in this reality. Too many small rbtrees.

#### Unit test
- [ ] Done

#### Manual test
- [x] Done

200MB less peak memory usage for building https://github.com/miounet/rime-kmm-big (3.1GB -> 2.9GB), tested with heaptrack twice.

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
