### PR TITLE
get_option with default value

### DIFF
--- a/src/rime/context.cc
+++ b/src/rime/context.cc
@@ -259,12 +259,11 @@ void Context::set_option(const string& name, bool value) {
   option_update_notifier_(this, name);
 }
 
-bool Context::get_option(const string& name) const {
+bool Context::get_option(const string& name, bool default_value) const {
   auto it = options_.find(name);
-  if (it != options_.end())
-    return it->second;
-  else
-    return false;
+  if (it == options_.end())
+    return default_value;
+  return it->second;
 }
 
 void Context::set_property(const string& name, const string& value) {

--- a/src/rime/context.h
+++ b/src/rime/context.h
@@ -69,7 +69,7 @@ class RIME_API Context {
   const CommitHistory& commit_history() const { return commit_history_; }
 
   void set_option(const string& name, bool value);
-  bool get_option(const string& name) const;
+  bool get_option(const string& name, bool default_value = false) const;
   void set_property(const string& name, const string& value);
   string get_property(const string& name) const;
   // options and properties starting with '_' are local to schema;

--- a/src/rime/engine.cc
+++ b/src/rime/engine.cc
@@ -397,14 +397,13 @@ void ConcreteEngine::InitializeOptions() {
   Config* config = schema_->config();
   Switches switches(config);
   switches.FindOption([this](Switches::SwitchOption option) {
-    if (option.reset_value >= 0) {
-      if (option.type == Switches::kToggleOption) {
-        context_->set_option(option.option_name, (option.reset_value != 0));
-      } else if (option.type == Switches::kRadioGroup) {
-        context_->set_option(
-            option.option_name,
-            static_cast<int>(option.option_index) == option.reset_value);
-      }
+    int reset_value = option.reset_value >= 0 ? option.reset_value : 0;
+    if (option.type == Switches::kToggleOption) {
+      context_->set_option(option.option_name, reset_value != 0);
+    } else if (option.type == Switches::kRadioGroup) {
+      context_->set_option(
+          option.option_name,
+          static_cast<int>(option.option_index) == reset_value);
     }
     return Switches::kContinue;
   });


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature

Previously, it’s impossible to provide an option (e.g. prediction) that is true if undefined, because `get_option` unconditionally treats undefined as false.
So the first commit enables using true as default.
But that’s not enough. Options without a `reset` aren’t stored at `Context::options_` in the beginning, so are still treated as undefined. They are stored only when user sets by F4.
So the second commit stores all defined options.

#### Unit test
- [ ] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
