### PR TITLE
Do not let paging keys fallback to be handled by OS

### DIFF
--- a/src/rime/gear/selector.cc
+++ b/src/rime/gear/selector.cc
@@ -122,7 +122,7 @@ ProcessResult Selector::ProcessKeyEvent(const KeyEvent& key_event) {
   if (ctx->composition().empty())
     return kNoop;
   Segment& current_segment(ctx->composition().back());
-  if (!current_segment.menu || current_segment.HasTag("raw"))
+  if (current_segment.HasTag("raw"))
     return kNoop;
 
   TextOrientation text_orientation =
@@ -160,6 +160,10 @@ bool Selector::PreviousPage(Context* ctx) {
   Composition& comp = ctx->composition();
   if (comp.empty())
     return false;
+  if (!comp.back().menu) {
+    // no-op; consume the key event so that page down is not sent to the app.
+    return true;
+  }
   int page_size = engine_->schema()->page_size();
   int selected_index = comp.back().selected_index;
   int index = selected_index < page_size ? 0 : selected_index - page_size;
@@ -170,8 +174,11 @@ bool Selector::PreviousPage(Context* ctx) {
 
 bool Selector::NextPage(Context* ctx) {
   Composition& comp = ctx->composition();
-  if (comp.empty() || !comp.back().menu)
+  if (comp.empty())
     return false;
+  if (!comp.back().menu)
+    // no-op; consume the key event so that page down is not sent to the app.
+    return true;
   int page_size = engine_->schema()->page_size();
   int index = comp.back().selected_index + page_size;
   int page_start = (index / page_size) * page_size;
@@ -202,7 +209,7 @@ bool Selector::PreviousCandidate(Context* ctx) {
     return false;
   }
   Composition& comp = ctx->composition();
-  if (comp.empty())
+  if (comp.empty() || !comp.back().menu)
     return false;
   int index = comp.back().selected_index;
   if (index <= 0) {


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Fix bugs when user press `page_up` (or other equivalent key bindings) on the first page or `page_down` on the last page, system handles the keys and voids the input as a result (since the insert cursor moves as a result of system handling `page_up` and `page_down`)

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
