### PR TITLE
upgrade boost to 1.83

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -16,8 +16,8 @@ jobs:
   build:
     runs-on: macos-latest
     env:
-      boost_version: 1.78.0
-      BOOST_ROOT: ${{ github.workspace }}/deps/boost_1_78_0
+      boost_version: 1.83.0
+      BOOST_ROOT: ${{ github.workspace }}/deps/boost_1_83_0
       RIME_PLUGINS: ${{ inputs.rime_plugins }}
     steps:
       - name: Checkout last commit

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -13,8 +13,8 @@ jobs:
   build:
     runs-on: windows-latest
     env:
-      boost_version: 1.78.0
-      BOOST_ROOT: ${{ github.workspace }}\deps\boost_1_78_0
+      boost_version: 1.83.0
+      BOOST_ROOT: ${{ github.workspace }}\deps\boost_1_83_0
       RIME_PLUGINS: ${{ inputs.rime_plugins }}
     steps:
       - name: Checkout last commit

--- a/README-mac.md
+++ b/README-mac.md
@@ -38,7 +38,7 @@ Set shell variable `BOOST_ROOT` to the path to `boost_<version>` directory prior
 to building librime.
 
 ``` sh
-export BOOST_ROOT="$(pwd)/deps/boost_1_78_0"
+export BOOST_ROOT="$(pwd)/deps/boost_1_83_0"
 ```
 
 **Option 2:** Install Boost libraries from Homebrew.

--- a/env.bat.template
+++ b/env.bat.template
@@ -3,7 +3,7 @@ rem Customize your build environment and save the modified copy to env.bat
 set RIME_ROOT=%CD%
 
 rem REQUIRED: path to Boost source directory
-if not defined BOOST_ROOT set BOOST_ROOT=%RIME_ROOT%\deps\boost_1_78_0
+if not defined BOOST_ROOT set BOOST_ROOT=%RIME_ROOT%\deps\boost_1_83_0
 
 rem architecture, Visual Studio version and platform toolset
 set ARCH=Win32

--- a/env.vs2019.bat
+++ b/env.vs2019.bat
@@ -3,7 +3,7 @@ rem Customize your build environment and save the modified copy to env.bat
 set RIME_ROOT=%CD%
 
 rem REQUIRED: path to Boost source directory
-if not defined BOOST_ROOT set BOOST_ROOT=%RIME_ROOT%\deps\boost_1_78_0
+if not defined BOOST_ROOT set BOOST_ROOT=%RIME_ROOT%\deps\boost_1_83_0
 
 rem architecture, Visual Studio version and platform toolset
 set ARCH=Win32

--- a/env.vs2022.bat
+++ b/env.vs2022.bat
@@ -3,7 +3,7 @@ rem Customize your build environment and save the modified copy to env.bat
 set RIME_ROOT=%CD%
 
 rem REQUIRED: path to Boost source directory
-if not defined BOOST_ROOT set BOOST_ROOT=%RIME_ROOT%\deps\boost_1_78_0
+if not defined BOOST_ROOT set BOOST_ROOT=%RIME_ROOT%\deps\boost_1_83_0
 
 rem architecture, Visual Studio version and platform toolset
 set ARCH=Win32

--- a/install-boost.bat
+++ b/install-boost.bat
@@ -2,7 +2,7 @@ setlocal
 
 if not defined RIME_ROOT set RIME_ROOT=%CD%
 
-if not defined boost_version set boost_version=1.78.0
+if not defined boost_version set boost_version=1.83.0
 set boost_x_y_z=%boost_version:.=_%
 
 if not defined BOOST_ROOT set BOOST_ROOT=%RIME_ROOT%\deps\boost_%boost_x_y_z%

--- a/install-boost.sh
+++ b/install-boost.sh
@@ -3,15 +3,15 @@ set -ex
 
 RIME_ROOT="$(cd "$(dirname "$0")"; pwd)"
 
-boost_version="${boost_version=1.78.0}"
+boost_version="${boost_version=1.83.0}"
 boost_x_y_z="${boost_version//./_}"
 
 BOOST_ROOT="${BOOST_ROOT=${RIME_ROOT}/deps/boost_${boost_x_y_z}}"
 
 boost_tarball="boost_${boost_x_y_z}.tar.bz2"
 download_url="https://boostorg.jfrog.io/artifactory/main/release/${boost_version}/source/${boost_tarball}"
-boost_tarball_sha256sum_1_78_0='8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc  boost_1_78_0.tar.bz2'
-boost_tarball_sha256sum="${boost_tarball_sha256sum=${boost_tarball_sha256sum_1_78_0}}"
+boost_tarball_sha256sum_1_83_0='6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e  boost_1_83_0.tar.bz2'
+boost_tarball_sha256sum="${boost_tarball_sha256sum=${boost_tarball_sha256sum_1_83_0}}"
 
 download_boost_source() {
     cd "${RIME_ROOT}/deps"


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature

1.78 is a bit old. When I build librime with clang on Windows, clang 15 produces tons of warning, and clang 16 refuses to build.

![image](https://github.com/rime/librime/assets/26783539/91f8bc53-84c0-49b6-bba7-a854202a9b30)

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
