### PR TITLE
Fix bugs in string split/join functions involving only one token / no delimiter found

### DIFF
--- a/src/rime/algo/calculus.cc
+++ b/src/rime/algo/calculus.cc
@@ -4,9 +4,9 @@
 //
 // 2012-01-17 GONG Chen <chen.sst@gmail.com>
 //
-#include <boost/algorithm/string.hpp>
 #include <utf8.h>
 #include <rime/algo/calculus.h>
+#include <rime/algo/strings.h>
 #include <rime/common.h>
 
 namespace rime {
@@ -31,9 +31,8 @@ Calculation* Calculus::Parse(const string& definition) {
   size_t sep = definition.find_first_not_of("zyxwvutsrqponmlkjihgfedcba");
   if (sep == string::npos)
     return NULL;
-  vector<string> args;
-  boost::split(args, definition,
-               boost::is_from_range(definition[sep], definition[sep]));
+  const string& delim = definition.substr(sep, 1);
+  vector<string> args = strings::split(definition, delim);
   if (args.empty())
     return NULL;
   auto it = factories_.find(args[0]);

--- a/src/rime/algo/strings.cc
+++ b/src/rime/algo/strings.cc
@@ -7,26 +7,16 @@ vector<string> split(const string& str,
                      const string& delim,
                      SplitBehavior behavior) {
   vector<string> strings;
-  size_t lastPos, pos;
-  if (behavior == SplitBehavior::SkipToken) {
-    lastPos = str.find_first_not_of(delim, 0);
-  } else {
-    lastPos = 0;
-  }
-  pos = str.find_first_of(delim, lastPos);
-
-  while (std::string::npos != pos || std::string::npos != lastPos) {
-    strings.emplace_back(str.substr(lastPos, pos - lastPos));
-    if (behavior == SplitBehavior::SkipToken) {
-      lastPos = str.find_first_not_of(delim, pos);
-    } else {
-      if (pos == std::string::npos) {
-        break;
-      }
-      lastPos = pos + 1;
+  size_t pos_start = 0, pos_end, delim_len = delim.length();
+  while ((pos_end = str.find(delim, pos_start)) != string::npos) {
+    if (pos_end != pos_start || behavior != SplitBehavior::SkipToken) {
+      string token = str.substr(pos_start, pos_end - pos_start);
+      strings.push_back(token);
     }
-    pos = str.find_first_of(delim, lastPos);
+    pos_start = pos_end + delim_len;
   }
+  if (pos_start != str.length() || behavior != SplitBehavior::SkipToken)
+    strings.push_back(str.substr(pos_start));
   return strings;
 };
 

--- a/src/rime/algo/strings.h
+++ b/src/rime/algo/strings.h
@@ -35,6 +35,32 @@ inline string join(std::initializer_list<C>&& container, T&& delim) {
   return join(std::begin(container), std::end(container), delim);
 }
 
+inline void trim_left(string& str) {
+  str.erase(str.begin(),
+            std::find_if(str.begin(), str.end(),
+                         [](unsigned char ch) { return !std::isspace(ch); }));
+}
+
+inline void trim_right(string& str) {
+  str.erase(std::find_if(str.rbegin(), str.rend(),
+                         [](unsigned char ch) { return !std::isspace(ch); })
+                .base(),
+            str.end());
+}
+
+inline void trim(string& str) {
+  trim_right(str);
+  trim_left(str);
+}
+
+inline bool starts_with(const string& str, const string& prefix) {
+  return str.rfind(prefix, 0) == 0;
+}
+
+inline bool ends_with(const string& str, const string& suffix) {
+  return str.find(suffix, str.length() - suffix.length()) != std::string::npos;
+}
+
 }  // namespace strings
 }  // namespace rime
 

--- a/src/rime/algo/strings.h
+++ b/src/rime/algo/strings.h
@@ -17,12 +17,8 @@ vector<string> split(const string& str, const string& delim);
 
 template <typename Iter, typename T>
 string join(Iter start, Iter end, T&& delim) {
-  string result;
-  if (start != end) {
-    result += (*start);
-    start++;
-  }
-  for (; start != end; start++) {
+  string result = (*start);
+  while (++start != end) {
     result += (delim);
     result += (*start);
   }

--- a/src/rime/config/config_data.cc
+++ b/src/rime/config/config_data.cc
@@ -6,9 +6,9 @@
 #include <cstdlib>
 #include <fstream>
 #include <sstream>
-#include <boost/algorithm/string.hpp>
 #include <filesystem>
 #include <yaml-cpp/yaml.h>
+#include <rime/algo/strings.h>
 #include <rime/config/config_compiler.h>
 #include <rime/config/config_cow_ref.h>
 #include <rime/config/config_data.h>
@@ -207,15 +207,13 @@ bool ConfigData::TraverseWrite(const string& path, an<ConfigItem> item) {
 }
 
 vector<string> ConfigData::SplitPath(const string& path) {
-  vector<string> keys;
-  auto is_separator = boost::is_any_of("/");
-  auto trimmed_path = boost::trim_left_copy_if(path, is_separator);
-  boost::split(keys, trimmed_path, is_separator);
+  auto trimmed_path = path.substr(strings::starts_with(path, "/"));
+  vector<string> keys = strings::split(trimmed_path, "/");
   return keys;
 }
 
 string ConfigData::JoinPath(const vector<string>& keys) {
-  return boost::join(keys, "/");
+  return strings::join(keys, "/");
 }
 
 an<ConfigItem> ConfigData::Traverse(const string& path) {

--- a/src/rime/dict/reverse_lookup_dictionary.cc
+++ b/src/rime/dict/reverse_lookup_dictionary.cc
@@ -8,12 +8,12 @@
 #include <cfloat>
 #include <cstdlib>
 #include <sstream>
-#include <boost/algorithm/string.hpp>
 #include <filesystem>
 #include <rime/resource.h>
 #include <rime/schema.h>
 #include <rime/service.h>
 #include <rime/ticket.h>
+#include <rime/algo/strings.h>
 #include <rime/dict/dict_settings.h>
 #include <rime/dict/reverse_lookup_dictionary.h>
 
@@ -107,7 +107,7 @@ bool ReverseDb::Build(DictSettings* settings,
   // save reverse lookup entries
   for (const auto& v : rev_table) {
     const string& key(v.first);
-    string value(boost::algorithm::join(v.second, " "));
+    string value(strings::join(v.second, " "));
     key_trie_builder.Add(key, 0.0, &key_ids[i]);
     value_trie_builder.Add(value, 0.0, &value_ids[i]);
     ++i;
@@ -115,7 +115,7 @@ bool ReverseDb::Build(DictSettings* settings,
   // save stems
   for (const auto& v : stems) {
     string key(v.first + kStemKeySuffix);
-    string value(boost::algorithm::join(v.second, " "));
+    string value(strings::join(v.second, " "));
     key_trie_builder.Add(key, 0.0, &key_ids[i]);
     value_trie_builder.Add(value, 0.0, &value_ids[i]);
     ++i;

--- a/src/rime/dict/table_db.cc
+++ b/src/rime/dict/table_db.cc
@@ -4,7 +4,7 @@
 //
 // 2013-04-18 GONG Chen <chen.sst@gmail.com>
 //
-#include <boost/algorithm/string.hpp>
+#include <rime/algo/strings.h>
 #include <rime/dict/table_db.h>
 #include <rime/dict/user_db.h>
 
@@ -22,7 +22,7 @@ static bool rime_table_entry_parser(const Tsv& row,
     return false;
   }
   string code(row[1]);
-  boost::algorithm::trim(code);
+  strings::trim(code);
   *key = code + " \t" + row[0];
   UserDbValue v;
   if (row.size() >= 3 && !row[2].empty()) {
@@ -42,13 +42,13 @@ static bool rime_table_entry_formatter(const string& key,
                                        Tsv* tsv) {
   Tsv& row(*tsv);
   // key ::= code <space> <Tab> phrase
-  boost::algorithm::split(row, key, boost::algorithm::is_any_of("\t"));
+  row = strings::split(key, "\t");
   if (row.size() != 2 || row[0].empty() || row[1].empty())
     return false;
   UserDbValue v(value);
   if (v.commits < 0)  // deleted entry
     return false;
-  boost::algorithm::trim(row[0]);  // remove trailing space
+  strings::trim(row[0]);  // remove trailing space
   row[0].swap(row[1]);
   row.push_back(std::to_string(v.commits));
   return true;

--- a/src/rime/dict/tsv.cc
+++ b/src/rime/dict/tsv.cc
@@ -5,7 +5,7 @@
 // 2013-04-14 GONG Chen <chen.sst@gmail.com>
 //
 #include <fstream>
-#include <boost/algorithm/string.hpp>
+#include <rime/algo/strings.h>
 #include <rime/common.h>
 #include <rime/dict/db_utils.h>
 #include <rime/dict/tsv.h>
@@ -24,15 +24,15 @@ int TsvReader::operator()(Sink* sink) {
   bool enable_comment = true;
   while (getline(fin, line)) {
     ++line_no;
-    boost::algorithm::trim_right(line);
+    strings::trim_right(line);
     // skip empty lines and comments
     if (line.empty())
       continue;
     if (enable_comment && line[0] == '#') {
-      if (boost::starts_with(line, "#@")) {
+      if (strings::starts_with(line, "#@")) {
         // metadata
         line.erase(0, 2);
-        boost::algorithm::split(row, line, boost::algorithm::is_any_of("\t"));
+        row = strings::split(line, "\t");
         if (row.size() != 2 || !sink->MetaPut(row[0], row[1])) {
           LOG(WARNING) << "invalid metadata at line " << line_no << ".";
         }
@@ -43,7 +43,7 @@ int TsvReader::operator()(Sink* sink) {
       continue;
     }
     // read a tsv entry
-    boost::algorithm::split(row, line, boost::algorithm::is_any_of("\t"));
+    row = strings::split(line, "\t");
     if (!parser_(row, &key, &value) || !sink->Put(key, value)) {
       LOG(WARNING) << "invalid entry at line " << line_no << ".";
       continue;

--- a/src/rime/dict/user_db.cc
+++ b/src/rime/dict/user_db.cc
@@ -6,7 +6,7 @@
 //
 #include <cstdlib>
 #include <sstream>
-#include <boost/algorithm/string.hpp>
+#include <rime/algo/strings.h>
 #include <rime/service.h>
 #include <rime/algo/dynamics.h>
 #include <rime/dict/text_db.h>
@@ -25,8 +25,7 @@ string UserDbValue::Pack() const {
 }
 
 bool UserDbValue::Unpack(const string& value) {
-  vector<string> kv;
-  boost::split(kv, value, boost::is_any_of(" "));
+  vector<string> kv = strings::split(value, " ");
   for (const string& k_eq_v : kv) {
     size_t eq = k_eq_v.find('=');
     if (eq == string::npos)
@@ -83,7 +82,7 @@ static bool userdb_entry_formatter(const string& key,
                                    const string& value,
                                    Tsv* tsv) {
   Tsv& row(*tsv);
-  boost::algorithm::split(row, key, boost::algorithm::is_any_of("\t"));
+  row = strings::split(key, "\t");
   if (row.size() != 2 || row[0].empty() || row[1].empty())
     return false;
   row.push_back(value);
@@ -107,7 +106,7 @@ bool UserDbHelper::UpdateUserInfo() {
 }
 
 bool UserDbHelper::IsUniformFormat(const string& file_name) {
-  return boost::ends_with(file_name, plain_userdb_extension);
+  return strings::ends_with(file_name, plain_userdb_extension);
 }
 
 bool UserDbHelper::UniformBackup(const string& snapshot_file) {
@@ -147,10 +146,10 @@ string UserDbHelper::GetDbName() {
   string name;
   if (!db_->MetaFetch("/db_name", &name))
     return name;
-  auto ext = boost::find_last(name, ".userdb");
-  if (!ext.empty()) {
+  auto ext = name.rfind(".userdb");
+  if (ext != std::string::npos) {
     // remove ".userdb.*"
-    name.erase(ext.begin(), name.end());
+    name.erase(ext, name.length() - ext);
   }
   return name;
 }

--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -9,7 +9,6 @@
 #include <algorithm>
 #include <stack>
 #include <cmath>
-#include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/reversed.hpp>
 #include <rime/composition.h>
 #include <rime/candidate.h>
@@ -18,6 +17,7 @@
 #include <rime/engine.h>
 #include <rime/schema.h>
 #include <rime/translation.h>
+#include <rime/algo/strings.h>
 #include <rime/algo/syllabifier.h>
 #include <rime/dict/corrector.h>
 #include <rime/dict/dictionary.h>
@@ -214,7 +214,7 @@ string ScriptTranslator::Spell(const Code& code) {
   vector<string> syllables;
   if (!dict_ || !dict_->Decode(code, &syllables) || syllables.empty())
     return result;
-  result = boost::algorithm::join(syllables, string(1, delimiters_.at(0)));
+  result = strings::join(syllables, string(1, delimiters_.at(0)));
   comment_formatter_.Apply(&result);
   return result;
 }

--- a/src/rime/gear/switch_translator.cc
+++ b/src/rime/gear/switch_translator.cc
@@ -4,7 +4,7 @@
 //
 // 2013-05-26 GONG Chen <chen.sst@gmail.com>
 //
-#include <boost/algorithm/string.hpp>
+#include <rime/algo/strings.h>
 #include <rime/candidate.h>
 #include <rime/common.h>
 #include <rime/config.h>
@@ -184,7 +184,7 @@ void FoldedOptions::Append(const SwitchOption& option, size_t state_index) {
 }
 
 void FoldedOptions::Finish() {
-  text_ = prefix_ + boost::algorithm::join(labels_, separator_) + suffix_;
+  text_ = prefix_ + strings::join(labels_, separator_) + suffix_;
 }
 
 class SwitchTranslation : public FifoTranslation {

--- a/src/rime/gear/unity_table_encoder.cc
+++ b/src/rime/gear/unity_table_encoder.cc
@@ -4,7 +4,7 @@
 //
 // 2013-08-31 GONG Chen <chen.sst@gmail.com>
 //
-#include <boost/algorithm/string.hpp>
+#include <rime/algo/strings.h>
 #include <rime/dict/dict_settings.h>
 #include <rime/dict/user_dictionary.h>
 #include <rime/dict/reverse_lookup_dictionary.h>
@@ -62,7 +62,7 @@ bool UnityTableEncoder::TranslateWord(const string& word,
   string str_list;
   if (rev_dict_->LookupStems(word, &str_list) ||
       rev_dict_->ReverseLookup(word, &str_list)) {
-    boost::split(*code, str_list, boost::is_any_of(" "));
+    *code = strings::split(str_list, " ");
     return !code->empty();
   }
   return false;
@@ -80,7 +80,7 @@ size_t UnityTableEncoder::LookupPhrases(UserDictEntryIterator* result,
 }
 
 bool UnityTableEncoder::HasPrefix(const string& key) {
-  return boost::starts_with(key, kEncodedPrefix);
+  return strings::starts_with(key, kEncodedPrefix);
 }
 
 bool UnityTableEncoder::AddPrefix(string* key) {


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Fix bugs in string split/join functions involving only one token / no delimiter found
Further apply the string functions to replace those from boost

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
