### PR TITLE
fix: InitGoogleLogging twice

### DIFF
--- a/src/rime/setup.cc
+++ b/src/rime/setup.cc
@@ -79,6 +79,9 @@ RIME_API void SetupLogging(const char* app_name,
 #ifdef RIME_ENABLE_LOGGING
   FLAGS_minloglevel = min_log_level;
   FLAGS_alsologtostderr = true;
+  if (google::IsGoogleLoggingInitialized()) {
+    return;
+  }
   if (log_dir) {
     if (log_dir[0] == '\0') {
       FLAGS_logtostderr = true;


### PR DESCRIPTION
Check failed: !IsGoogleLoggingInitialized() You called InitGoogleLogging() twice!

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #782

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [X] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
