### PR TITLE
feat(key_binder): add `when: predicting` condition

### DIFF
--- a/data/minimal/default.yaml
+++ b/data/minimal/default.yaml
@@ -1,8 +1,7 @@
 # Rime default settings
-# vim: set sw=2 sts=2 et:
 # encoding: utf-8
 
-config_version: "0.15.minimal"
+config_version: "0.16.minimal"
 
 schema_list:
   - schema: luna_pinyin
@@ -118,6 +117,8 @@ key_binder:
     - { when: has_menu, accept: equal, send: Page_Down }
     - { when: paging, accept: comma, send: Page_Up }
     - { when: has_menu, accept: period, send: Page_Down }
+    - { when: predicting, accept: comma, send: comma }
+    - { when: predicting, accept: period, send: period }
     # hotkey switch
     - { when: always, accept: Control+Shift+1, select: .next }
     - { when: always, accept: Control+Shift+2, toggle: ascii_mode }

--- a/src/rime/gear/key_binder.cc
+++ b/src/rime/gear/key_binder.cc
@@ -22,9 +22,9 @@ namespace rime {
 
 enum KeyBindingCondition {
   kNever,
-  kWhenPredicting, // showing prediction candidates
-  kWhenPaging,     // user has changed page
-  kWhenHasMenu,    // at least one candidate
+  kWhenPredicting,  // showing prediction candidates
+  kWhenPaging,  // user has changed page
+  kWhenHasMenu,  // at least one candidate
   kWhenComposing,  // input string is not empty
   kAlways,
 };

--- a/src/rime/gear/key_binder.cc
+++ b/src/rime/gear/key_binder.cc
@@ -23,9 +23,9 @@ namespace rime {
 enum KeyBindingCondition {
   kNever,
   kWhenPredicting,  // showing prediction candidates
-  kWhenPaging,  // user has changed page
-  kWhenHasMenu,  // at least one candidate
-  kWhenComposing,  // input string is not empty
+  kWhenPaging,      // user has changed page
+  kWhenHasMenu,     // at least one candidate
+  kWhenComposing,   // input string is not empty
   kAlways,
 };
 

--- a/src/rime/gear/key_binder.cc
+++ b/src/rime/gear/key_binder.cc
@@ -22,6 +22,7 @@ namespace rime {
 
 enum KeyBindingCondition {
   kNever,
+  kWhenPredicting, // showing prediction candidates
   kWhenPaging,     // user has changed page
   kWhenHasMenu,    // at least one candidate
   kWhenComposing,  // input string is not empty
@@ -31,7 +32,8 @@ enum KeyBindingCondition {
 static struct KeyBindingConditionDef {
   KeyBindingCondition condition;
   const char* name;
-} condition_definitions[] = {{kWhenPaging, "paging"},
+} condition_definitions[] = {{kWhenPredicting, "predicting"},
+                             {kWhenPaging, "paging"},
                              {kWhenHasMenu, "has_menu"},
                              {kWhenComposing, "composing"},
                              {kAlways, "always"},
@@ -242,8 +244,14 @@ KeyBindingConditions::KeyBindingConditions(Context* ctx) {
   }
 
   Composition& comp = ctx->composition();
-  if (!comp.empty() && comp.back().HasTag("paging")) {
-    insert(kWhenPaging);
+  if (!comp.empty()) {
+    const Segment& last_seg = comp.back();
+    if (last_seg.HasTag("paging")) {
+      insert(kWhenPaging);
+    }
+    if (last_seg.HasTag("prediction")) {
+      insert(kWhenPredicting);
+    }
   }
 }
 


### PR DESCRIPTION
the new condition `when: predicting` allow paging key binding to comma, period keys to be disabled when the active menu has tag `prediction`.

it's used with the `predictor` component in the librime-predict plugin. see updates in data/minimal/default.yaml for example configuration.
