### PR TITLE
CleanOldLogFiles respects log_dir

### DIFF
--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -617,26 +617,21 @@ bool CleanupTrash::Run(Deployer* deployer) {
 }
 
 bool CleanOldLogFiles::Run(Deployer* deployer) {
+  bool success = true;
+#ifdef RIME_ENABLE_LOGGING
+  if (FLAGS_logtostderr) {
+    return success;
+  }
+
   char ymd[12] = {0};
   time_t now = time(NULL);
   strftime(ymd, sizeof(ymd), ".%Y%m%d", localtime(&now));
   string today(ymd);
   DLOG(INFO) << "today: " << today;
 
-  vector<string> dirs;
-#ifdef RIME_ENABLE_LOGGING
-#ifdef _WIN32
-  // work-around: google::GetExistingTempDirectories crashes on windows 7
-  char tmp[MAX_PATH];
-  if (GetTempPathA(MAX_PATH, tmp))
-    dirs.push_back(tmp);
-#else
-  google::GetExistingTempDirectories(&dirs);
-#endif  // _WIN32
-#endif  // RIME_ENABLE_LOGGING
+  vector<string> dirs = google::GetLoggingDirectories();
   DLOG(INFO) << "scanning " << dirs.size() << " temp directory for log files.";
 
-  bool success = true;
   int removed = 0;
   for (auto i = dirs.cbegin(); i != dirs.cend(); ++i) {
     DLOG(INFO) << "temp directory: " << *i;
@@ -660,6 +655,7 @@ bool CleanOldLogFiles::Run(Deployer* deployer) {
   if (removed != 0) {
     LOG(INFO) << "cleaned " << removed << " log files.";
   }
+#endif  // RIME_ENABLE_LOGGING
   return success;
 }
 


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #726

#### Feature
* If log disabled or only log to stderr, do not perform clean.
* Otherwise, respect log_dir instead of always searching temporary directories.

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
