### PR TITLE
ci: build boost::locale for charcode in clang win

### DIFF
--- a/README-windows.md
+++ b/README-windows.md
@@ -5,15 +5,9 @@
 `librime` is tested to work on Windows with the following combinations of build
 tools and libraries:
 
-  - Visual Studio 2017
-  - [Boost](http://www.boost.org/)=1.64
-  - [cmake](http://www.cmake.org/)>=3.8
-
-and
-
-  - Visual Studio 2015
-  - [Boost](http://www.boost.org/)=1.60
-  - [cmake](http://www.cmake.org/)>=3.8
+  - Visual Studio 2022 or LLVM 16
+  - [Boost](http://www.boost.org/)=1.83
+  - [cmake](http://www.cmake.org/)>=3.10
 
 Boost and cmake versions need to match higher VS version.
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Follow the instructions to build librime on platforms other than Linux:
 Build dependencies
 ---
   - compiler with C++14 support
-  - cmake>=2.8
-  - libboost>=1.48
+  - cmake>=3.10
+  - libboost>=1.74
   - libglog (optional)
   - libleveldb
   - libmarisa
@@ -126,3 +126,4 @@ Contributors
   - [jakwings](https://github.com/jakwings)
   - [Prcuvu](https://github.com/Prcuvu)
   - [hchunhui](https://github.com/hchunhui)
+  - [Qijia Liu](https://github.com/eagleoflqj)

--- a/build-clang.bat
+++ b/build-clang.bat
@@ -57,6 +57,7 @@ if %build_boost% == 1 (
     link=static^
     runtime-link=static^
     stage^
+    --with-locale^
     --with-filesystem^
     --with-system^
     --with-regex || exit


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature

Simply add the build target for charcode plugin.
Before: [release CI](https://github.com/rime/librime/actions/runs/6064923382/job/16453870294) for https://github.com/rime/librime/commit/9e9141864fc5a63e8738d5f994cea7c976f080af
![Screenshot from 2023-09-03 23-58-14](https://github.com/rime/librime/assets/26783539/a3da65db-1a70-4701-9622-edaa57b3ca22)

After: [release CI](https://github.com/rime/librime/actions/runs/6068513313/job/16461568173) for https://github.com/rime/librime/commit/024651cfbf567f1a24f1394fbafbca86e131a70c
![Screenshot from 2023-09-03 23-59-12](https://github.com/rime/librime/assets/26783539/e2fe2327-2e9d-4332-b98b-c9b9a580e9bc)


#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
