### PR TITLE
fixed: opencc does not work under Windows, when opencc files in a path code page incompatible with UTF-8.

### DIFF
--- a/src/rime/gear/simplifier.cc
+++ b/src/rime/gear/simplifier.cc
@@ -25,6 +25,11 @@
 #include <opencc/Dict.hpp>
 #include <opencc/DictEntry.hpp>
 
+#ifdef WIN32
+#include <opencc/UTF8Util.hpp>
+namespace fs = boost::filesystem;
+#endif
+
 static const char* quote_left = "\xe3\x80\x94";   //"\xef\xbc\x88";
 static const char* quote_right = "\xe3\x80\x95";  //"\xef\xbc\x89";
 
@@ -36,7 +41,14 @@ class Opencc {
     LOG(INFO) << "initializing opencc: " << config_path;
     opencc::Config config;
     try {
+      // windows config_path in CP_ACP, convert it to UTF-8
+#ifdef WIN32
+      fs::path path{config_path};
+      converter_ =
+          config.NewFromFile(opencc::UTF8Util::U16ToU8(path.wstring()));
+#else
       converter_ = config.NewFromFile(config_path);
+#endif /*  WIN32 */
       const list<opencc::ConversionPtr> conversions =
           converter_->GetConversionChain()->GetConversions();
       dict_ = conversions.front()->GetDict();


### PR DESCRIPTION

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

under Windows, with weasel, user_dir and shared_dir encoded in CP_ACP ( depend on code page setting ), if opencc file in those paths with NONE ASCII code (for example with simplified Chinese Windows code page CP936, user_dir with chinese characters ), it will make opencc hanged.

#### Feature
Describe feature of pull request

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
