### PR TITLE
perf: less nest in filesystem iteration When CleanOldLogFiles::Run

### DIFF
--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -648,7 +648,7 @@ bool CleanOldLogFiles::Run(Deployer* deployer) {
     for (const auto& entry : fs::directory_iterator(dir)) {
       const string& file_name(entry.path().filename().string());
       if (entry.is_regular_file() && !entry.is_symlink() &&
-          boost::starts_with(file_name, "rime.*") &&
+          boost::starts_with(file_name, "rime.") &&
           !boost::contains(file_name, today)) {
         files.push_back(entry.path());
       }

--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -666,7 +666,6 @@ bool CleanOldLogFiles::Run(Deployer* deployer) {
         success = false;
       }
     }
-    vector<fs::path>().swap(files);
   }
   if (removed != 0) {
     LOG(INFO) << "cleaned " << removed << " log files.";

--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -641,24 +641,32 @@ bool CleanOldLogFiles::Run(Deployer* deployer) {
   DLOG(INFO) << "scanning " << dirs.size() << " temp directory for log files.";
 
   int removed = 0;
-  for (auto i = dirs.cbegin(); i != dirs.cend(); ++i) {
-    DLOG(INFO) << "temp directory: " << *i;
-    for (fs::directory_iterator j(*i), end; j != end; ++j) {
-      fs::path entry(j->path());
-      string file_name(entry.filename().string());
+  for (const auto& dir : dirs) {
+    vector<fs::path> files;
+    DLOG(INFO) << "temp directory: " << dir;
+    // preparing files
+    for (const auto& entry : fs::directory_iterator(dir)) {
+      const string& file_name(entry.path().filename().string());
+      if (entry.is_regular_file() && !entry.is_symlink() &&
+          boost::starts_with(file_name, "rime.*") &&
+          !boost::contains(file_name, today)) {
+        files.push_back(entry.path());
+      }
+    }
+    // remove files
+    for (const auto& file : files) {
       try {
-        if (fs::is_regular_file(entry) && !fs::is_symlink(entry) &&
-            boost::starts_with(file_name, "rime.") &&
-            !boost::contains(file_name, today)) {
-          DLOG(INFO) << "removing log file '" << file_name << "'.";
-          fs::remove(entry);
-          ++removed;
-        }
+        DLOG(INFO) << "removing log file '" << file.filename() << "'.";
+        // ensure write permission
+        fs::permissions(file, fs::perms::owner_write);
+        fs::remove(file);
+        ++removed;
       } catch (const fs::filesystem_error& ex) {
         LOG(ERROR) << ex.what();
         success = false;
       }
     }
+    vector<fs::path>().swap(files);
   }
   if (removed != 0) {
     LOG(INFO) << "cleaned " << removed << " log files.";


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

less nest when filesystem iteration in CleanOldLogFiles::Run(Deployer* deplyer) for better performance. esp under Windows with log dir %TEMP% and too much files inside that directory.

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
simple test code, target iteration folder `./files` with 1 million files. compiled with command
`g++ -Wall iterator.cpp -std=c++17 -o iterator`
![image](https://github.com/rime/librime/assets/4023160/20e6b8d3-1135-4b6f-b994-be25ddbf31ec)

```cpp
#include <chrono>
#include <iostream>
#include <filesystem>
#include <vector>

using namespace std;
namespace fs = std::filesystem;

int main()
{
    auto start = chrono::high_resolution_clock::now();
    vector<string> dirs;
    // with 1 million files inside ./files
    dirs.push_back("./files");
    // ----------------------------------------------------------------
    vector<string> files;
    for (const auto& dir : dirs) {
        for (const auto& entry : fs::directory_iterator(dir)){
            if(entry.is_regular_file() && !entry.is_symlink())
                files.push_back(entry.path().string());
        }
    }
    for (const auto& file: files) {
    }
    vector<string>().swap(files);
    auto _end = chrono::high_resolution_clock::now();
    auto duration = chrono::duration_cast<chrono::microseconds>(_end - start);
    cout << "with new process, duration: " << duration.count() << " us" << endl;

    // ----------------------------------------------------------------
    start = chrono::high_resolution_clock::now();
    for (auto i = dirs.cbegin(); i != dirs.cend(); ++i) {
        for (fs::directory_iterator j(*i), end; j != end; ++j) {
            fs::path entry(j->path());
            string file_name(entry.filename().string());
            if (fs::is_regular_file(entry) && !fs::is_symlink(entry));
        }
    }
    _end = chrono::high_resolution_clock::now();
    duration = chrono::duration_cast<chrono::microseconds>(_end - start);
    cout << "with old process, duration: " << duration.count() << " us" << endl;
    return 0;
}
```