### PR TITLE
prevent initializing glog twice

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Build dependencies
   - compiler with C++17 support
   - cmake>=3.12
   - libboost>=1.74
-  - libglog (optional)
+  - libglog>=0.7 (optional)
   - libleveldb
   - libmarisa
   - libopencc>=1.0.2

--- a/src/rime/setup.cc
+++ b/src/rime/setup.cc
@@ -84,7 +84,11 @@ RIME_API void SetupLogging(const char* app_name,
   // Do not allow other users to read/write log files created by current
   // process.
   FLAGS_logfile_mode = 0600;
-  google::InitGoogleLogging(app_name);
+  if (google::IsGoogleLoggingInitialized()) {
+    LOG(WARNING) << "Glog is already initialized.";
+  } else {
+    google::InitGoogleLogging(app_name);
+  }
 #endif  // RIME_ENABLE_LOGGING
 }
 


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature

Prevent initializing glog twice by using an API that is available in glog 0.7

#### Unit test
- [ ] Done

#### Manual test
- [x] Done by duplicating `rime->setup` in rime_api_console.

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
