### PR TITLE
feat: rime_api add RimeApi::RimeReplaceInput

### DIFF
--- a/src/rime/context.cc
+++ b/src/rime/context.cc
@@ -254,6 +254,12 @@ void Context::set_input(const string& value) {
   update_notifier_(this);
 }
 
+void Context::replace_input(size_t pos, size_t count, const string& value) {
+  input_.replace(pos, count, value);
+  caret_pos_ = input_.length();
+  update_notifier_(this);
+}
+
 void Context::set_option(const string& name, bool value) {
   options_[name] = value;
   option_update_notifier_(this, name);

--- a/src/rime/context.h
+++ b/src/rime/context.h
@@ -58,6 +58,7 @@ class RIME_API Context {
 
   void set_input(const string& value);
   const string& input() const { return input_; }
+  void replace_input(size_t pos, size_t count, const string& value);
 
   void set_caret_pos(size_t caret_pos);
   size_t caret_pos() const { return caret_pos_; }

--- a/src/rime_api.cc
+++ b/src/rime_api.cc
@@ -1084,6 +1084,20 @@ const char* RimeGetStateLabel(RimeSessionId session_id,
       .str;
 }
 
+RIME_API Bool RimeReplaceInput(RimeSessionId session_id,
+                               size_t pos,
+                               size_t count,
+                               const char* replace_char) {
+  an<Session> session(Service::instance().GetSession(session_id));
+  if (!session)
+    return False;
+  Context* ctx = session->context();
+  if (!ctx)
+    return False;
+  ctx->replace_input(pos, count, replace_char);
+  return True;
+}
+
 RIME_API RimeApi* rime_get_api() {
   static RimeApi s_api = {0};
   if (!s_api.data_size) {
@@ -1177,6 +1191,7 @@ RIME_API RimeApi* rime_get_api() {
     s_api.delete_candidate = &RimeDeleteCandidate;
     s_api.delete_candidate_on_current_page = &RimeDeleteCandidateOnCurrentPage;
     s_api.get_state_label_abbreviated = &RimeGetStateLabelAbbreviated;
+    s_api.replace_input = &RimeReplaceInput;
   }
   return &s_api;
 }

--- a/src/rime_api.h
+++ b/src/rime_api.h
@@ -273,6 +273,7 @@ RIME_API void RimeCleanupAllSessions(void);
 // Input
 
 RIME_API Bool RimeProcessKey(RimeSessionId session_id, int keycode, int mask);
+
 /*!
  * return True if there is unread commit text
  */
@@ -387,6 +388,10 @@ RIME_API Bool RimeConfigUpdateSignature(RimeConfig* config, const char* signer);
 RIME_API Bool RimeSimulateKeySequence(RimeSessionId session_id,
                                       const char* key_sequence);
 
+RIME_API Bool RimeReplaceInput(RimeSessionId session_id,
+                               size_t pos,
+                               size_t count,
+                               const char* replace_char);
 // Module
 
 /*!
@@ -644,6 +649,11 @@ typedef struct rime_api_t {
                                                  const char* option_name,
                                                  Bool state,
                                                  Bool abbreviated);
+  //! modify the current input
+  Bool (*replace_input)(RimeSessionId session_id,
+                        size_t pos,
+                        size_t count,
+                        const char* replace_char);
 } RimeApi;
 
 //! API entry


### PR DESCRIPTION
resolve #547 

新增 api 用于调整用户已输入的字符。