### PR TITLE
Fix build error of deprecated api

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ else()
   set(BOOST_COMPONENTS ${BOOST_COMPONENTS} signals)
 endif()
 
-find_package(Boost 1.46.0 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
+find_package(Boost 1.74.0 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 if(Boost_FOUND)
   include_directories(${Boost_INCLUDE_DIRS})
   link_directories(${Boost_LIBRARY_DIRS})

--- a/src/rime/lever/customizer.cc
+++ b/src/rime/lever/customizer.cc
@@ -89,7 +89,7 @@ bool Customizer::UpdateConfigFile() {
   if (redistribute || (is_dirty && !missing_original_copy)) {
     try {
       fs::copy_file(source_path_, dest_path_,
-                    fs::copy_option::overwrite_if_exists);
+                    fs::copy_options::overwrite_existing);
     } catch (...) {
       LOG(ERROR) << "Error copying config file '" << source_path_.string()
                  << "' to user directory.";

--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -562,7 +562,7 @@ bool BackupConfigFiles::Run(Deployer* deployer) {
       continue;
     }
     boost::system::error_code ec;
-    fs::copy_file(entry, backup, fs::copy_option::overwrite_if_exists, ec);
+    fs::copy_file(entry, backup, fs::copy_options::overwrite_existing, ec);
     if (ec) {
       LOG(ERROR) << "error backing up file " << backup.string();
       ++failure;


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Build failed on Trime procject with boost 1.83.0

```
/trime/app/src/main/jni/librime/src/rime/lever/customizer.cc:91:11: error: 'copy_file' is deprecated: Use copy_options instead of copy_option [-Werror,-Wdeprecated-declarations]
```
#### Feature
Describe feature of pull request

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
