### PR TITLE
feat: Allow reverse_lookup_filter to append new codes to existing comments

### DIFF
--- a/src/rime/gear/reverse_lookup_filter.cc
+++ b/src/rime/gear/reverse_lookup_filter.cc
@@ -53,6 +53,7 @@ void ReverseLookupFilter::Initialize() {
   }
   if (Config* config = engine_->schema()->config()) {
     config->GetBool(name_space_ + "/overwrite_comment", &overwrite_comment_);
+    config->GetBool(name_space_ + "/append_comment", &append_comment_);
     comment_formatter_.Load(config->GetList(name_space_ + "/comment_format"));
   }
 }
@@ -69,7 +70,7 @@ an<Translation> ReverseLookupFilter::Apply(an<Translation> translation,
 }
 
 void ReverseLookupFilter::Process(const an<Candidate>& cand) {
-  if (!overwrite_comment_ && !cand->comment().empty())
+  if (!cand->comment().empty() && !(overwrite_comment_ || append_comment_))
     return;
   auto phrase = As<Phrase>(Candidate::GetGenuineCandidate(cand));
   if (!phrase)
@@ -78,7 +79,11 @@ void ReverseLookupFilter::Process(const an<Candidate>& cand) {
   if (rev_dict_->ReverseLookup(phrase->text(), &codes)) {
     comment_formatter_.Apply(&codes);
     if (!codes.empty()) {
-      phrase->set_comment(codes);
+      if (overwrite_comment_) {
+        phrase->set_comment(codes);
+      } else if (append_comment_) {
+        phrase->set_comment(cand->comment() + " " + codes);
+      }
     }
   }
 }

--- a/src/rime/gear/reverse_lookup_filter.h
+++ b/src/rime/gear/reverse_lookup_filter.h
@@ -34,6 +34,7 @@ class ReverseLookupFilter : public Filter, TagMatching {
   the<ReverseLookupDictionary> rev_dict_;
   // settings
   bool overwrite_comment_ = false;
+  bool append_comment_ = false;
   Projection comment_formatter_;
 };
 


### PR DESCRIPTION
## Pull request

#### Issue tracker
None

#### Feature
Allows `reverse_lookup_filter` to append new information to existing comments, instead of just ignoring or overwriting them. Before this PR, the user has to discard some information when the comment and the new codes are not empty.

This PR introduces a new option `append_comment`, akin to the existing `overwrite_comment`.
- If `append_comment` is `true`, the newly found codes are appended to the existing comments (separated with a space). 
- If both `append_comment` and `overwrite_comment` are true, `overwrite_comment` takes priority, ie. the existing comments are discarded.

#### Unit test
- [ ] Done

Not sure where to put the test? I'd be happy to add tests, should there be any guidance.

#### Manual test
- [x] Done

<img width="577" alt="image" src="https://github.com/rime/librime/assets/23358293/91be38ee-9db7-4bb3-9aeb-d97064e95a27">


#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
