### PR TITLE
allow only logging to stderr with minloglevel

### DIFF
--- a/src/rime/setup.cc
+++ b/src/rime/setup.cc
@@ -80,7 +80,11 @@ RIME_API void SetupLogging(const char* app_name,
   FLAGS_minloglevel = min_log_level;
   FLAGS_alsologtostderr = true;
   if (log_dir) {
-    FLAGS_log_dir = log_dir;
+    if (log_dir[0] == '\0') {
+      FLAGS_logtostderr = true;
+    } else {
+      FLAGS_log_dir = log_dir;
+    }
   }
   // Do not allow other users to read/write log files created by current
   // process.

--- a/src/rime_api.h
+++ b/src/rime_api.h
@@ -94,6 +94,7 @@ typedef struct rime_traits_t {
   int min_log_level;
   /*! Directory of log files.
    *  Value is passed to Glog library using FLAGS_log_dir variable.
+   *  NULL means temporary directory, and "" means only writing to stderr.
    */
   const char* log_dir;
   //! prebuilt data directory. defaults to ${shared_data_dir}/build


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #727

#### Feature
Before:
If `app_name` not provided, only log to stderr, `min_log_level` doesn't work at all.
If `app_name` provided, log to both stderr and file (if `log_dir` not provided, use temporary dir).

After:
If `app_name` provided and provide `log_dir` as empty string, log only to stderr with `min_log_level` working.

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
