### PR TITLE
Fix a regression in reverse_lookup_filter introduced in #699 

### DIFF
--- a/src/rime/gear/reverse_lookup_filter.cc
+++ b/src/rime/gear/reverse_lookup_filter.cc
@@ -79,11 +79,9 @@ void ReverseLookupFilter::Process(const an<Candidate>& cand) {
   if (rev_dict_->ReverseLookup(phrase->text(), &codes)) {
     comment_formatter_.Apply(&codes);
     if (!codes.empty()) {
-      if (!overwrite_comment_ && !append_comment_ && cand->comment().empty()) {
+      if (overwrite_comment_ || cand->comment().empty()) {
         phrase->set_comment(codes);
-      } else if (overwrite_comment_) {
-        phrase->set_comment(codes);
-      } else if (append_comment_) {
+      } else {
         phrase->set_comment(cand->comment() + " " + codes);
       }
     }

--- a/src/rime/gear/reverse_lookup_filter.cc
+++ b/src/rime/gear/reverse_lookup_filter.cc
@@ -79,7 +79,9 @@ void ReverseLookupFilter::Process(const an<Candidate>& cand) {
   if (rev_dict_->ReverseLookup(phrase->text(), &codes)) {
     comment_formatter_.Apply(&codes);
     if (!codes.empty()) {
-      if (overwrite_comment_) {
+      if (!overwrite_comment_ && !append_comment_ && cand->comment().empty()) {
+        phrase->set_comment(codes);
+      } else if (overwrite_comment_) {
         phrase->set_comment(codes);
       } else if (append_comment_) {
         phrase->set_comment(cand->comment() + " " + codes);


### PR DESCRIPTION
## Pull request

#### Issue tracker
Reported by @eagleoflqj ; Fix a regression introduced by #699 

#699 mistakenly assumed at least one of `append_comment` and `overwrite_comment` is true, and will break the old behavior. This PR fixes this.

Sorry for my mistake :(

#### Feature

#### Unit test
- [ ] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
