### PR TITLE
fix backspace and navigation keys with caps lock on

### DIFF
--- a/src/rime/key_event.h
+++ b/src/rime/key_event.h
@@ -23,7 +23,7 @@ class KeyEvent {
 
   int keycode() const { return keycode_; }
   void keycode(int value) { keycode_ = value; }
-  int modifier() const { return modifier_; }
+  int modifier() const { return (modifier_ & ~kLockMask); }
   void modifier(int value) { modifier_ = value; }
 
   bool shift() const { return (modifier_ & kShiftMask) != 0; }
@@ -41,13 +41,14 @@ class KeyEvent {
   RIME_API bool Parse(const string& repr);
 
   bool operator==(const KeyEvent& other) const {
-    return keycode_ == other.keycode_ && modifier_ == other.modifier_;
+    return (keycode_ == other.keycode_) &&
+           ((modifier_ & ~kLockMask) == (other.modifier_ & ~kLockMask));
   }
 
   bool operator<(const KeyEvent& other) const {
     if (keycode_ != other.keycode_)
       return keycode_ < other.keycode_;
-    return modifier_ < other.modifier_;
+    return (modifier_ & ~kLockMask) < (other.modifier_ & ~kLockMask);
   }
 
  private:


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Fix bugs where backspace and navigation keys are not correctly interpreted when caps lock is on.  This is particularly problematic in non-inline mode: letters and punctuators are correctly inputed into rime while control actions happen outside of rime directly in the text area of the client app. This pull simply dismisses cap lock as a modifier except when it's used to toggle ascii mode (capitalization is done by system before feeding into rime).

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
