### PR TITLE
chain conversion

### DIFF
--- a/src/rime/gear/simplifier.cc
+++ b/src/rime/gear/simplifier.cc
@@ -83,15 +83,15 @@ class Opencc {
           for (const char* wstr = original_word.c_str(); *wstr != '\0';) {
             opencc::Optional<const opencc::DictEntry*> matched =
                 dict->MatchPrefix(wstr);
-            size_t matchedLength;
+            size_t matched_length;
             if (matched.IsNull()) {
-              matchedLength = opencc::UTF8Util::NextCharLength(wstr);
-              buffer << opencc::UTF8Util::FromSubstr(wstr, matchedLength);
+              matched_length = opencc::UTF8Util::NextCharLength(wstr);
+              buffer << opencc::UTF8Util::FromSubstr(wstr, matched_length);
             } else {
-              matchedLength = matched.Get()->KeyLength();
+              matched_length = matched.Get()->KeyLength();
               buffer << matched.Get()->GetDefault();
             }
-            wstr += matchedLength;
+            wstr += matched_length;
           }
           const string& converted_word = buffer.str();
           // Even if current dictionary doesn't convert the word
@@ -136,16 +136,16 @@ class Opencc {
       for (const char* pstr = phrase; *pstr != '\0';) {
         opencc::Optional<const opencc::DictEntry*> matched =
             dict->MatchPrefix(pstr);
-        size_t matchedLength;
+        size_t matched_length;
         if (matched.IsNull()) {
-          matchedLength = opencc::UTF8Util::NextCharLength(pstr);
-          buffer << opencc::UTF8Util::FromSubstr(pstr, matchedLength);
+          matched_length = opencc::UTF8Util::NextCharLength(pstr);
+          buffer << opencc::UTF8Util::FromSubstr(pstr, matched_length);
         } else {
-          matchedLength = matched.Get()->KeyLength();
+          matched_length = matched.Get()->KeyLength();
           size_t i = rand() % (matched.Get()->NumValues());
           buffer << matched.Get()->Values().at(i);
         }
-        pstr += matchedLength;
+        pstr += matched_length;
       }
       *simplified = buffer.str();
       phrase = simplified->c_str();

--- a/src/rime/gear/simplifier.cc
+++ b/src/rime/gear/simplifier.cc
@@ -76,11 +76,30 @@ class Opencc {
         opencc::Optional<const opencc::DictEntry*> item =
             dict->Match(original_word);
         if (item.IsNull()) {
-          // Current dictionary doesn't convert the word. We need to keep it for
-          // other dicts in the chain. e.g. s2t.json expands 里 to 里 and 裏,
-          // then t2tw.json passes 里 as-is and converts 裏 to 裡.
-          if (word_set.insert(original_word).second) {
-            converted_words.push_back(original_word);
+          // There is no exact match, but still need to convert partially
+          // matched in a chain conversion. Here apply default (max. seg.)
+          // match to get the most probable conversion result
+          std::ostringstream buffer;
+          for (const char* wstr = original_word.c_str(); *wstr != '\0';) {
+            opencc::Optional<const opencc::DictEntry*> matched =
+                dict->MatchPrefix(wstr);
+            size_t matchedLength;
+            if (matched.IsNull()) {
+              matchedLength = opencc::UTF8Util::NextCharLength(wstr);
+              buffer << opencc::UTF8Util::FromSubstr(wstr, matchedLength);
+            } else {
+              matchedLength = matched.Get()->KeyLength();
+              buffer << matched.Get()->GetDefault();
+            }
+            wstr += matchedLength;
+          }
+          const string& converted_word = buffer.str();
+          // Even if current dictionary doesn't convert the word
+          // (converted_word == original_word), we still need to keep it for
+          // subsequent dicts in the chain. e.g. s2t.json expands 里 to 里 and
+          // 裏, then t2tw.json passes 里 as-is and converts 裏 to 裡.
+          if (word_set.insert(converted_word).second) {
+            converted_words.push_back(converted_word);
           }
           continue;
         }
@@ -105,23 +124,32 @@ class Opencc {
   bool RandomConvertText(const string& text, string* simplified) {
     if (dict_ == nullptr)
       return false;
+    const list<opencc::ConversionPtr> conversions =
+        converter_->GetConversionChain()->GetConversions();
     const char* phrase = text.c_str();
-    std::ostringstream buffer;
-    for (const char* pstr = phrase; *pstr != '\0';) {
-      opencc::Optional<const opencc::DictEntry*> matched =
-          dict_->MatchPrefix(pstr);
-      size_t matchedLength;
-      if (matched.IsNull()) {
-        matchedLength = opencc::UTF8Util::NextCharLength(pstr);
-        buffer << opencc::UTF8Util::FromSubstr(pstr, matchedLength);
-      } else {
-        matchedLength = matched.Get()->KeyLength();
-        size_t i = rand() % (matched.Get()->NumValues());
-        buffer << matched.Get()->Values().at(i);
+    for (auto conversion : conversions) {
+      opencc::DictPtr dict = conversion->GetDict();
+      if (dict == nullptr) {
+        return false;
       }
-      pstr += matchedLength;
+      std::ostringstream buffer;
+      for (const char* pstr = phrase; *pstr != '\0';) {
+        opencc::Optional<const opencc::DictEntry*> matched =
+            dict->MatchPrefix(pstr);
+        size_t matchedLength;
+        if (matched.IsNull()) {
+          matchedLength = opencc::UTF8Util::NextCharLength(pstr);
+          buffer << opencc::UTF8Util::FromSubstr(pstr, matchedLength);
+        } else {
+          matchedLength = matched.Get()->KeyLength();
+          size_t i = rand() % (matched.Get()->NumValues());
+          buffer << matched.Get()->Values().at(i);
+        }
+        pstr += matchedLength;
+      }
+      *simplified = buffer.str();
+      phrase = simplified->c_str();
     }
-    *simplified = buffer.str();
     return *simplified != text;
   }
 


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #652 , improves #688 

#### Feature
Improve chain conversion #688 . Specifically, this PR corrects the mistake that chain conversion only converts EXACT matched string while ignoring partially matched conversions.
E.g. previously, the exact matching results in `才能 (zh-Hans) -> 才能 & 纔能 (zh-Hant) -> 才能 & 纔能 (zh-TW, zh-HK)`, because it starts with exactly-matched `才能 (zh-Hans) -> 才能 & 纔能 (zh-Hant)`, then ignores the partially-matched rule of `纔 (zh-Hant) -> 才 (zh-TW, zh-HK) `. Now the conversion can get the correct result: `才能 (zh-Hans) -> 才能 & 纔能 (zh-Hant) -> 才能 (zh-TW, zh-HK)`

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
