### PR TITLE
make sure glog only write to stderr using google::LogToStderr()

### DIFF
--- a/src/rime/setup.cc
+++ b/src/rime/setup.cc
@@ -81,7 +81,7 @@ RIME_API void SetupLogging(const char* app_name,
   FLAGS_alsologtostderr = true;
   if (log_dir) {
     if (log_dir[0] == '\0') {
-      FLAGS_logtostderr = true;
+      google::LogToStderr();
     } else {
       FLAGS_log_dir = log_dir;
     }


### PR DESCRIPTION
## Pull request

#### Feature
`FLAGS_logtostderr` works fine on desktop environments, but on Android, it does not write to logcat, and requires to have a valid `log_dir` in order to write log files as well as logcat. 
https://github.com/google/glog/blob/b33e3bad4c46c8a6345525fd822af355e5ef9446/src/logging.cc#L809 (only `LogDestination::MaybeLogToStderr` can write to logcat on Android)
https://github.com/google/glog/blob/b33e3bad4c46c8a6345525fd822af355e5ef9446/src/logging.cc#L1840 (if `FLAGS_logtostderr` is set, the branch above cannot be reached)

`google::LogToStderr()` makes the log only goes to stderr on desktop, and logcat on Android.
https://github.com/google/glog/blob/b33e3bad4c46c8a6345525fd822af355e5ef9446/src/logging.cc#L727-L734

I only tested it on Android, maybe further testing is needed.

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
