### PR TITLE
ci: use clang 16 for macOS

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Configure build environment
         run: |
+          brew install llvm
+          echo "/usr/local/opt/llvm/bin" >> $GITHUB_PATH
           echo git_ref_name="$(git describe --always)" >> $GITHUB_ENV
 
       - name: Configure build variant


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature

Before: [release CI](https://github.com/rime/librime/actions/runs/6064923382/job/16453870343) for https://github.com/rime/librime/commit/9e9141864fc5a63e8738d5f994cea7c976f080af
boost's locale isn't built under Apple Clang 14.
![Screenshot from 2023-09-03 19-29-36](https://github.com/rime/librime/assets/26783539/126b1c00-6969-41cf-9619-58cd2fb5867d)

After: [release CI](https://github.com/rime/librime/actions/runs/6067082076/job/16458343630) for https://github.com/rime/librime/commit/37d6e922d3c161b2ccf59fc208246089395a833d
boost's locale is built under Homebrew Clang 16.
![Screenshot from 2023-09-03 19-32-54](https://github.com/rime/librime/assets/26783539/e3b3e957-535b-4aac-a58f-ce5c8778bd37)

These behaviors are the same in my local macOS x64 13.5.1
#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
