### PR TITLE
feat(engine): translate zero-length prediction

### DIFF
--- a/tools/rime_api_console.cc
+++ b/tools/rime_api_console.cc
@@ -64,7 +64,7 @@ void print_menu(RimeMenu* menu) {
 }
 
 void print_context(RimeContext* context) {
-  if (context->composition.length > 0) {
+  if (context->composition.length > 0 || context->menu.num_candidates > 0) {
     print_composition(&context->composition);
   } else {
     printf("(not composing)\n");


### PR DESCRIPTION
allow zero-length segment to be translated.
add `placeholder` tag to the segment to prevent it from being trimmed.