### PR TITLE
Update charset_filter.cc

### DIFF
--- a/src/rime/gear/charset_filter.cc
+++ b/src/rime/gear/charset_filter.cc
@@ -24,6 +24,7 @@ bool is_extended_cjk(uint32_t ch) {
       (ch >= 0x2CEB0 && ch <= 0x2EBEF) ||  // CJK Unified Ideographs Extension F
       (ch >= 0x30000 && ch <= 0x3134F) ||  // CJK Unified Ideographs Extension G
       (ch >= 0x31350 && ch <= 0x323AF) ||  // CJK Unified Ideographs Extension H
+      (ch >= 0x2EBF0 && ch <= 0x2EE5D) ||  // CJK Unified Ideographs Extension I
       (ch >= 0x3300 && ch <= 0x33FF) ||    // CJK Compatibility
       (ch >= 0xFE30 && ch <= 0xFE4F) ||    // CJK Compatibility Forms
       (ch >= 0xF900 && ch <= 0xFAFF) ||    // CJK Compatibility Ideographs


### PR DESCRIPTION
add CJK Unified Ideographs Extension I range  in function is_extended_cjk
Range: 2EBF0–2EE5D, REF [CJK Extension I](https://www.unicode.org/charts/PDF/U2EBF0.pdf)


## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
