### PR TITLE
drop BOOST_USE_CXX11; fix 2 cmake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/c_flag_overrides.cmake)
 set(CMAKE_USER_MAKE_RULES_OVERRIDE_CXX ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cxx_flag_overrides.cmake)
 
-project(rime)
 cmake_minimum_required(VERSION 3.12)
+project(rime)
 set(CMAKE_CXX_STANDARD 14)
 
 set(rime_version 1.8.5)
@@ -20,7 +20,6 @@ option(BUILD_SAMPLE "Build sample Rime plugin" OFF)
 option(BUILD_TEST "Build and run tests" ON)
 option(BUILD_SEPARATE_LIBS "Build separate rime-* libraries" OFF)
 option(ENABLE_LOGGING "Enable logging with google-glog library" ON)
-option(BOOST_USE_CXX11 "Boost has been built with C++11 support" OFF)
 option(BOOST_USE_SIGNALS2 "Boost use signals2 instead of signals" ON)
 option(ENABLE_ASAN "Enable Address Sanitizer (Unix Only)" OFF)
 option(INSTALL_PRIVATE_HEADERS "Install private headers (usually needed for externally built Rime plugins)" OFF)
@@ -57,10 +56,6 @@ set(YamlCpp_STATIC ${BUILD_STATIC})
 set(Boost_USE_MULTITHREADED ON)
 if(MSVC)
   set(Boost_USE_STATIC_RUNTIME ON)
-endif()
-
-if(NOT BOOST_USE_CXX11)
-  add_definitions("-DBOOST_NO_CXX11_SCOPED_ENUMS")
 endif()
 
 set(BOOST_COMPONENTS filesystem regex system)

--- a/build.bat
+++ b/build.bat
@@ -271,7 +271,6 @@ set rime_cmake_flags=%common_cmake_flags%^
  -DBUILD_SHARED_LIBS=%build_shared%^
  -DBUILD_TEST=%build_test%^
  -DENABLE_LOGGING=%enable_logging%^
- -DBOOST_USE_CXX11=ON^
  -DCMAKE_CONFIGURATION_TYPES="%build_config%"^
  -DCMAKE_INSTALL_PREFIX:PATH="%RIME_ROOT%\dist"
 

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
+project(marisa)
 
 # libmarisa
 


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
* Drop the `BOOST_USE_CXX11` cmake option as it's 2023.
* Fix cmake warning of wrong command order.
![Screenshot from 2023-08-19 23-13-53](https://github.com/rime/librime/assets/26783539/946f4c78-3126-4999-9e59-e7e2e05b8c24)
* Fix cmake warning of `project` missing. This is not tested here because linux ci uses system library and windows/macos ci caches dependencies, but I tested locally with My RIME.
![Screenshot from 2023-08-19 23-16-39](https://github.com/rime/librime/assets/26783539/02057b24-e179-4acf-8fcf-5eebdfe4a339)


#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
