### PR TITLE
CleanOldLogFiles doesn't scan cwd when no log_dir

### DIFF
--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -629,7 +629,15 @@ bool CleanOldLogFiles::Run(Deployer* deployer) {
   string today(ymd);
   DLOG(INFO) << "today: " << today;
 
-  vector<string> dirs = google::GetLoggingDirectories();
+  vector<string> dirs;
+  // Don't call GetLoggingDirectories as it contains current directory,
+  // which causes permission issue on Android
+  // https://github.com/google/glog/blob/b58718f37cf58fa17f48bf1d576974d133d89839/src/logging.cc#L2410
+  if (FLAGS_log_dir.empty()) {
+    google::GetExistingTempDirectories(&dirs);
+  } else {
+    dirs.push_back(FLAGS_log_dir);
+  }
   DLOG(INFO) << "scanning " << dirs.size() << " temp directory for log files.";
 
   int removed = 0;


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
