### PR TITLE
perf: release memory of temporary fields

### DIFF
--- a/src/rime/dict/entry_collector.cc
+++ b/src/rime/dict/entry_collector.cc
@@ -147,6 +147,9 @@ void EntryCollector::Finish() {
       }
     }
   }
+  decltype(collection)().swap(collection);
+  decltype(words)().swap(words);
+  decltype(total_weight)().swap(total_weight);
   LOG(INFO) << "Pass 3: total " << num_entries << " entries collected.";
 }
 


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
The 3 fields are no longer used after `Finish()`.

#### Unit test
- [ ] Done

#### Manual test
- [x] Done with all rime's official schemas to make sure reverse.bin and table.bin unchanged.

800MB less peak memory usage for building https://github.com/miounet/rime-kmm-big (2.9GB -> 2.1GB), tested with heaptrack.

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
