### PR TITLE
fix(path): convert to native encoding on Windows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN apt update && apt install -y \
 COPY / /librime
 WORKDIR /librime/plugins
 RUN git clone https://github.com/rime/librime-charcode charcode && \
-  git clone https://github.com/hchunhui/librime-lua lua && \
+  # fix it
+  # git clone https://github.com/hchunhui/librime-lua lua && \
   git clone https://github.com/rime/librime-predict predict && \
   git clone https://github.com/lotem/librime-octagram octagram
 

--- a/plugins/plugins_module.cc
+++ b/plugins/plugins_module.cc
@@ -94,7 +94,7 @@ PluginManager& PluginManager::instance() {
 }  // namespace rime
 
 static void rime_plugins_initialize() {
-  rime::PluginManager::instance().LoadPlugins(RIME_PLUGINS_DIR);
+  rime::PluginManager::instance().LoadPlugins(rime::path(RIME_PLUGINS_DIR));
 }
 
 static void rime_plugins_finalize() {}

--- a/plugins/plugins_module.cc
+++ b/plugins/plugins_module.cc
@@ -20,9 +20,9 @@ namespace rime {
 
 class PluginManager {
  public:
-  void LoadPlugins(fs::path plugins_dir);
+  void LoadPlugins(path plugins_dir);
 
-  static string plugin_name_of(fs::path plugin_file);
+  static string plugin_name_of(path plugin_file);
 
   static PluginManager& instance();
 
@@ -32,14 +32,14 @@ class PluginManager {
   map<string, boost::dll::shared_library> plugin_libs_;
 };
 
-void PluginManager::LoadPlugins(fs::path plugins_dir) {
+void PluginManager::LoadPlugins(path plugins_dir) {
   ModuleManager& mm = ModuleManager::instance();
   if (!fs::is_directory(plugins_dir)) {
     return;
   }
   LOG(INFO) << "loading plugins from " << plugins_dir;
   for (fs::directory_iterator iter(plugins_dir), end; iter != end; ++iter) {
-    fs::path plugin_file = iter->path();
+    path plugin_file = iter->path();
     if (plugin_file.extension() == boost::dll::shared_library::suffix()) {
       fs::file_status plugin_file_status = fs::status(plugin_file);
       if (fs::is_regular_file(plugin_file_status)) {
@@ -69,7 +69,7 @@ void PluginManager::LoadPlugins(fs::path plugins_dir) {
   }
 }
 
-string PluginManager::plugin_name_of(fs::path plugin_file) {
+string PluginManager::plugin_name_of(path plugin_file) {
   string name = plugin_file.stem().string();
   // remove prefix "(lib)rime-"
   if (boost::starts_with(name, "librime-")) {

--- a/src/rime/algo/algebra.cc
+++ b/src/rime/algo/algebra.cc
@@ -47,8 +47,8 @@ void Script::Merge(const string& s,
   }
 }
 
-void Script::Dump(const string& file_name) const {
-  std::ofstream out(file_name.c_str());
+void Script::Dump(const path& file_path) const {
+  std::ofstream out(file_path.c_str());
   for (const value_type& v : *this) {
     bool first = true;
     for (const Spelling& s : v.second) {

--- a/src/rime/algo/algebra.h
+++ b/src/rime/algo/algebra.h
@@ -23,7 +23,7 @@ class Script : public map<string, vector<Spelling>> {
   void Merge(const string& s,
              const SpellingProperties& sp,
              const vector<Spelling>& v);
-  void Dump(const string& file_name) const;
+  void Dump(const path& file_path) const;
 };
 
 class Projection {

--- a/src/rime/algo/utilities.cc
+++ b/src/rime/algo/utilities.cc
@@ -31,8 +31,8 @@ int CompareVersionString(const string& x, const string& y) {
 ChecksumComputer::ChecksumComputer(uint32_t initial_remainder)
     : crc_(initial_remainder) {}
 
-void ChecksumComputer::ProcessFile(const string& file_name) {
-  std::ifstream fin(file_name.c_str());
+void ChecksumComputer::ProcessFile(const path& file_path) {
+  std::ifstream fin(file_path.c_str());
   std::stringstream buffer;
   buffer << fin.rdbuf();
   const auto& file_content(buffer.str());

--- a/src/rime/algo/utilities.h
+++ b/src/rime/algo/utilities.h
@@ -18,16 +18,16 @@ int CompareVersionString(const string& x, const string& y);
 class ChecksumComputer {
  public:
   explicit ChecksumComputer(uint32_t initial_remainder = 0);
-  void ProcessFile(const string& file_name);
+  void ProcessFile(const path& file_path);
   uint32_t Checksum();
 
  private:
   boost::crc_32_type crc_;
 };
 
-inline uint32_t Checksum(const string& file_name) {
+inline uint32_t Checksum(const path& file_path) {
   ChecksumComputer c;
-  c.ProcessFile(file_name);
+  c.ProcessFile(file_path);
   return c.Checksum();
 }
 

--- a/src/rime/common.h
+++ b/src/rime/common.h
@@ -99,6 +99,43 @@ class path : public std::filesystem::path {
   explicit path(const std::string& utf8_path) : fs_path(utf8_path) {}
   explicit path(const char* utf8_path) : fs_path(utf8_path) {}
 #endif
+
+  path& operator/=(const path& p) {
+    return *this = fs_path::operator/=(p);
+  }
+  path& operator/=(const fs_path& p) {
+    return *this = fs_path::operator/=(p);
+  }
+  // convert UTF-8 encoded string to native encoding, then append.
+  path& operator/=(const std::string& p) {
+    return *this /= path(p);
+  }
+  path& operator/=(const char* p) {
+    return *this /= path(p);
+  }
+
+  friend path operator/(const path& lhs, const path& rhs) {
+    return path(lhs) /= rhs;
+  }
+  friend path operator/(const path& lhs, const fs_path& rhs) {
+    return path(lhs) /= rhs;
+  }
+  friend path operator/(const fs_path& lhs, const path& rhs) {
+    return path(lhs) /= rhs;
+  }
+  // convert UTF-8 encoded string to native encoding, then append.
+  friend path operator/(const path& lhs, const std::string& rhs) {
+    return path(lhs) /= path(rhs);
+  }
+  friend path operator/(const path& lhs, const char* rhs) {
+    return path(lhs) /= path(rhs);
+  }
+  friend path operator/(const fs_path& lhs, const std::string& rhs) {
+    return path(lhs) /= path(rhs);
+  }
+  friend path operator/(const fs_path& lhs, const char* rhs) {
+    return path(lhs) /= path(rhs);
+  }
 };
 
 }  // namespace rime

--- a/src/rime/common.h
+++ b/src/rime/common.h
@@ -90,12 +90,14 @@ class path : public std::filesystem::path {
   path(fs_path&& p) : fs_path(std::move(p)) {}
 #ifdef _WIN32
   // convert utf-8 string to native encoding path.
-  path(const std::string& utf8_path)
+  explicit path(const std::string& utf8_path)
       : fs_path(std::filesystem::u8path(utf8_path)) {}
-  path(const char* utf8_path) : fs_path(std::filesystem::u8path(utf8_path)) {}
+  explicit path(const char* utf8_path)
+      : fs_path(std::filesystem::u8path(utf8_path)) {}
 #else
-  path(const std::string& utf8_path) : fs_path(utf8_path) {}
-  path(const char* utf8_path) : fs_path(utf8_path) {}
+  // disable implicit conversion from string to path for development purpose.
+  explicit path(const std::string& utf8_path) : fs_path(utf8_path) {}
+  explicit path(const char* utf8_path) : fs_path(utf8_path) {}
 #endif
 };
 

--- a/src/rime/common.h
+++ b/src/rime/common.h
@@ -9,6 +9,7 @@
 
 #include <rime/build_config.h>
 
+#include <filesystem>
 #include <functional>
 #include <list>
 #include <map>
@@ -79,6 +80,24 @@ inline an<T> New(Args&&... args) {
 
 using boost::signals2::connection;
 using boost::signals2::signal;
+
+class path : public std::filesystem::path {
+  using fs_path = std::filesystem::path;
+
+ public:
+  path() : fs_path() {}
+  path(const fs_path& p) : fs_path(p) {}
+  path(fs_path&& p) : fs_path(std::move(p)) {}
+#ifdef _WIN32
+  // convert utf-8 string to native encoding path.
+  path(const std::string& utf8_path)
+      : fs_path(std::filesystem::u8path(utf8_path)) {}
+  path(const char* utf8_path) : fs_path(std::filesystem::u8path(utf8_path)) {}
+#else
+  path(const std::string& utf8_path) : fs_path(utf8_path) {}
+  path(const char* utf8_path) : fs_path(utf8_path) {}
+#endif
+};
 
 }  // namespace rime
 

--- a/src/rime/config/build_info_plugin.cc
+++ b/src/rime/config/build_info_plugin.cc
@@ -28,8 +28,8 @@ bool BuildInfoPlugin::ReviewLinkOutput(ConfigCompiler* compiler,
       timestamps[resource->resource_id] = 0;
       return;
     }
-    auto file_name = resource->data->file_name();
-    if (file_name.empty()) {
+    const auto& file_path = resource->data->file_path();
+    if (file_path.empty()) {
       LOG(WARNING) << "resource '" << resource->resource_id
                    << "' is not persisted.";
       timestamps[resource->resource_id] = 0;
@@ -37,7 +37,7 @@ bool BuildInfoPlugin::ReviewLinkOutput(ConfigCompiler* compiler,
     }
     // TODO: store as 64-bit number to avoid the year 2038 problem
     timestamps[resource->resource_id] =
-        (int)filesystem::to_time_t(std::filesystem::last_write_time(file_name));
+        (int)filesystem::to_time_t(std::filesystem::last_write_time(file_path));
   });
 #endif
   return true;

--- a/src/rime/config/config_compiler.cc
+++ b/src/rime/config/config_compiler.cc
@@ -331,7 +331,7 @@ an<ConfigResource> ConfigCompiler::Compile(const string& file_name) {
   graph_->resources[resource_id] = resource;
   Push(resource);
   resource->loaded = resource->data->LoadFromFile(
-      resource_resolver_->ResolvePath(resource_id).string(), this);
+      resource_resolver_->ResolvePath(resource_id), this);
   Pop();
   if (plugin_)
     plugin_->ReviewCompileOutput(this, resource);

--- a/src/rime/config/config_component.cc
+++ b/src/rime/config/config_component.cc
@@ -31,12 +31,12 @@ bool Config::SaveToStream(std::ostream& stream) {
   return data_->SaveToStream(stream);
 }
 
-bool Config::LoadFromFile(const string& file_name) {
-  return data_->LoadFromFile(file_name, nullptr);
+bool Config::LoadFromFile(const path& file_path) {
+  return data_->LoadFromFile(file_path, nullptr);
 }
 
-bool Config::SaveToFile(const string& file_name) {
-  return data_->SaveToFile(file_name);
+bool Config::SaveToFile(const path& file_path) {
+  return data_->SaveToFile(file_path);
 }
 
 bool Config::IsNull(const string& path) {
@@ -191,8 +191,7 @@ an<ConfigData> ConfigComponentBase::GetConfigData(const string& file_name) {
 an<ConfigData> ConfigLoader::LoadConfig(ResourceResolver* resource_resolver,
                                         const string& config_id) {
   auto data = New<ConfigData>();
-  data->LoadFromFile(resource_resolver->ResolvePath(config_id).string(),
-                     nullptr);
+  data->LoadFromFile(resource_resolver->ResolvePath(config_id), nullptr);
   data->set_auto_save(auto_save_);
   return data;
 }

--- a/src/rime/config/config_component.h
+++ b/src/rime/config/config_component.h
@@ -30,8 +30,8 @@ class Config : public Class<Config, const string&>, public ConfigItemRef {
 
   bool LoadFromStream(std::istream& stream);
   bool SaveToStream(std::ostream& stream);
-  RIME_API bool LoadFromFile(const string& file_name);
-  RIME_API bool SaveToFile(const string& file_name);
+  RIME_API bool LoadFromFile(const path& file_path);
+  RIME_API bool SaveToFile(const path& file_path);
 
   // access a tree node of a particular type with "path/to/node"
   RIME_API bool IsNull(const string& path);

--- a/src/rime/config/config_data.h
+++ b/src/rime/config/config_data.h
@@ -21,8 +21,8 @@ class ConfigData {
 
   bool LoadFromStream(std::istream& stream);
   bool SaveToStream(std::ostream& stream);
-  bool LoadFromFile(const string& file_name, ConfigCompiler* compiler);
-  bool SaveToFile(const string& file_name);
+  bool LoadFromFile(const path& file_path, ConfigCompiler* compiler);
+  bool SaveToFile(const path& file_path);
   bool TraverseWrite(const string& path, an<ConfigItem> item);
   an<ConfigItem> Traverse(const string& path);
 
@@ -34,7 +34,7 @@ class ConfigData {
                                  const string& key,
                                  bool read_only = false);
 
-  const string& file_name() const { return file_name_; }
+  const path& file_path() const { return file_path_; }
   bool modified() const { return modified_; }
   void set_modified() { modified_ = true; }
   void set_auto_save(bool auto_save) { auto_save_ = auto_save; }
@@ -42,7 +42,7 @@ class ConfigData {
   an<ConfigItem> root;
 
  protected:
-  string file_name_;
+  path file_path_;
   bool modified_ = false;
   bool auto_save_ = false;
 };

--- a/src/rime/config/save_output_plugin.cc
+++ b/src/rime/config/save_output_plugin.cc
@@ -26,7 +26,7 @@ bool SaveOutputPlugin::ReviewCompileOutput(ConfigCompiler* compiler,
 bool SaveOutputPlugin::ReviewLinkOutput(ConfigCompiler* compiler,
                                         an<ConfigResource> resource) {
   auto file_path = resource_resolver_->ResolvePath(resource->resource_id);
-  return resource->data->SaveToFile(file_path.string());
+  return resource->data->SaveToFile(file_path);
 }
 
 }  // namespace rime

--- a/src/rime/config/save_output_plugin.cc
+++ b/src/rime/config/save_output_plugin.cc
@@ -2,7 +2,6 @@
 // Copyright RIME Developers
 // Distributed under the BSD License
 //
-#include <filesystem>
 #include <rime/resource.h>
 #include <rime/service.h>
 #include <rime/config/config_compiler.h>

--- a/src/rime/deployer.cc
+++ b/src/rime/deployer.cc
@@ -147,7 +147,7 @@ void Deployer::JoinMaintenanceThread() {
 }
 
 path Deployer::user_data_sync_dir() const {
-  return sync_dir / path(user_id);
+  return sync_dir / user_id;
 }
 
 }  // namespace rime

--- a/src/rime/deployer.cc
+++ b/src/rime/deployer.cc
@@ -146,8 +146,8 @@ void Deployer::JoinMaintenanceThread() {
   JoinWorkThread();
 }
 
-string Deployer::user_data_sync_dir() const {
-  return (path(sync_dir) / user_id).string();
+path Deployer::user_data_sync_dir() const {
+  return sync_dir / path(user_id);
 }
 
 }  // namespace rime

--- a/src/rime/deployer.cc
+++ b/src/rime/deployer.cc
@@ -7,7 +7,7 @@
 #include <chrono>
 #include <exception>
 #include <utility>
-#include <filesystem>
+#include <rime/common.h>
 #include <rime/deployer.h>
 
 namespace rime {
@@ -147,7 +147,7 @@ void Deployer::JoinMaintenanceThread() {
 }
 
 string Deployer::user_data_sync_dir() const {
-  return (std::filesystem::path(sync_dir) / user_id).string();
+  return (path(sync_dir) / user_id).string();
 }
 
 }  // namespace rime

--- a/src/rime/deployer.h
+++ b/src/rime/deployer.h
@@ -32,11 +32,11 @@ class DeploymentTask : public Class<DeploymentTask, TaskInitializer> {
 class Deployer : public Messenger {
  public:
   // read-only access after library initialization {
-  string shared_data_dir;
-  string user_data_dir;
-  string prebuilt_data_dir;
-  string staging_dir;
-  string sync_dir;
+  path shared_data_dir;
+  path user_data_dir;
+  path prebuilt_data_dir;
+  path staging_dir;
+  path sync_dir;
   string user_id;
   string distribution_name;
   string distribution_code_name;
@@ -63,7 +63,7 @@ class Deployer : public Messenger {
   void JoinWorkThread();
   void JoinMaintenanceThread();
 
-  string user_data_sync_dir() const;
+  path user_data_sync_dir() const;
 
  private:
   std::queue<of<DeploymentTask>> pending_tasks_;

--- a/src/rime/dict/corrector.cc
+++ b/src/rime/dict/corrector.cc
@@ -240,8 +240,8 @@ bool EditDistanceCorrector::Build(const Syllabary& syllabary,
   return Prism::Build(syllabary, &correction_script, dict_file_checksum,
                       schema_file_checksum);
 }
-EditDistanceCorrector::EditDistanceCorrector(const string& file_name)
-    : Prism(file_name) {}
+EditDistanceCorrector::EditDistanceCorrector(const path& file_path)
+    : Prism(file_path) {}
 
 void NearSearchCorrector::ToleranceSearch(const Prism& prism,
                                           const string& key,
@@ -308,10 +308,10 @@ Corrector* CorrectorComponent::Create(const Ticket& ticket) noexcept {
     config->GetString(ticket.name_space + "/dictionary", &prism_name);
   }
 
-  auto file_name = resolver_->ResolvePath(prism_name).string();
+  auto file_path = resolver_->ResolvePath(prism_name);
 
-  auto ed_corrector = New<EditDistanceCorrector>(file_name);
-  if (edCorrector->Load()) {
+  auto ed_corrector = New<EditDistanceCorrector>(file_path);
+  if (ed_corrector->Load()) {
     return Combine(New<NearSearchCorrector>(), ed_corrector);
   } else {
     return new NearSearchCorrector();

--- a/src/rime/dict/corrector.h
+++ b/src/rime/dict/corrector.h
@@ -94,7 +94,7 @@ class CorrectorComponent : public Corrector::Component {
 class EditDistanceCorrector : public Corrector, public Prism {
  public:
   ~EditDistanceCorrector() override = default;
-  RIME_API explicit EditDistanceCorrector(const string& file_name);
+  RIME_API explicit EditDistanceCorrector(const path& file_path);
 
   RIME_API bool Build(const Syllabary& syllabary,
                       const Script* script = nullptr,

--- a/src/rime/dict/db.cc
+++ b/src/rime/dict/db.cc
@@ -29,18 +29,18 @@ DbComponentBase::DbComponentBase()
 
 DbComponentBase::~DbComponentBase() {}
 
-string DbComponentBase::DbFilePath(const string& name,
-                                   const string& extension) const {
-  return db_resource_resolver_->ResolvePath(name + extension).string();
+path DbComponentBase::DbFilePath(const string& name,
+                                 const string& extension) const {
+  return db_resource_resolver_->ResolvePath(name + extension);
 }
 
 // Db members
 
-Db::Db(const string& file_name, const string& name)
-    : name_(name), file_name_(file_name) {}
+Db::Db(const path& file_path, const string& name)
+    : name_(name), file_path_(file_path) {}
 
 bool Db::Exists() const {
-  return std::filesystem::exists(file_name());
+  return std::filesystem::exists(file_path());
 }
 
 bool Db::Remove() {
@@ -48,7 +48,7 @@ bool Db::Remove() {
     LOG(ERROR) << "attempt to remove opened db '" << name_ << "'.";
     return false;
   }
-  return std::filesystem::remove(file_name());
+  return std::filesystem::remove(file_path());
 }
 
 bool Db::CreateMetadata() {

--- a/src/rime/dict/db.h
+++ b/src/rime/dict/db.h
@@ -32,7 +32,7 @@ class DbAccessor {
 
 class Db : public Class<Db, const string&> {
  public:
-  Db(const string& file_name, const string& name);
+  Db(const path& file_path, const string& name);
   virtual ~Db() = default;
 
   RIME_API bool Exists() const;
@@ -42,8 +42,8 @@ class Db : public Class<Db, const string&> {
   virtual bool OpenReadOnly() = 0;
   virtual bool Close() = 0;
 
-  virtual bool Backup(const string& snapshot_file) = 0;
-  virtual bool Restore(const string& snapshot_file) = 0;
+  virtual bool Backup(const path& snapshot_file) = 0;
+  virtual bool Restore(const path& snapshot_file) = 0;
 
   virtual bool CreateMetadata();
   virtual bool MetaFetch(const string& key, string* value) = 0;
@@ -57,7 +57,7 @@ class Db : public Class<Db, const string&> {
   virtual bool Erase(const string& key) = 0;
 
   const string& name() const { return name_; }
-  const string& file_name() const { return file_name_; }
+  const path& file_path() const { return file_path_; }
   bool loaded() const { return loaded_; }
   bool readonly() const { return readonly_; }
   bool disabled() const { return disabled_; }
@@ -66,7 +66,7 @@ class Db : public Class<Db, const string&> {
 
  protected:
   string name_;
-  string file_name_;
+  path file_path_;
   bool loaded_ = false;
   bool readonly_ = false;
   bool disabled_ = false;
@@ -98,7 +98,7 @@ class RIME_API DbComponentBase {
   DbComponentBase();
   virtual ~DbComponentBase();
 
-  string DbFilePath(const string& name, const string& extension) const;
+  path DbFilePath(const string& name, const string& extension) const;
 
  protected:
   the<ResourceResolver> db_resource_resolver_;

--- a/src/rime/dict/db_pool_impl.h
+++ b/src/rime/dict/db_pool_impl.h
@@ -14,7 +14,7 @@ template <class T>
 an<T> DbPool<T>::GetDb(const string& db_name) {
   auto db = db_pool_[db_name].lock();
   if (!db) {
-    auto file_path = resource_resolver_->ResolvePath(db_name).string();
+    auto file_path = resource_resolver_->ResolvePath(db_name);
     db = New<T>(file_path);
     db_pool_[db_name] = db;
   }

--- a/src/rime/dict/dict_compiler.cc
+++ b/src/rime/dict/dict_compiler.cc
@@ -38,13 +38,13 @@ DictCompiler::~DictCompiler() {}
 
 static bool load_dict_settings_from_file(DictSettings* settings,
                                          const path& dict_file) {
-  std::ifstream fin(dict_file.string().c_str());
+  std::ifstream fin(dict_file.c_str());
   bool success = settings->LoadDictHeader(fin);
   fin.close();
   return success;
 }
 
-static bool get_dict_files_from_settings(vector<string>* dict_files,
+static bool get_dict_files_from_settings(vector<path>* dict_files,
                                          DictSettings& settings,
                                          ResourceResolver* source_resolver) {
   if (auto tables = settings.GetTables()) {
@@ -55,21 +55,21 @@ static bool get_dict_files_from_settings(vector<string>* dict_files,
         LOG(ERROR) << "source file '" << dict_file << "' does not exist.";
         return false;
       }
-      dict_files->push_back(dict_file.string());
+      dict_files->push_back(dict_file);
     }
   }
   return true;
 }
 
 static uint32_t compute_dict_file_checksum(uint32_t initial_checksum,
-                                           const vector<string>& dict_files,
+                                           const vector<path>& dict_files,
                                            DictSettings& settings) {
   if (dict_files.empty()) {
     return initial_checksum;
   }
   ChecksumComputer cc(initial_checksum);
-  for (const auto& file_name : dict_files) {
-    cc.ProcessFile(file_name);
+  for (const auto& file_path : dict_files) {
+    cc.ProcessFile(file_path);
   }
   if (settings.use_preset_vocabulary()) {
     cc.ProcessFile(PresetVocabulary::DictFilePath(settings.vocabulary()));
@@ -77,7 +77,7 @@ static uint32_t compute_dict_file_checksum(uint32_t initial_checksum,
   return cc.Checksum();
 }
 
-bool DictCompiler::Compile(const string& schema_file) {
+bool DictCompiler::Compile(const path& schema_file) {
   LOG(INFO) << "compiling dictionary for " << schema_file;
   bool build_table_from_source = true;
   DictSettings settings;
@@ -89,7 +89,7 @@ bool DictCompiler::Compile(const string& schema_file) {
     LOG(ERROR) << "failed to load settings from '" << dict_file << "'.";
     return false;
   }
-  vector<string> dict_files;
+  vector<path> dict_files;
   if (!get_dict_files_from_settings(&dict_files, settings,
                                     source_resolver_.get())) {
     return false;
@@ -106,7 +106,7 @@ bool DictCompiler::Compile(const string& schema_file) {
       rebuild_table = primary_table->dict_file_checksum() != dict_file_checksum;
     } else {
       dict_file_checksum = primary_table->dict_file_checksum();
-      LOG(INFO) << "reuse existing table: " << primary_table->file_name();
+      LOG(INFO) << "reuse existing table: " << primary_table->file_path();
     }
     primary_table->Close();
   } else if (build_table_from_source) {
@@ -130,7 +130,7 @@ bool DictCompiler::Compile(const string& schema_file) {
     the<ResourceResolver> resolver(
         Service::instance().CreateDeployedResourceResolver(
             {"find_reverse_db", "", ".reverse.bin"}));
-    ReverseDb reverse_db(resolver->ResolvePath(dict_name_).string());
+    ReverseDb reverse_db(resolver->ResolvePath(dict_name_));
     if (!reverse_db.Exists() || !reverse_db.Load() ||
         reverse_db.dict_file_checksum() != dict_file_checksum) {
       rebuild_table = true;
@@ -168,7 +168,7 @@ bool DictCompiler::Compile(const string& schema_file) {
         LOG(ERROR) << "failed to load settings from '" << dict_file << "'.";
         continue;
       }
-      vector<string> dict_files;
+      vector<path> dict_files;
       if (!get_dict_files_from_settings(&dict_files, settings,
                                         source_resolver_.get())) {
         continue;
@@ -188,27 +188,27 @@ bool DictCompiler::Compile(const string& schema_file) {
 
 static path relocate_target(const path& source_path,
                             ResourceResolver* target_resolver) {
-  auto resource_id = source_path.filename().string();
+  auto resource_id = source_path.filename().u8string();
   return target_resolver->ResolvePath(resource_id);
 }
 
 bool DictCompiler::BuildTable(int table_index,
                               EntryCollector& collector,
                               DictSettings* settings,
-                              const vector<string>& dict_files,
+                              const vector<path>& dict_files,
                               uint32_t dict_file_checksum) {
   auto& table = tables_[table_index];
   auto target_path =
-      relocate_target(table->file_name(), target_resolver_.get());
+      relocate_target(table->file_path(), target_resolver_.get());
   LOG(INFO) << "building table: " << target_path;
-  table = New<Table>(target_path.string());
+  table = New<Table>(target_path);
 
   collector.Configure(settings);
   collector.Collect(dict_files);
   if (options_ & kDump) {
-    path dump_path(table->file_name());
+    path dump_path(table->file_path());
     dump_path.replace_extension(".txt");
-    collector.Dump(dump_path.string());
+    collector.Dump(dump_path);
   }
   Vocabulary vocabulary;
   // build .table.bin
@@ -261,9 +261,8 @@ bool DictCompiler::BuildReverseDb(DictSettings* settings,
                                   const Vocabulary& vocabulary,
                                   uint32_t dict_file_checksum) {
   // build .reverse.bin
-  auto target_path =
-      relocate_target(dict_name_ + ".reverse.bin", target_resolver_.get());
-  ReverseDb reverse_db(target_path.string());
+  auto target_path = target_resolver_->ResolvePath(dict_name_ + ".reverse.bin");
+  ReverseDb reverse_db(target_path);
   if (!reverse_db.Build(settings, collector.syllabary, vocabulary,
                         collector.stems, dict_file_checksum) ||
       !reverse_db.Save()) {
@@ -273,13 +272,13 @@ bool DictCompiler::BuildReverseDb(DictSettings* settings,
   return true;
 }
 
-bool DictCompiler::BuildPrism(const string& schema_file,
+bool DictCompiler::BuildPrism(const path& schema_file,
                               uint32_t dict_file_checksum,
                               uint32_t schema_file_checksum) {
   LOG(INFO) << "building prism...";
   auto target_path =
-      relocate_target(prism_->file_name(), target_resolver_.get());
-  prism_ = New<Prism>(target_path.string());
+      relocate_target(prism_->file_path(), target_resolver_.get());
+  prism_ = New<Prism>(target_path);
 
   // get syllabary from primary table, which may not be rebuilt
   Syllabary syllabary;
@@ -311,12 +310,12 @@ bool DictCompiler::BuildPrism(const string& schema_file,
     bool enable_correction = false; // Avoid if initializer to comfort compilers
     if (config.GetBool("translator/enable_correction", &enable_correction) &&
         enable_correction) {
-      path corrector_path(prism_->file_name());
+      path corrector_path(prism_->file_path());
       corrector_path.replace_extension("");
       corrector_path.replace_extension(".correction.bin");
       auto target_path = relocate_target(corrector_path,
                                          target_resolver_.get());
-      correction_ = New<EditDistanceCorrector>(target_path.string());
+      correction_ = New<EditDistanceCorrector>(target_path);
       if (correction_->Exists()) {
         correction_->Remove();
       }
@@ -329,9 +328,9 @@ bool DictCompiler::BuildPrism(const string& schema_file,
 #endif
   }
   if ((options_ & kDump) && !script.empty()) {
-    path dump_path(prism_->file_name());
+    path dump_path(prism_->file_path());
     dump_path.replace_extension(".txt");
-    script.Dump(dump_path.string());
+    script.Dump(dump_path);
   }
   // build .prism.bin
   {

--- a/src/rime/dict/dict_compiler.h
+++ b/src/rime/dict/dict_compiler.h
@@ -34,16 +34,16 @@ class DictCompiler {
   RIME_API explicit DictCompiler(Dictionary* dictionary);
   RIME_API virtual ~DictCompiler();
 
-  RIME_API bool Compile(const string& schema_file);
+  RIME_API bool Compile(const path& schema_file);
   void set_options(int options) { options_ = options; }
 
  private:
   bool BuildTable(int table_index,
                   EntryCollector& collector,
                   DictSettings* settings,
-                  const vector<string>& dict_files,
+                  const vector<path>& dict_files,
                   uint32_t dict_file_checksum);
-  bool BuildPrism(const string& schema_file,
+  bool BuildPrism(const path& schema_file,
                   uint32_t dict_file_checksum,
                   uint32_t schema_file_checksum);
   bool BuildReverseDb(DictSettings* settings,

--- a/src/rime/dict/dictionary.cc
+++ b/src/rime/dict/dictionary.cc
@@ -306,8 +306,8 @@ bool Dictionary::Decode(const Code& code, vector<string>* result) {
 }
 
 bool Dictionary::Exists() const {
-  return std::filesystem::exists(prism_->file_name()) && !tables_.empty() &&
-         std::filesystem::exists(tables_[0]->file_name());
+  return std::filesystem::exists(prism_->file_path()) && !tables_.empty() &&
+         std::filesystem::exists(tables_[0]->file_path());
 }
 
 bool Dictionary::Remove() {
@@ -400,19 +400,19 @@ Dictionary* DictionaryComponent::Create(string dict_name,
   // obtain prism and primary table objects
   auto primary_table = table_map_[dict_name].lock();
   if (!primary_table) {
-    auto file_path = table_resource_resolver_->ResolvePath(dict_name).string();
+    auto file_path = table_resource_resolver_->ResolvePath(dict_name);
     table_map_[dict_name] = primary_table = New<Table>(file_path);
   }
   auto prism = prism_map_[prism_name].lock();
   if (!prism) {
-    auto file_path = prism_resource_resolver_->ResolvePath(prism_name).string();
+    auto file_path = prism_resource_resolver_->ResolvePath(prism_name);
     prism_map_[prism_name] = prism = New<Prism>(file_path);
   }
   vector<of<Table>> tables = {std::move(primary_table)};
   for (const auto& pack : packs) {
     auto table = table_map_[pack].lock();
     if (!table) {
-      auto file_path = table_resource_resolver_->ResolvePath(pack).string();
+      auto file_path = table_resource_resolver_->ResolvePath(pack);
       table_map_[pack] = table = New<Table>(file_path);
     }
     tables.push_back(std::move(table));

--- a/src/rime/dict/entry_collector.cc
+++ b/src/rime/dict/entry_collector.cc
@@ -35,8 +35,8 @@ void EntryCollector::Configure(DictSettings* settings) {
   encoder->LoadSettings(settings);
 }
 
-void EntryCollector::Collect(const vector<string>& dict_files) {
-  for (const string& dict_file : dict_files) {
+void EntryCollector::Collect(const vector<path>& dict_files) {
+  for (const path& dict_file : dict_files) {
     Collect(dict_file);
   }
   Finish();
@@ -54,7 +54,7 @@ void EntryCollector::LoadPresetVocabulary(DictSettings* settings) {
   }
 }
 
-void EntryCollector::Collect(const string& dict_file) {
+void EntryCollector::Collect(const path& dict_file) {
   LOG(INFO) << "collecting entries from " << dict_file;
   // read table
   std::ifstream fin(dict_file.c_str());
@@ -234,8 +234,8 @@ bool EntryCollector::TranslateWord(const string& word, vector<string>* result) {
   return false;
 }
 
-void EntryCollector::Dump(const string& file_name) const {
-  std::ofstream out(file_name.c_str());
+void EntryCollector::Dump(const path& file_path) const {
+  std::ofstream out(file_path.c_str());
   out << "# syllabary:" << std::endl;
   for (const string& syllable : syllabary) {
     out << "# - " << syllable << std::endl;

--- a/src/rime/dict/entry_collector.h
+++ b/src/rime/dict/entry_collector.h
@@ -47,10 +47,10 @@ class EntryCollector : public PhraseCollector {
   virtual ~EntryCollector();
 
   void Configure(DictSettings* settings);
-  void Collect(const vector<string>& dict_files);
+  void Collect(const vector<path>& dict_files);
 
   // export contents of table and prism to text files
-  void Dump(const string& file_name) const;
+  void Dump(const path& file_path) const;
 
   void CreateEntry(const string& word,
                    const string& code_str,
@@ -60,7 +60,7 @@ class EntryCollector : public PhraseCollector {
  protected:
   void LoadPresetVocabulary(DictSettings* settings);
   // call Collect() multiple times for all required tables
-  void Collect(const string& dict_file);
+  void Collect(const path& dict_file);
   // encode all collected entries
   void Finish();
 

--- a/src/rime/dict/level_db.cc
+++ b/src/rime/dict/level_db.cc
@@ -51,10 +51,10 @@ struct LevelDbWrapper {
   leveldb::DB* ptr = nullptr;
   leveldb::WriteBatch batch;
 
-  leveldb::Status Open(const string& file_name, bool readonly) {
+  leveldb::Status Open(const path& file_path, bool readonly) {
     leveldb::Options options;
     options.create_if_missing = !readonly;
-    return leveldb::DB::Open(options, file_name, &ptr);
+    return leveldb::DB::Open(options, file_path.string(), &ptr);
   }
 
   void Release() {
@@ -139,10 +139,10 @@ bool LevelDbAccessor::exhausted() {
 
 // LevelDb members
 
-LevelDb::LevelDb(const string& file_name,
+LevelDb::LevelDb(const path& file_path,
                  const string& db_name,
                  const string& db_type)
-    : Db(file_name, db_name), db_type_(db_type) {}
+    : Db(file_path, db_name), db_type_(db_type) {}
 
 LevelDb::~LevelDb() {
   if (loaded())
@@ -190,7 +190,7 @@ bool LevelDb::Erase(const string& key) {
   return db_->Erase(key, in_transaction());
 }
 
-bool LevelDb::Backup(const string& snapshot_file) {
+bool LevelDb::Backup(const path& snapshot_file) {
   if (!loaded())
     return false;
   LOG(INFO) << "backing up db '" << name() << "' to " << snapshot_file;
@@ -203,7 +203,7 @@ bool LevelDb::Backup(const string& snapshot_file) {
   return success;
 }
 
-bool LevelDb::Restore(const string& snapshot_file) {
+bool LevelDb::Restore(const path& snapshot_file) {
   if (!loaded() || readonly())
     return false;
   // TODO(chen): suppose we only use this method for user dbs.
@@ -217,7 +217,7 @@ bool LevelDb::Restore(const string& snapshot_file) {
 
 bool LevelDb::Recover() {
   LOG(INFO) << "trying to recover db '" << name() << "'.";
-  auto status = leveldb::RepairDB(file_name(), leveldb::Options());
+  auto status = leveldb::RepairDB(file_path().string(), leveldb::Options());
   if (status.ok()) {
     LOG(INFO) << "repair finished.";
     return true;
@@ -231,7 +231,7 @@ bool LevelDb::Remove() {
     LOG(ERROR) << "attempt to remove opened db '" << name() << "'.";
     return false;
   }
-  auto status = leveldb::DestroyDB(file_name(), leveldb::Options());
+  auto status = leveldb::DestroyDB(file_path().string(), leveldb::Options());
   if (!status.ok()) {
     LOG(ERROR) << "Error removing db '" << name() << "': " << status.ToString();
     return false;
@@ -244,7 +244,7 @@ bool LevelDb::Open() {
     return false;
   Initialize();
   readonly_ = false;
-  auto status = db_->Open(file_name(), readonly_);
+  auto status = db_->Open(file_path(), readonly_);
   loaded_ = status.ok();
 
   if (loaded_) {
@@ -266,7 +266,7 @@ bool LevelDb::OpenReadOnly() {
     return false;
   Initialize();
   readonly_ = true;
-  auto status = db_->Open(file_name(), readonly_);
+  auto status = db_->Open(file_path(), readonly_);
   loaded_ = status.ok();
 
   if (!loaded_) {
@@ -331,8 +331,8 @@ RIME_API string UserDbComponent<LevelDb>::extension() const {
 }
 
 template <>
-RIME_API UserDbWrapper<LevelDb>::UserDbWrapper(const string& file_name,
+RIME_API UserDbWrapper<LevelDb>::UserDbWrapper(const path& file_path,
                                                const string& db_name)
-    : LevelDb(file_name, db_name, "userdb") {}
+    : LevelDb(file_path, db_name, "userdb") {}
 
 }  // namespace rime

--- a/src/rime/dict/level_db.cc
+++ b/src/rime/dict/level_db.cc
@@ -5,7 +5,6 @@
 // 2014-12-04 Chen Gong <chen.sst@gmail.com>
 //
 
-#include <filesystem>
 #include <leveldb/db.h>
 #include <leveldb/write_batch.h>
 #include <rime/common.h>

--- a/src/rime/dict/level_db.h
+++ b/src/rime/dict/level_db.h
@@ -22,10 +22,10 @@ class LevelDbAccessor : public DbAccessor {
   LevelDbAccessor(LevelDbCursor* cursor, const string& prefix);
   virtual ~LevelDbAccessor();
 
-  virtual bool Reset();
-  virtual bool Jump(const string& key);
-  virtual bool GetNextRecord(string* key, string* value);
-  virtual bool exhausted();
+  bool Reset() override;
+  bool Jump(const string& key) override;
+  bool GetNextRecord(string* key, string* value) override;
+  bool exhausted() override;
 
  private:
   the<LevelDbCursor> cursor_;
@@ -34,37 +34,37 @@ class LevelDbAccessor : public DbAccessor {
 
 class LevelDb : public Db, public Recoverable, public Transactional {
  public:
-  LevelDb(const string& file_name,
+  LevelDb(const path& file_path,
           const string& db_name,
           const string& db_type = "");
   virtual ~LevelDb();
 
-  virtual bool Remove();
-  virtual bool Open();
-  virtual bool OpenReadOnly();
-  virtual bool Close();
+  bool Remove() override;
+  bool Open() override;
+  bool OpenReadOnly() override;
+  bool Close() override;
 
-  virtual bool Backup(const string& snapshot_file);
-  virtual bool Restore(const string& snapshot_file);
+  bool Backup(const path& snapshot_file) override;
+  bool Restore(const path& snapshot_file) override;
 
-  virtual bool CreateMetadata();
-  virtual bool MetaFetch(const string& key, string* value);
-  virtual bool MetaUpdate(const string& key, const string& value);
+  bool CreateMetadata() override;
+  bool MetaFetch(const string& key, string* value) override;
+  bool MetaUpdate(const string& key, const string& value) override;
 
-  virtual an<DbAccessor> QueryMetadata();
-  virtual an<DbAccessor> QueryAll();
-  virtual an<DbAccessor> Query(const string& key);
-  virtual bool Fetch(const string& key, string* value);
-  virtual bool Update(const string& key, const string& value);
-  virtual bool Erase(const string& key);
+  an<DbAccessor> QueryMetadata() override;
+  an<DbAccessor> QueryAll() override;
+  an<DbAccessor> Query(const string& key) override;
+  bool Fetch(const string& key, string* value) override;
+  bool Update(const string& key, const string& value) override;
+  bool Erase(const string& key) override;
 
   // Recoverable
-  virtual bool Recover();
+  bool Recover() override;
 
   // Transactional
-  virtual bool BeginTransaction();
-  virtual bool AbortTransaction();
-  virtual bool CommitTransaction();
+  bool BeginTransaction() override;
+  bool AbortTransaction() override;
+  bool CommitTransaction() override;
 
  private:
   void Initialize();

--- a/src/rime/dict/mapped_file.cc
+++ b/src/rime/dict/mapped_file.cc
@@ -21,11 +21,11 @@ class MappedFileImpl {
     kOpenReadWrite,
   };
 
-  MappedFileImpl(const string& file_name, OpenMode mode) {
+  MappedFileImpl(const path& file_path, OpenMode mode) {
     boost::interprocess::mode_t file_mapping_mode =
         (mode == kOpenReadOnly) ? boost::interprocess::read_only
                                 : boost::interprocess::read_write;
-    file_.reset(new boost::interprocess::file_mapping(file_name.c_str(),
+    file_.reset(new boost::interprocess::file_mapping(file_path.c_str(),
                                                       file_mapping_mode));
     region_.reset(
         new boost::interprocess::mapped_region(*file_, file_mapping_mode));
@@ -43,7 +43,7 @@ class MappedFileImpl {
   the<boost::interprocess::mapped_region> region_;
 };
 
-MappedFile::MappedFile(const string& file_name) : file_name_(file_name) {}
+MappedFile::MappedFile(const path& file_path) : file_path_(file_path) {}
 
 MappedFile::~MappedFile() {
   if (file_) {
@@ -53,12 +53,12 @@ MappedFile::~MappedFile() {
 
 bool MappedFile::Create(size_t capacity) {
   if (Exists()) {
-    LOG(INFO) << "overwriting file '" << file_name_ << "'.";
+    LOG(INFO) << "overwriting file '" << file_path_ << "'.";
     Resize(capacity);
   } else {
-    LOG(INFO) << "creating file '" << file_name_ << "'.";
+    LOG(INFO) << "creating file '" << file_path_ << "'.";
     std::filebuf fbuf;
-    fbuf.open(file_name_.c_str(), std::ios_base::in | std::ios_base::out |
+    fbuf.open(file_path_.c_str(), std::ios_base::in | std::ios_base::out |
                                       std::ios_base::trunc |
                                       std::ios_base::binary);
     if (capacity > 0) {
@@ -68,27 +68,27 @@ bool MappedFile::Create(size_t capacity) {
     fbuf.close();
   }
   LOG(INFO) << "opening file for read/write access.";
-  file_.reset(new MappedFileImpl(file_name_, MappedFileImpl::kOpenReadWrite));
+  file_.reset(new MappedFileImpl(file_path_, MappedFileImpl::kOpenReadWrite));
   size_ = 0;
   return bool(file_);
 }
 
 bool MappedFile::OpenReadOnly() {
   if (!Exists()) {
-    LOG(ERROR) << "attempt to open non-existent file '" << file_name_ << "'.";
+    LOG(ERROR) << "attempt to open non-existent file '" << file_path_ << "'.";
     return false;
   }
-  file_.reset(new MappedFileImpl(file_name_, MappedFileImpl::kOpenReadOnly));
+  file_.reset(new MappedFileImpl(file_path_, MappedFileImpl::kOpenReadOnly));
   size_ = file_->get_size();
   return bool(file_);
 }
 
 bool MappedFile::OpenReadWrite() {
   if (!Exists()) {
-    LOG(ERROR) << "attempt to open non-existent file '" << file_name_ << "'.";
+    LOG(ERROR) << "attempt to open non-existent file '" << file_path_ << "'.";
     return false;
   }
-  file_.reset(new MappedFileImpl(file_name_, MappedFileImpl::kOpenReadWrite));
+  file_.reset(new MappedFileImpl(file_path_, MappedFileImpl::kOpenReadWrite));
   size_ = 0;
   return bool(file_);
 }
@@ -101,7 +101,7 @@ void MappedFile::Close() {
 }
 
 bool MappedFile::Exists() const {
-  return std::filesystem::exists(file_name_);
+  return std::filesystem::exists(file_path_);
 }
 
 bool MappedFile::IsOpen() const {
@@ -122,7 +122,7 @@ bool MappedFile::ShrinkToFit() {
 bool MappedFile::Remove() {
   if (IsOpen())
     Close();
-  return boost::interprocess::file_mapping::remove(file_name_.c_str());
+  return boost::interprocess::file_mapping::remove(file_path_.c_str());
 }
 
 bool MappedFile::Resize(size_t capacity) {
@@ -130,7 +130,7 @@ bool MappedFile::Resize(size_t capacity) {
   if (IsOpen())
     Close();
   try {
-    std::filesystem::resize_file(file_name_.c_str(), capacity);
+    std::filesystem::resize_file(file_path_, capacity);
   } catch (...) {
     return false;
   }

--- a/src/rime/dict/mapped_file.h
+++ b/src/rime/dict/mapped_file.h
@@ -82,7 +82,7 @@ class MappedFileImpl;
 
 class RIME_API MappedFile {
  protected:
-  explicit MappedFile(const string& file_name);
+  explicit MappedFile(const path& file_path);
   virtual ~MappedFile();
 
   bool Create(size_t capacity);
@@ -117,11 +117,11 @@ class RIME_API MappedFile {
   template <class T>
   T* Find(size_t offset);
 
-  const string& file_name() const { return file_name_; }
+  const path& file_path() const { return file_path_; }
   size_t file_size() const { return size_; }
 
  private:
-  string file_name_;
+  path file_path_;
   size_t size_ = 0;
   the<MappedFileImpl> file_;
 };

--- a/src/rime/dict/preset_vocabulary.cc
+++ b/src/rime/dict/preset_vocabulary.cc
@@ -49,10 +49,10 @@ const TextFormat VocabularyDb::format = {
     "Rime vocabulary",
 };
 
-string PresetVocabulary::DictFilePath(const string& vocabulary) {
+path PresetVocabulary::DictFilePath(const string& vocabulary) {
   the<ResourceResolver> resource_resolver(
       Service::instance().CreateResourceResolver(kVocabularyResourceType));
-  return resource_resolver->ResolvePath(vocabulary).string();
+  return resource_resolver->ResolvePath(vocabulary);
 }
 
 PresetVocabulary::PresetVocabulary(const string& vocabulary) {

--- a/src/rime/dict/preset_vocabulary.cc
+++ b/src/rime/dict/preset_vocabulary.cc
@@ -4,7 +4,6 @@
 //
 // 2011-11-27 GONG Chen <chen.sst@gmail.com>
 //
-#include <filesystem>
 #include <utf8.h>
 #include <rime/resource.h>
 #include <rime/service.h>

--- a/src/rime/dict/preset_vocabulary.cc
+++ b/src/rime/dict/preset_vocabulary.cc
@@ -15,13 +15,16 @@ namespace rime {
 static const ResourceType kVocabularyResourceType = {"vocabulary", "", ".txt"};
 
 struct VocabularyDb : public TextDb {
-  VocabularyDb(const string& path, const string& name);
+  VocabularyDb(const path& file_path, const string& db_name);
   an<DbAccessor> cursor;
   static const TextFormat format;
 };
 
-VocabularyDb::VocabularyDb(const string& path, const string& name)
-    : TextDb(path, name, kVocabularyResourceType.name, VocabularyDb::format) {}
+VocabularyDb::VocabularyDb(const path& file_path, const string& db_name)
+    : TextDb(file_path,
+             db_name,
+             kVocabularyResourceType.name,
+             VocabularyDb::format) {}
 
 static bool rime_vocabulary_entry_parser(const Tsv& row,
                                          string* key,

--- a/src/rime/dict/preset_vocabulary.h
+++ b/src/rime/dict/preset_vocabulary.h
@@ -28,7 +28,7 @@ class PresetVocabulary {
   void set_max_phrase_length(int length) { max_phrase_length_ = length; }
   void set_min_phrase_weight(double weight) { min_phrase_weight_ = weight; }
 
-  static string DictFilePath(const string& vacabulary);
+  static path DictFilePath(const string& vacabulary);
 
  protected:
   the<VocabularyDb> db_;

--- a/src/rime/dict/prism.cc
+++ b/src/rime/dict/prism.cc
@@ -69,17 +69,17 @@ SpellingProperties SpellingAccessor::properties() const {
   return props;
 }
 
-Prism::Prism(const string& file_name)
-    : MappedFile(file_name), trie_(new Darts::DoubleArray) {}
+Prism::Prism(const path& file_path)
+    : MappedFile(file_path), trie_(new Darts::DoubleArray) {}
 
 bool Prism::Load() {
-  LOG(INFO) << "loading prism file: " << file_name();
+  LOG(INFO) << "loading prism file: " << file_path();
 
   if (IsOpen())
     Close();
 
   if (!OpenReadOnly()) {
-    LOG(ERROR) << "error opening prism file '" << file_name() << "'.";
+    LOG(ERROR) << "error opening prism file '" << file_path() << "'.";
     return false;
   }
 
@@ -114,7 +114,7 @@ bool Prism::Load() {
 }
 
 bool Prism::Save() {
-  LOG(INFO) << "saving prism file: " << file_name();
+  LOG(INFO) << "saving prism file: " << file_path();
   if (!trie_->total_size()) {
     LOG(ERROR) << "the trie has not been constructed!";
     return false;
@@ -154,13 +154,13 @@ bool Prism::Build(const Syllabary& syllabary,
       map_size * (4 + sizeof(prism::SpellingDescriptor) + kDescriptorExtraSize);
   const size_t kReservedSize = 1024;
   if (!Create(image_size + estimated_map_size + kReservedSize)) {
-    LOG(ERROR) << "Error creating prism file '" << file_name() << "'.";
+    LOG(ERROR) << "Error creating prism file '" << file_path() << "'.";
     return false;
   }
   // creating metadata
   auto metadata = Allocate<prism::Metadata>();
   if (!metadata) {
-    LOG(ERROR) << "Error creating metadata in file '" << file_name() << "'.";
+    LOG(ERROR) << "Error creating metadata in file '" << file_path() << "'.";
     return false;
   }
   metadata->dict_file_checksum = dict_file_checksum;

--- a/src/rime/dict/prism.h
+++ b/src/rime/dict/prism.h
@@ -67,7 +67,7 @@ class Prism : public MappedFile {
  public:
   using Match = Darts::DoubleArray::result_pair_type;
 
-  RIME_API explicit Prism(const string& file_name);
+  RIME_API explicit Prism(const path& file_path);
 
   RIME_API bool Load();
   RIME_API bool Save();

--- a/src/rime/dict/reverse_lookup_dictionary.cc
+++ b/src/rime/dict/reverse_lookup_dictionary.cc
@@ -27,16 +27,16 @@ const size_t kReverseFormatPrefixLen = sizeof(kReverseFormatPrefix) - 1;
 
 static const char* kStemKeySuffix = "\x1fstem";
 
-ReverseDb::ReverseDb(const string& file_name) : MappedFile(file_name) {}
+ReverseDb::ReverseDb(const path& file_path) : MappedFile(file_path) {}
 
 bool ReverseDb::Load() {
-  LOG(INFO) << "loading reversedb: " << file_name();
+  LOG(INFO) << "loading reversedb: " << file_path();
 
   if (IsOpen())
     Close();
 
   if (!OpenReadOnly()) {
-    LOG(ERROR) << "Error opening reversedb '" << file_name() << "'.";
+    LOG(ERROR) << "Error opening reversedb '" << file_path() << "'.";
     return false;
   }
 
@@ -139,14 +139,14 @@ bool ReverseDb::Build(DictSettings* settings,
                                entry_count * sizeof(StringId) +
                                key_trie_image_size + value_trie_image_size;
   if (!Create(estimated_data_size)) {
-    LOG(ERROR) << "Error creating prism file '" << file_name() << "'.";
+    LOG(ERROR) << "Error creating prism file '" << file_path() << "'.";
     return false;
   }
 
   // create metadata
   metadata_ = Allocate<reverse::Metadata>();
   if (!metadata_) {
-    LOG(ERROR) << "Error creating metadata in file '" << file_name() << "'.";
+    LOG(ERROR) << "Error creating metadata in file '" << file_path() << "'.";
     return false;
   }
   metadata_->dict_file_checksum = dict_file_checksum;
@@ -194,7 +194,7 @@ bool ReverseDb::Build(DictSettings* settings,
 }
 
 bool ReverseDb::Save() {
-  LOG(INFO) << "saving reverse file: " << file_name();
+  LOG(INFO) << "saving reverse file: " << file_path();
   return ShrinkToFit();
 }
 

--- a/src/rime/dict/reverse_lookup_dictionary.cc
+++ b/src/rime/dict/reverse_lookup_dictionary.cc
@@ -9,7 +9,6 @@
 #include <cstdlib>
 #include <sstream>
 #include <boost/algorithm/string.hpp>
-#include <filesystem>
 #include <rime/resource.h>
 #include <rime/schema.h>
 #include <rime/service.h>

--- a/src/rime/dict/reverse_lookup_dictionary.h
+++ b/src/rime/dict/reverse_lookup_dictionary.h
@@ -39,7 +39,7 @@ class DictSettings;
 
 class ReverseDb : public MappedFile {
  public:
-  explicit ReverseDb(const string& file_name);
+  explicit ReverseDb(const path& file_path);
 
   bool Load();
   bool Lookup(const string& text, string* result);

--- a/src/rime/dict/table.cc
+++ b/src/rime/dict/table.cc
@@ -246,18 +246,18 @@ bool Table::OnLoad() {
   return true;
 }
 
-Table::Table(const string& file_name) : MappedFile(file_name) {}
+Table::Table(const path& file_path) : MappedFile(file_path) {}
 
 Table::~Table() {}
 
 bool Table::Load() {
-  LOG(INFO) << "loading table file: " << file_name();
+  LOG(INFO) << "loading table file: " << file_path();
 
   if (IsOpen())
     Close();
 
   if (!OpenReadOnly()) {
-    LOG(ERROR) << "Error opening table file '" << file_name() << "'.";
+    LOG(ERROR) << "Error opening table file '" << file_path() << "'.";
     return false;
   }
 
@@ -297,7 +297,7 @@ bool Table::Load() {
 }
 
 bool Table::Save() {
-  LOG(INFO) << "saving table file: " << file_name();
+  LOG(INFO) << "saving table file: " << file_path();
 
   if (!index_) {
     LOG(ERROR) << "the table has not been constructed!";
@@ -324,14 +324,14 @@ bool Table::Build(const Syllabary& syllabary,
   LOG(INFO) << "num entries: " << num_entries;
   LOG(INFO) << "estimated file size: " << estimated_file_size;
   if (!Create(estimated_file_size)) {
-    LOG(ERROR) << "Error creating table file '" << file_name() << "'.";
+    LOG(ERROR) << "Error creating table file '" << file_path() << "'.";
     return false;
   }
 
   LOG(INFO) << "creating metadata.";
   metadata_ = Allocate<table::Metadata>();
   if (!metadata_) {
-    LOG(ERROR) << "Error creating metadata in file '" << file_name() << "'.";
+    LOG(ERROR) << "Error creating metadata in file '" << file_path() << "'.";
     return false;
   }
   metadata_->dict_file_checksum = dict_file_checksum;

--- a/src/rime/dict/table.h
+++ b/src/rime/dict/table.h
@@ -162,7 +162,7 @@ class TableQuery {
 
 class Table : public MappedFile {
  public:
-  RIME_API Table(const string& file_name);
+  RIME_API Table(const path& file_path);
   virtual ~Table();
 
   RIME_API bool Load();

--- a/src/rime/dict/table_db.cc
+++ b/src/rime/dict/table_db.cc
@@ -60,11 +60,11 @@ const TextFormat TableDb::format = {
     "Rime table",
 };
 
-TableDb::TableDb(const string& file_name, const string& db_name)
-    : TextDb(file_name, db_name, "tabledb", TableDb::format) {}
+TableDb::TableDb(const path& file_path, const string& db_name)
+    : TextDb(file_path, db_name, "tabledb", TableDb::format) {}
 
-StableDb::StableDb(const string& file_name, const string& db_name)
-    : TableDb(file_name, db_name) {}
+StableDb::StableDb(const path& file_path, const string& db_name)
+    : TableDb(file_path, db_name) {}
 
 bool StableDb::Open() {
   if (loaded())

--- a/src/rime/dict/table_db.h
+++ b/src/rime/dict/table_db.h
@@ -13,7 +13,7 @@ namespace rime {
 
 class TableDb : public TextDb {
  public:
-  TableDb(const string& file_name, const string& db_name);
+  TableDb(const path& file_path, const string& db_name);
 
   static const TextFormat format;
 };
@@ -21,7 +21,7 @@ class TableDb : public TextDb {
 // read-only tabledb
 class StableDb : public TableDb {
  public:
-  StableDb(const string& file_name, const string& db_name);
+  StableDb(const path& file_path, const string& db_name);
 
   virtual bool Open();
 };

--- a/src/rime/dict/text_db.cc
+++ b/src/rime/dict/text_db.cc
@@ -43,11 +43,11 @@ bool TextDbAccessor::exhausted() {
 
 // TextDb members
 
-TextDb::TextDb(const string& file_name,
+TextDb::TextDb(const path& file_path,
                const string& db_name,
                const string& db_type,
                TextFormat format)
-    : Db(file_name, db_name), db_type_(db_type), format_(format) {}
+    : Db(file_path, db_name), db_type_(db_type), format_(format) {}
 
 TextDb::~TextDb() {
   if (loaded())
@@ -104,7 +104,7 @@ bool TextDb::Open() {
     return false;
   loaded_ = true;
   readonly_ = false;
-  loaded_ = !Exists() || LoadFromFile(file_name());
+  loaded_ = !Exists() || LoadFromFile(file_path());
   if (loaded_) {
     string db_name;
     if (!MetaFetch("/db_name", &db_name)) {
@@ -125,7 +125,7 @@ bool TextDb::OpenReadOnly() {
     return false;
   loaded_ = true;
   readonly_ = false;
-  loaded_ = Exists() && LoadFromFile(file_name());
+  loaded_ = Exists() && LoadFromFile(file_path());
   if (loaded_) {
     readonly_ = true;
   } else {
@@ -138,7 +138,7 @@ bool TextDb::OpenReadOnly() {
 bool TextDb::Close() {
   if (!loaded())
     return false;
-  if (modified_ && !SaveToFile(file_name())) {
+  if (modified_ && !SaveToFile(file_path())) {
     return false;
   }
   loaded_ = false;
@@ -153,7 +153,7 @@ void TextDb::Clear() {
   data_.clear();
 }
 
-bool TextDb::Backup(const string& snapshot_file) {
+bool TextDb::Backup(const path& snapshot_file) {
   if (!loaded())
     return false;
   LOG(INFO) << "backing up db '" << name() << "' to " << snapshot_file;
@@ -165,7 +165,7 @@ bool TextDb::Backup(const string& snapshot_file) {
   return true;
 }
 
-bool TextDb::Restore(const string& snapshot_file) {
+bool TextDb::Restore(const path& snapshot_file) {
   if (!loaded() || readonly())
     return false;
   if (!LoadFromFile(snapshot_file)) {
@@ -200,7 +200,7 @@ bool TextDb::MetaUpdate(const string& key, const string& value) {
   return true;
 }
 
-bool TextDb::LoadFromFile(const string& file) {
+bool TextDb::LoadFromFile(const path& file) {
   Clear();
   TsvReader reader(file, format_.parser);
   DbSink sink(this);
@@ -215,7 +215,7 @@ bool TextDb::LoadFromFile(const string& file) {
   return true;
 }
 
-bool TextDb::SaveToFile(const string& file) {
+bool TextDb::SaveToFile(const path& file) {
   TsvWriter writer(file, format_.formatter);
   writer.file_description = format_.file_description;
   DbSource source(this);

--- a/src/rime/dict/text_db.h
+++ b/src/rime/dict/text_db.h
@@ -39,34 +39,34 @@ struct TextFormat {
 
 class TextDb : public Db {
  public:
-  TextDb(const string& file_name,
+  TextDb(const path& file_path,
          const string& db_name,
          const string& db_type,
          TextFormat format);
   RIME_API virtual ~TextDb();
 
-  RIME_API virtual bool Open();
-  RIME_API virtual bool OpenReadOnly();
-  RIME_API virtual bool Close();
+  RIME_API bool Open() override;
+  RIME_API bool OpenReadOnly() override;
+  RIME_API bool Close() override;
 
-  RIME_API virtual bool Backup(const string& snapshot_file);
-  RIME_API virtual bool Restore(const string& snapshot_file);
+  RIME_API bool Backup(const path& snapshot_file) override;
+  RIME_API bool Restore(const path& snapshot_file) override;
 
-  RIME_API virtual bool CreateMetadata();
-  RIME_API virtual bool MetaFetch(const string& key, string* value);
-  RIME_API virtual bool MetaUpdate(const string& key, const string& value);
+  RIME_API bool CreateMetadata() override;
+  RIME_API bool MetaFetch(const string& key, string* value) override;
+  RIME_API bool MetaUpdate(const string& key, const string& value) override;
 
-  RIME_API virtual an<DbAccessor> QueryMetadata();
-  RIME_API virtual an<DbAccessor> QueryAll();
-  RIME_API virtual an<DbAccessor> Query(const string& key);
-  RIME_API virtual bool Fetch(const string& key, string* value);
-  RIME_API virtual bool Update(const string& key, const string& value);
-  RIME_API virtual bool Erase(const string& key);
+  RIME_API an<DbAccessor> QueryMetadata() override;
+  RIME_API an<DbAccessor> QueryAll() override;
+  RIME_API an<DbAccessor> Query(const string& key) override;
+  RIME_API bool Fetch(const string& key, string* value) override;
+  RIME_API bool Update(const string& key, const string& value) override;
+  RIME_API bool Erase(const string& key) override;
 
  protected:
   void Clear();
-  bool LoadFromFile(const string& file);
-  bool SaveToFile(const string& file);
+  bool LoadFromFile(const path& file);
+  bool SaveToFile(const path& file);
 
   string db_type_;
   TextFormat format_;

--- a/src/rime/dict/tsv.cc
+++ b/src/rime/dict/tsv.cc
@@ -15,8 +15,8 @@ namespace rime {
 int TsvReader::operator()(Sink* sink) {
   if (!sink)
     return 0;
-  LOG(INFO) << "reading tsv file: " << path_;
-  std::ifstream fin(path_.c_str());
+  LOG(INFO) << "reading tsv file: " << file_path_;
+  std::ifstream fin(file_path_.c_str());
   string line, key, value;
   Tsv row;
   int line_no = 0;
@@ -57,8 +57,8 @@ int TsvReader::operator()(Sink* sink) {
 int TsvWriter::operator()(Source* source) {
   if (!source)
     return 0;
-  LOG(INFO) << "writing tsv file: " << path_;
-  std::ofstream fout(path_.c_str());
+  LOG(INFO) << "writing tsv file: " << file_path_;
+  std::ofstream fout(file_path_.c_str());
   if (!file_description.empty()) {
     fout << "# " << file_description << std::endl;
   }

--- a/src/rime/dict/tsv.h
+++ b/src/rime/dict/tsv.h
@@ -7,6 +7,8 @@
 #ifndef RIME_TSV_H_
 #define RIME_TSV_H_
 
+#include <rime/common.h>
+
 namespace rime {
 
 using Tsv = vector<string>;
@@ -21,25 +23,25 @@ class Source;
 
 class TsvReader {
  public:
-  TsvReader(const string& path, TsvParser parser)
-      : path_(path), parser_(parser) {}
+  TsvReader(const path& file_path, TsvParser parser)
+      : file_path_(file_path), parser_(parser) {}
   // return number of records read
   int operator()(Sink* sink);
 
  protected:
-  string path_;
+  path file_path_;
   TsvParser parser_;
 };
 
 class TsvWriter {
  public:
-  TsvWriter(const string& path, TsvFormatter formatter)
-      : path_(path), formatter_(formatter) {}
+  TsvWriter(const path& file_path, TsvFormatter formatter)
+      : file_path_(file_path), formatter_(formatter) {}
   // return number of records written
   int operator()(Source* source);
 
  protected:
-  string path_;
+  path file_path_;
   TsvFormatter formatter_;
 
  public:

--- a/src/rime/dict/user_db.cc
+++ b/src/rime/dict/user_db.cc
@@ -97,20 +97,21 @@ static TextFormat plain_userdb_format = {
 };
 
 template <>
-RIME_API UserDbWrapper<TextDb>::UserDbWrapper(const string& file_name,
+RIME_API UserDbWrapper<TextDb>::UserDbWrapper(const path& file_path,
                                               const string& db_name)
-    : TextDb(file_name, db_name, "userdb", plain_userdb_format) {}
+    : TextDb(file_path, db_name, "userdb", plain_userdb_format) {}
 
 bool UserDbHelper::UpdateUserInfo() {
   Deployer& deployer(Service::instance().deployer());
   return db_->MetaUpdate("/user_id", deployer.user_id);
 }
 
-bool UserDbHelper::IsUniformFormat(const string& file_name) {
-  return boost::ends_with(file_name, plain_userdb_extension);
+bool UserDbHelper::IsUniformFormat(const path& file_path) {
+  return boost::ends_with(file_path.filename().u8string(),
+                          plain_userdb_extension);
 }
 
-bool UserDbHelper::UniformBackup(const string& snapshot_file) {
+bool UserDbHelper::UniformBackup(const path& snapshot_file) {
   LOG(INFO) << "backing up userdb '" << db_->name() << "' to " << snapshot_file;
   TsvWriter writer(snapshot_file, plain_userdb_format.formatter);
   writer.file_description = plain_userdb_format.file_description;
@@ -124,7 +125,7 @@ bool UserDbHelper::UniformBackup(const string& snapshot_file) {
   return true;
 }
 
-bool UserDbHelper::UniformRestore(const string& snapshot_file) {
+bool UserDbHelper::UniformRestore(const path& snapshot_file) {
   LOG(INFO) << "restoring userdb '" << db_->name() << "' from "
             << snapshot_file;
   TsvReader reader(snapshot_file, plain_userdb_format.parser);

--- a/src/rime/dict/user_db.h
+++ b/src/rime/dict/user_db.h
@@ -62,9 +62,9 @@ class UserDbHelper {
   UserDbHelper(const an<Db>& db) : db_(db.get()) {}
 
   RIME_API bool UpdateUserInfo();
-  RIME_API static bool IsUniformFormat(const string& name);
-  RIME_API bool UniformBackup(const string& snapshot_file);
-  RIME_API bool UniformRestore(const string& snapshot_file);
+  RIME_API static bool IsUniformFormat(const path& file_path);
+  RIME_API bool UniformBackup(const path& snapshot_file);
+  RIME_API bool UniformRestore(const path& snapshot_file);
 
   bool IsUserDb();
   string GetDbName();
@@ -79,17 +79,17 @@ class UserDbHelper {
 template <class BaseDb>
 class UserDbWrapper : public BaseDb {
  public:
-  RIME_API UserDbWrapper(const string& file_name, const string& db_name);
+  RIME_API UserDbWrapper(const path& file_path, const string& db_name);
 
   virtual bool CreateMetadata() {
     return BaseDb::CreateMetadata() && UserDbHelper(this).UpdateUserInfo();
   }
-  virtual bool Backup(const string& snapshot_file) {
+  virtual bool Backup(const path& snapshot_file) {
     return UserDbHelper::IsUniformFormat(snapshot_file)
                ? UserDbHelper(this).UniformBackup(snapshot_file)
                : BaseDb::Backup(snapshot_file);
   }
-  virtual bool Restore(const string& snapshot_file) {
+  virtual bool Restore(const path& snapshot_file) {
     return UserDbHelper::IsUniformFormat(snapshot_file)
                ? UserDbHelper(this).UniformRestore(snapshot_file)
                : BaseDb::Restore(snapshot_file);

--- a/src/rime/dict/user_db_recovery_task.cc
+++ b/src/rime/dict/user_db_recovery_task.cc
@@ -12,8 +12,6 @@
 #include <rime/dict/user_db.h>
 #include <rime/dict/user_db_recovery_task.h>
 
-namespace fs = std::filesystem;
-
 namespace rime {
 
 UserDbRecoveryTask::UserDbRecoveryTask(an<Db> db) : db_(db) {
@@ -65,15 +63,15 @@ void UserDbRecoveryTask::RestoreUserDataFromSnapshot(Deployer* deployer) {
   string dict_name(db_->name());
   boost::erase_last(dict_name, component->extension());
   // locate snapshot file
-  std::filesystem::path dir(deployer->user_data_sync_dir());
+  path dir(deployer->user_data_sync_dir());
   // try *.userdb.txt
-  fs::path snapshot_path = dir / (dict_name + UserDb::snapshot_extension());
-  if (!fs::exists(snapshot_path)) {
+  path snapshot_path = dir / (dict_name + UserDb::snapshot_extension());
+  if (!std::filesystem::exists(snapshot_path)) {
     // try *.userdb.*.snapshot
     string legacy_snapshot_file =
         dict_name + component->extension() + ".snapshot";
     snapshot_path = dir / legacy_snapshot_file;
-    if (!fs::exists(snapshot_path)) {
+    if (!std::filesystem::exists(snapshot_path)) {
       return;  // not found
     }
   }

--- a/src/rime/dict/user_db_recovery_task.cc
+++ b/src/rime/dict/user_db_recovery_task.cc
@@ -66,11 +66,11 @@ void UserDbRecoveryTask::RestoreUserDataFromSnapshot(Deployer* deployer) {
   // locate snapshot file
   const path& dir(deployer->user_data_sync_dir());
   // try *.userdb.txt
-  path snapshot_path = dir / path(dict_name + UserDb::snapshot_extension());
+  path snapshot_path = dir / (dict_name + UserDb::snapshot_extension());
   if (!std::filesystem::exists(snapshot_path)) {
     // try *.userdb.*.snapshot
-    path legacy_snapshot_file =
-        path(dict_name + component->extension() + ".snapshot");
+    string legacy_snapshot_file =
+        dict_name + component->extension() + ".snapshot";
     snapshot_path = dir / legacy_snapshot_file;
     if (!std::filesystem::exists(snapshot_path)) {
       return;  // not found

--- a/src/rime/dict/user_db_recovery_task.cc
+++ b/src/rime/dict/user_db_recovery_task.cc
@@ -41,9 +41,10 @@ bool UserDbRecoveryTask::Run(Deployer* deployer) {
   LOG(INFO) << "recreating db file.";
   if (db_->Exists()) {
     std::error_code ec;
-    std::filesystem::rename(db_->file_name(), db_->file_name() + ".old", ec);
+    std::filesystem::rename(db_->file_path(),
+                            path(db_->file_path()).concat(".old"), ec);
     if (ec && !db_->Remove()) {
-      LOG(ERROR) << "Error removing db file '" << db_->file_name() << "'.";
+      LOG(ERROR) << "Error removing db file '" << db_->file_path() << "'.";
       return false;
     }
   }
@@ -63,20 +64,20 @@ void UserDbRecoveryTask::RestoreUserDataFromSnapshot(Deployer* deployer) {
   string dict_name(db_->name());
   boost::erase_last(dict_name, component->extension());
   // locate snapshot file
-  path dir(deployer->user_data_sync_dir());
+  const path& dir(deployer->user_data_sync_dir());
   // try *.userdb.txt
-  path snapshot_path = dir / (dict_name + UserDb::snapshot_extension());
+  path snapshot_path = dir / path(dict_name + UserDb::snapshot_extension());
   if (!std::filesystem::exists(snapshot_path)) {
     // try *.userdb.*.snapshot
-    string legacy_snapshot_file =
-        dict_name + component->extension() + ".snapshot";
+    path legacy_snapshot_file =
+        path(dict_name + component->extension() + ".snapshot");
     snapshot_path = dir / legacy_snapshot_file;
     if (!std::filesystem::exists(snapshot_path)) {
       return;  // not found
     }
   }
   LOG(INFO) << "snapshot exists, trying to restore db '" << dict_name << "'.";
-  if (db_->Restore(snapshot_path.string())) {
+  if (db_->Restore(snapshot_path)) {
     LOG(INFO) << "restored db '" << dict_name << "' from snapshot.";
   }
 }

--- a/src/rime/gear/simplifier.cc
+++ b/src/rime/gear/simplifier.cc
@@ -31,12 +31,12 @@ namespace rime {
 
 class Opencc {
  public:
-  Opencc(const string& config_path) {
+  Opencc(const path& config_path) {
     LOG(INFO) << "initializing opencc: " << config_path;
     opencc::Config config;
     try {
-      // opencc accepts UTF-8 path.
-      converter_ = config.NewFromFile(path(config_path).u8string());
+      // opencc accepts file path encoded in UTF-8.
+      converter_ = config.NewFromFile(config_path.u8string());
 
       const list<opencc::ConversionPtr> conversions =
           converter_->GetConversionChain()->GetConversions();
@@ -168,7 +168,7 @@ Simplifier::Simplifier(const Ticket& ticket)
 
 void Simplifier::Initialize() {
   initialized_ = true;  // no retry
-  path opencc_config_path = opencc_config_;
+  path opencc_config_path = path(opencc_config_);
   if (opencc_config_path.extension().string() == ".ini") {
     LOG(ERROR) << "please upgrade opencc_config to an opencc 1.0 config file.";
     return;
@@ -185,7 +185,7 @@ void Simplifier::Initialize() {
     }
   }
   try {
-    opencc_.reset(new Opencc(opencc_config_path.string()));
+    opencc_.reset(new Opencc(opencc_config_path));
   } catch (opencc::Exception& e) {
     LOG(ERROR) << "Error initializing opencc: " << e.what();
   }

--- a/src/rime/gear/simplifier.cc
+++ b/src/rime/gear/simplifier.cc
@@ -5,7 +5,6 @@
 // 2011-12-12 GONG Chen <chen.sst@gmail.com>
 //
 #include <boost/algorithm/string.hpp>
-#include <filesystem>
 #include <stdint.h>
 #include <utf8.h>
 #include <utility>
@@ -25,11 +24,6 @@
 #include <opencc/Dict.hpp>
 #include <opencc/DictEntry.hpp>
 
-#ifdef _MSC_VER
-#include <opencc/UTF8Util.hpp>
-namespace fs = std::filesystem;
-#endif
-
 static const char* quote_left = "\xe3\x80\x94";   //"\xef\xbc\x88";
 static const char* quote_right = "\xe3\x80\x95";  //"\xef\xbc\x89";
 
@@ -41,14 +35,9 @@ class Opencc {
     LOG(INFO) << "initializing opencc: " << config_path;
     opencc::Config config;
     try {
-      // windows config_path in CP_ACP, convert it to UTF-8
-#ifdef _MSC_VER
-      fs::path path{config_path};
-      converter_ =
-          config.NewFromFile(opencc::UTF8Util::U16ToU8(path.wstring()));
-#else
-      converter_ = config.NewFromFile(config_path);
-#endif /*  _MSC_VER */
+      // opencc accepts UTF-8 path.
+      converter_ = config.NewFromFile(path(config_path).u8string());
+
       const list<opencc::ConversionPtr> conversions =
           converter_->GetConversionChain()->GetConversions();
       dict_ = conversions.front()->GetDict();
@@ -178,7 +167,6 @@ Simplifier::Simplifier(const Ticket& ticket)
 }
 
 void Simplifier::Initialize() {
-  using namespace std::filesystem;
   initialized_ = true;  // no retry
   path opencc_config_path = opencc_config_;
   if (opencc_config_path.extension().string() == ".ini") {

--- a/src/rime/lever/custom_settings.cc
+++ b/src/rime/lever/custom_settings.cc
@@ -29,15 +29,15 @@ CustomSettings::CustomSettings(Deployer* deployer,
 
 bool CustomSettings::Load() {
   path config_path = deployer_->staging_dir / (config_id_ + ".yaml");
-  if (!config_.LoadFromFile(config_path.string())) {
+  if (!config_.LoadFromFile(config_path)) {
     config_path = deployer_->prebuilt_data_dir / (config_id_ + ".yaml");
-    if (!config_.LoadFromFile(config_path.string())) {
+    if (!config_.LoadFromFile(config_path)) {
       LOG(WARNING) << "cannot find '" << config_id_ << ".yaml'.";
     }
   }
   path custom_config_path =
       deployer_->user_data_dir / custom_config_file(config_id_);
-  if (!custom_config_.LoadFromFile(custom_config_path.string())) {
+  if (!custom_config_.LoadFromFile(custom_config_path)) {
     return false;
   }
   modified_ = false;
@@ -51,7 +51,7 @@ bool CustomSettings::Save() {
   signature.Sign(&custom_config_, deployer_);
   path custom_config_path(deployer_->user_data_dir);
   custom_config_path /= custom_config_file(config_id_);
-  custom_config_.SaveToFile(custom_config_path.string());
+  custom_config_.SaveToFile(custom_config_path);
   modified_ = false;
   return true;
 }
@@ -85,7 +85,7 @@ bool CustomSettings::IsFirstRun() {
   path custom_config_path =
       deployer_->user_data_dir / custom_config_file(config_id_);
   Config config;
-  if (!config.LoadFromFile(custom_config_path.string()))
+  if (!config.LoadFromFile(custom_config_path))
     return true;
   return !config.GetMap("customization");
 }

--- a/src/rime/lever/custom_settings.cc
+++ b/src/rime/lever/custom_settings.cc
@@ -28,15 +28,15 @@ CustomSettings::CustomSettings(Deployer* deployer,
     : deployer_(deployer), config_id_(config_id), generator_id_(generator_id) {}
 
 bool CustomSettings::Load() {
-  path config_path = path(deployer_->staging_dir) / (config_id_ + ".yaml");
+  path config_path = deployer_->staging_dir / (config_id_ + ".yaml");
   if (!config_.LoadFromFile(config_path.string())) {
-    config_path = path(deployer_->prebuilt_data_dir) / (config_id_ + ".yaml");
+    config_path = deployer_->prebuilt_data_dir / (config_id_ + ".yaml");
     if (!config_.LoadFromFile(config_path.string())) {
       LOG(WARNING) << "cannot find '" << config_id_ << ".yaml'.";
     }
   }
   path custom_config_path =
-      path(deployer_->user_data_dir) / custom_config_file(config_id_);
+      deployer_->user_data_dir / custom_config_file(config_id_);
   if (!custom_config_.LoadFromFile(custom_config_path.string())) {
     return false;
   }
@@ -82,8 +82,8 @@ bool CustomSettings::Customize(const string& key, const an<ConfigItem>& item) {
 }
 
 bool CustomSettings::IsFirstRun() {
-  path custom_config_path(deployer_->user_data_dir);
-  custom_config_path /= custom_config_file(config_id_);
+  path custom_config_path =
+      deployer_->user_data_dir / custom_config_file(config_id_);
   Config config;
   if (!config.LoadFromFile(custom_config_path.string()))
     return true;

--- a/src/rime/lever/custom_settings.cc
+++ b/src/rime/lever/custom_settings.cc
@@ -5,13 +5,10 @@
 // 2012-02-26 GONG Chen <chen.sst@gmail.com>
 //
 #include <boost/algorithm/string.hpp>
-#include <filesystem>
 #include <rime/config.h>
 #include <rime/deployer.h>
 #include <rime/signature.h>
 #include <rime/lever/custom_settings.h>
-
-namespace fs = std::filesystem;
 
 namespace rime {
 
@@ -31,17 +28,15 @@ CustomSettings::CustomSettings(Deployer* deployer,
     : deployer_(deployer), config_id_(config_id), generator_id_(generator_id) {}
 
 bool CustomSettings::Load() {
-  fs::path config_path =
-      fs::path(deployer_->staging_dir) / (config_id_ + ".yaml");
+  path config_path = path(deployer_->staging_dir) / (config_id_ + ".yaml");
   if (!config_.LoadFromFile(config_path.string())) {
-    config_path =
-        fs::path(deployer_->prebuilt_data_dir) / (config_id_ + ".yaml");
+    config_path = path(deployer_->prebuilt_data_dir) / (config_id_ + ".yaml");
     if (!config_.LoadFromFile(config_path.string())) {
       LOG(WARNING) << "cannot find '" << config_id_ << ".yaml'.";
     }
   }
-  fs::path custom_config_path =
-      fs::path(deployer_->user_data_dir) / custom_config_file(config_id_);
+  path custom_config_path =
+      path(deployer_->user_data_dir) / custom_config_file(config_id_);
   if (!custom_config_.LoadFromFile(custom_config_path.string())) {
     return false;
   }
@@ -54,7 +49,7 @@ bool CustomSettings::Save() {
     return false;
   Signature signature(generator_id_, "customization");
   signature.Sign(&custom_config_, deployer_);
-  fs::path custom_config_path(deployer_->user_data_dir);
+  path custom_config_path(deployer_->user_data_dir);
   custom_config_path /= custom_config_file(config_id_);
   custom_config_.SaveToFile(custom_config_path.string());
   modified_ = false;
@@ -87,7 +82,7 @@ bool CustomSettings::Customize(const string& key, const an<ConfigItem>& item) {
 }
 
 bool CustomSettings::IsFirstRun() {
-  fs::path custom_config_path(deployer_->user_data_dir);
+  path custom_config_path(deployer_->user_data_dir);
   custom_config_path /= custom_config_file(config_id_);
   Config config;
   if (!config.LoadFromFile(custom_config_path.string()))

--- a/src/rime/lever/customizer.cc
+++ b/src/rime/lever/customizer.cc
@@ -38,7 +38,7 @@ bool Customizer::UpdateConfigFile() {
   string applied_customization;
 
   Config dest_config;
-  if (dest_config.LoadFromFile(dest_path_.string())) {
+  if (dest_config.LoadFromFile(dest_path_)) {
     dest_config.GetString(version_key_, &dest_version);
     dest_config.GetString("customization", &applied_customization);
   }
@@ -48,7 +48,7 @@ bool Customizer::UpdateConfigFile() {
     source_version = dest_version;
   } else {
     Config source_config;
-    if (source_config.LoadFromFile(source_path_.string())) {
+    if (source_config.LoadFromFile(source_path_)) {
       source_config.GetString(version_key_, &source_version);
     } else {
       LOG(ERROR) << "Error loading config from '" << source_path_ << "'.";
@@ -101,13 +101,13 @@ bool Customizer::UpdateConfigFile() {
                       "is discouraged.";
     }
     LOG(INFO) << "applying customization file: " << custom_path;
-    if (!dest_config.LoadFromFile(dest_path_.string())) {
+    if (!dest_config.LoadFromFile(dest_path_)) {
       LOG(ERROR) << "Error reloading destination config file.";
       return false;
     }
     // applying patch
     Config custom_config;
-    if (!custom_config.LoadFromFile(custom_path.string())) {
+    if (!custom_config.LoadFromFile(custom_path)) {
       LOG(ERROR) << "Error loading customization file.";
       return false;
     }
@@ -130,7 +130,7 @@ bool Customizer::UpdateConfigFile() {
     dest_version.append(".custom.").append(customization);
     dest_config.SetString(version_key_, dest_version);
     dest_config.SetString("customization", customization);
-    if (!dest_config.SaveToFile(dest_path_.string())) {
+    if (!dest_config.SaveToFile(dest_path_)) {
       LOG(ERROR) << "Error saving destination config file.";
       return false;
     }

--- a/src/rime/lever/customizer.cc
+++ b/src/rime/lever/customizer.cc
@@ -69,7 +69,7 @@ bool Customizer::UpdateConfigFile() {
     if (custom_path.extension() == ".schema") {
       custom_path.replace_extension();
     }
-    custom_path = custom_path.string() + ".custom.yaml";
+    custom_path += path(".custom.yaml");
   }
   string customization;
   if (!custom_path.empty() && fs::exists(custom_path)) {

--- a/src/rime/lever/customizer.cc
+++ b/src/rime/lever/customizer.cc
@@ -4,6 +4,7 @@
 //
 // 2011-12-12 GONG Chen <chen.sst@gmail.com>
 //
+#include <filesystem>
 #include <stdint.h>
 #include <rime/common.h>
 #include <rime/config.h>
@@ -60,7 +61,7 @@ bool Customizer::UpdateConfigFile() {
     }
   }
 
-  fs::path custom_path(dest_path_);
+  path custom_path(dest_path_);
   if (custom_path.extension() != ".yaml") {
     custom_path.clear();
   } else {

--- a/src/rime/lever/customizer.cc
+++ b/src/rime/lever/customizer.cc
@@ -68,7 +68,7 @@ bool Customizer::UpdateConfigFile() {
     if (custom_path.extension() == ".schema") {
       custom_path.replace_extension();
     }
-    custom_path += path(".custom.yaml");
+    custom_path += ".custom.yaml";
   }
   string customization;
   if (!custom_path.empty() && fs::exists(custom_path)) {

--- a/src/rime/lever/customizer.cc
+++ b/src/rime/lever/customizer.cc
@@ -51,8 +51,7 @@ bool Customizer::UpdateConfigFile() {
     if (source_config.LoadFromFile(source_path_.string())) {
       source_config.GetString(version_key_, &source_version);
     } else {
-      LOG(ERROR) << "Error loading config from '" << source_path_.string()
-                 << "'.";
+      LOG(ERROR) << "Error loading config from '" << source_path_ << "'.";
       return false;
     }
     if (CompareVersionString(source_version, dest_version) > 0) {
@@ -73,17 +72,17 @@ bool Customizer::UpdateConfigFile() {
   }
   string customization;
   if (!custom_path.empty() && fs::exists(custom_path)) {
-    customization = std::to_string(Checksum(custom_path.string()));
+    customization = std::to_string(Checksum(custom_path));
   }
   if (applied_customization != customization) {
     need_update = true;
   }
 
   if (!need_update) {
-    LOG(INFO) << "config file '" << dest_path_.string() << "' is up-to-date.";
+    LOG(INFO) << "config file '" << dest_path_ << "' is up-to-date.";
     return false;
   }
-  LOG(INFO) << "updating config file '" << dest_path_.string() << "'.";
+  LOG(INFO) << "updating config file '" << dest_path_ << "'.";
 
   bool is_dirty = !applied_customization.empty();
   if (redistribute || (is_dirty && !missing_original_copy)) {
@@ -91,7 +90,7 @@ bool Customizer::UpdateConfigFile() {
       fs::copy_file(source_path_, dest_path_,
                     fs::copy_options::overwrite_existing);
     } catch (...) {
-      LOG(ERROR) << "Error copying config file '" << source_path_.string()
+      LOG(ERROR) << "Error copying config file '" << source_path_
                  << "' to user directory.";
       return false;
     }
@@ -101,7 +100,7 @@ bool Customizer::UpdateConfigFile() {
       LOG(WARNING) << "patching user config without a shared original copy "
                       "is discouraged.";
     }
-    LOG(INFO) << "applying customization file: " << custom_path.string();
+    LOG(INFO) << "applying customization file: " << custom_path;
     if (!dest_config.LoadFromFile(dest_path_.string())) {
       LOG(ERROR) << "Error reloading destination config file.";
       return false;

--- a/src/rime/lever/customizer.h
+++ b/src/rime/lever/customizer.h
@@ -5,14 +5,14 @@
 #ifndef RIME_CUSTOMIZER_H_
 #define RIME_CUSTOMIZER_H_
 
-#include <filesystem>
+#include <rime/common.h>
 
 namespace rime {
 
 class Customizer {
  public:
-  Customizer(const std::filesystem::path& source_path,
-             const std::filesystem::path& dest_path,
+  Customizer(const path& source_path,
+             const path& dest_path,
              const string& version_key)
       : source_path_(source_path),
         dest_path_(dest_path),
@@ -22,8 +22,8 @@ class Customizer {
   bool UpdateConfigFile();
 
  protected:
-  std::filesystem::path source_path_;
-  std::filesystem::path dest_path_;
+  path source_path_;
+  path dest_path_;
   string version_key_;
 };
 

--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -37,7 +37,7 @@ namespace rime {
 
 DetectModifications::DetectModifications(TaskInitializer arg) {
   try {
-    data_dirs_ = std::any_cast<vector<string>>(arg);
+    data_dirs_ = std::any_cast<vector<path>>(arg);
   } catch (const std::bad_any_cast&) {
     LOG(ERROR) << "DetectModifications: invalid arguments.";
   }

--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -556,8 +556,7 @@ bool BackupConfigFiles::Run(Deployer* deployer) {
       continue;
     path backup = backup_dir /
                   entry.filename();  // TODO: convert entry.filename() to path
-    if (fs::exists(backup) &&
-        Checksum(backup) == Checksum(entry)) {
+    if (fs::exists(backup) && Checksum(backup) == Checksum(entry)) {
       ++latest;  // already up-to-date
       continue;
     }
@@ -574,9 +573,9 @@ bool BackupConfigFiles::Run(Deployer* deployer) {
       ++success;
     }
   }
-  LOG(INFO) << "backed up " << success << " config files to "
-            << backup_dir << ", " << failure << " failed, " << latest
-            << " up-to-date, " << skipped << " skipped.";
+  LOG(INFO) << "backed up " << success << " config files to " << backup_dir
+            << ", " << failure << " failed, " << latest << " up-to-date, "
+            << skipped << " skipped.";
   return !failure;
 }
 

--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -311,7 +311,7 @@ static bool TrashDeprecatedUserCopy(const path& shared_copy,
     if (!MaybeCreateDirectory(trash)) {
       return false;
     }
-    path backup = trash / user_copy.filename();  // TODO: convert path
+    path backup = trash / user_copy.filename();
     std::error_code ec;
     fs::rename(user_copy, backup, ec);
     if (ec) {
@@ -554,8 +554,7 @@ bool BackupConfigFiles::Run(Deployer* deployer) {
     bool is_text_file = file_extension == ".txt";
     if (!is_yaml_file && !is_text_file)
       continue;
-    path backup = backup_dir /
-                  entry.filename();  // TODO: convert entry.filename() to path
+    path backup = backup_dir / entry.filename();
     if (fs::exists(backup) && Checksum(backup) == Checksum(entry)) {
       ++latest;  // already up-to-date
       continue;
@@ -567,7 +566,7 @@ bool BackupConfigFiles::Run(Deployer* deployer) {
     std::error_code ec;
     fs::copy_file(entry, backup, fs::copy_options::overwrite_existing, ec);
     if (ec) {
-      LOG(ERROR) << "error backing up file " << backup.string();
+      LOG(ERROR) << "error backing up file " << backup;
       ++failure;
     } else {
       ++success;

--- a/src/rime/lever/deployment_tasks.h
+++ b/src/rime/lever/deployment_tasks.h
@@ -21,7 +21,7 @@ class DetectModifications : public DeploymentTask {
   bool Run(Deployer* deployer);
 
  protected:
-  vector<string> data_dirs_;
+  vector<path> data_dirs_;
 };
 
 // initialize/update installation.yaml

--- a/src/rime/lever/deployment_tasks.h
+++ b/src/rime/lever/deployment_tasks.h
@@ -46,14 +46,13 @@ class RIME_API WorkspaceUpdate : public DeploymentTask {
 // update a specific schema, build corresponding dictionary
 class RIME_API SchemaUpdate : public DeploymentTask {
  public:
-  explicit SchemaUpdate(const string& schema_file)
-      : schema_file_(schema_file) {}
+  explicit SchemaUpdate(const path& source_path) : source_path_(source_path) {}
   SchemaUpdate(TaskInitializer arg);
   bool Run(Deployer* deployer);
   void set_verbose(bool verbose) { verbose_ = verbose; }
 
  protected:
-  string schema_file_;
+  path source_path_;
   bool verbose_ = false;
 };
 

--- a/src/rime/lever/levers_module.cc
+++ b/src/rime/lever/levers_module.cc
@@ -255,19 +255,19 @@ static Bool rime_levers_backup_user_dict(const char* dict_name) {
 
 static Bool rime_levers_restore_user_dict(const char* snapshot_file) {
   UserDictManager mgr(&Service::instance().deployer());
-  return Bool(mgr.Restore(snapshot_file));
+  return Bool(mgr.Restore(path(snapshot_file)));
 }
 
 static int rime_levers_export_user_dict(const char* dict_name,
                                         const char* text_file) {
   UserDictManager mgr(&Service::instance().deployer());
-  return mgr.Export(dict_name, text_file);
+  return mgr.Export(dict_name, path(text_file));
 }
 
 static int rime_levers_import_user_dict(const char* dict_name,
                                         const char* text_file) {
   UserDictManager mgr(&Service::instance().deployer());
-  return mgr.Import(dict_name, text_file);
+  return mgr.Import(dict_name, path(text_file));
 }
 
 //

--- a/src/rime/lever/switcher_settings.cc
+++ b/src/rime/lever/switcher_settings.cc
@@ -49,12 +49,12 @@ bool SwitcherSettings::SetHotkeys(const string& hotkeys) {
 
 void SwitcherSettings::GetAvailableSchemasFromDirectory(const path& dir) {
   if (!fs::exists(dir) || !fs::is_directory(dir)) {
-    LOG(INFO) << "directory '" << dir.string() << "' does not exist.";
+    LOG(INFO) << "directory '" << dir << "' does not exist.";
     return;
   }
   for (fs::directory_iterator it(dir), end; it != end; ++it) {
-    string file_path(it->path().string());
-    if (boost::ends_with(file_path, ".schema.yaml")) {
+    path file_path(it->path());
+    if (boost::ends_with(file_path.string(), ".schema.yaml")) {
       Config config;
       if (config.LoadFromFile(file_path)) {
         SchemaInfo info;
@@ -86,7 +86,7 @@ void SwitcherSettings::GetAvailableSchemasFromDirectory(const path& dir) {
           }
         }
         config.GetString("schema/description", &info.description);
-        info.file_path = file_path;
+        info.file_path = file_path.string();
         available_.push_back(info);
       }
     }

--- a/src/rime/lever/switcher_settings.cc
+++ b/src/rime/lever/switcher_settings.cc
@@ -47,7 +47,7 @@ bool SwitcherSettings::SetHotkeys(const string& hotkeys) {
   return false;
 }
 
-void SwitcherSettings::GetAvailableSchemasFromDirectory(const fs::path& dir) {
+void SwitcherSettings::GetAvailableSchemasFromDirectory(const path& dir) {
   if (!fs::exists(dir) || !fs::is_directory(dir)) {
     LOG(INFO) << "directory '" << dir.string() << "' does not exist.";
     return;

--- a/src/rime/lever/switcher_settings.h
+++ b/src/rime/lever/switcher_settings.h
@@ -7,8 +7,8 @@
 #ifndef RIME_SWITCHER_SETTINGS_H_
 #define RIME_SWITCHER_SETTINGS_H_
 
-#include <filesystem>
 #include "custom_settings.h"
+#include <rime/common.h>
 
 namespace rime {
 
@@ -37,7 +37,7 @@ class SwitcherSettings : public CustomSettings {
   const string& hotkeys() const { return hotkeys_; }
 
  private:
-  void GetAvailableSchemasFromDirectory(const std::filesystem::path& dir);
+  void GetAvailableSchemasFromDirectory(const path& dir);
   void GetSelectedSchemasFromConfig();
   void GetHotkeysFromConfig();
 

--- a/src/rime/lever/user_dict_manager.cc
+++ b/src/rime/lever/user_dict_manager.cc
@@ -59,9 +59,9 @@ bool UserDictManager::Backup(const string& dict_name) {
       return false;
     }
   }
-  std::filesystem::path dir(deployer_->user_data_sync_dir());
-  if (!std::filesystem::exists(dir)) {
-    if (!std::filesystem::create_directories(dir)) {
+  path dir(deployer_->user_data_sync_dir());
+  if (!fs::exists(dir)) {
+    if (!fs::create_directories(dir)) {
       LOG(ERROR) << "error creating directory '" << dir.string() << "'.";
       return false;
     }
@@ -161,7 +161,7 @@ bool UserDictManager::UpgradeUserDict(const string& dict_name) {
   if (!legacy_db->OpenReadOnly() || !UserDbHelper(legacy_db).IsUserDb())
     return false;
   LOG(INFO) << "upgrading user dict '" << dict_name << "'.";
-  fs::path trash = fs::path(deployer_->user_data_dir) / "trash";
+  path trash = path(deployer_->user_data_dir) / "trash";
   if (!fs::exists(trash)) {
     std::error_code ec;
     if (!fs::create_directories(trash, ec)) {
@@ -170,7 +170,7 @@ bool UserDictManager::UpgradeUserDict(const string& dict_name) {
     }
   }
   string snapshot_file = dict_name + UserDb::snapshot_extension();
-  fs::path snapshot_path = trash / snapshot_file;
+  path snapshot_path = trash / snapshot_file;
   return legacy_db->Backup(snapshot_path.string()) && legacy_db->Close() &&
          legacy_db->Remove() && Restore(snapshot_path.string());
 }
@@ -178,7 +178,7 @@ bool UserDictManager::UpgradeUserDict(const string& dict_name) {
 bool UserDictManager::Synchronize(const string& dict_name) {
   LOG(INFO) << "synchronize user dict '" << dict_name << "'.";
   bool success = true;
-  fs::path sync_dir(deployer_->sync_dir);
+  path sync_dir(deployer_->sync_dir);
   if (!fs::exists(sync_dir)) {
     std::error_code ec;
     if (!fs::create_directories(sync_dir, ec)) {
@@ -191,7 +191,7 @@ bool UserDictManager::Synchronize(const string& dict_name) {
   for (fs::directory_iterator it(sync_dir), end; it != end; ++it) {
     if (!fs::is_directory(it->path()))
       continue;
-    fs::path file_path = it->path() / snapshot_file;
+    path file_path = it->path() / snapshot_file;
     if (fs::exists(file_path)) {
       LOG(INFO) << "merging snapshot file: " << file_path.string();
       if (!Restore(file_path.string())) {

--- a/src/rime/lever/user_dict_manager.cc
+++ b/src/rime/lever/user_dict_manager.cc
@@ -66,7 +66,7 @@ bool UserDictManager::Backup(const string& dict_name) {
       return false;
     }
   }
-  path snapshot_file = path(dict_name + UserDb::snapshot_extension());
+  string snapshot_file = dict_name + UserDb::snapshot_extension();
   return db->Backup(dir / snapshot_file);
 }
 
@@ -161,7 +161,7 @@ bool UserDictManager::UpgradeUserDict(const string& dict_name) {
   if (!legacy_db->OpenReadOnly() || !UserDbHelper(legacy_db).IsUserDb())
     return false;
   LOG(INFO) << "upgrading user dict '" << dict_name << "'.";
-  path trash = path(deployer_->user_data_dir) / "trash";
+  path trash = deployer_->user_data_dir / "trash";
   if (!fs::exists(trash)) {
     std::error_code ec;
     if (!fs::create_directories(trash, ec)) {
@@ -169,7 +169,7 @@ bool UserDictManager::UpgradeUserDict(const string& dict_name) {
       return false;
     }
   }
-  path snapshot_file = path(dict_name + UserDb::snapshot_extension());
+  string snapshot_file = dict_name + UserDb::snapshot_extension();
   path snapshot_path = trash / snapshot_file;
   return legacy_db->Backup(snapshot_path) && legacy_db->Close() &&
          legacy_db->Remove() && Restore(snapshot_path);
@@ -187,11 +187,11 @@ bool UserDictManager::Synchronize(const string& dict_name) {
     }
   }
   // *.userdb.txt
-  path snapshot_file = path(dict_name + UserDb::snapshot_extension());
+  string snapshot_file = dict_name + UserDb::snapshot_extension();
   for (fs::directory_iterator it(sync_dir), end; it != end; ++it) {
     if (!fs::is_directory(it->path()))
       continue;
-    path file_path = it->path() / snapshot_file;
+    path file_path = path(it->path()) / snapshot_file;
     if (fs::exists(file_path)) {
       LOG(INFO) << "merging snapshot file: " << file_path;
       if (!Restore(file_path)) {

--- a/src/rime/lever/user_dict_manager.cc
+++ b/src/rime/lever/user_dict_manager.cc
@@ -62,7 +62,7 @@ bool UserDictManager::Backup(const string& dict_name) {
   const path& dir(deployer_->user_data_sync_dir());
   if (!fs::exists(dir)) {
     if (!fs::create_directories(dir)) {
-      LOG(ERROR) << "error creating directory '" << dir.string() << "'.";
+      LOG(ERROR) << "error creating directory '" << dir << "'.";
       return false;
     }
   }
@@ -165,7 +165,7 @@ bool UserDictManager::UpgradeUserDict(const string& dict_name) {
   if (!fs::exists(trash)) {
     std::error_code ec;
     if (!fs::create_directories(trash, ec)) {
-      LOG(ERROR) << "error creating directory '" << trash.string() << "'.";
+      LOG(ERROR) << "error creating directory '" << trash << "'.";
       return false;
     }
   }
@@ -182,7 +182,7 @@ bool UserDictManager::Synchronize(const string& dict_name) {
   if (!fs::exists(sync_dir)) {
     std::error_code ec;
     if (!fs::create_directories(sync_dir, ec)) {
-      LOG(ERROR) << "error creating directory '" << sync_dir.string() << "'.";
+      LOG(ERROR) << "error creating directory '" << sync_dir << "'.";
       return false;
     }
   }

--- a/src/rime/lever/user_dict_manager.cc
+++ b/src/rime/lever/user_dict_manager.cc
@@ -36,11 +36,11 @@ void UserDictManager::GetUserDictList(UserDictList* user_dict_list,
   }
   user_dict_list->clear();
   if (!fs::exists(path_) || !fs::is_directory(path_)) {
-    LOG(INFO) << "directory '" << path_.string() << "' does not exist.";
+    LOG(INFO) << "directory '" << path_ << "' does not exist.";
     return;
   }
   for (fs::directory_iterator it(path_), end; it != end; ++it) {
-    string name = it->path().filename().string();
+    string name = it->path().filename().u8string();
     if (boost::ends_with(name, component->extension())) {
       boost::erase_last(name, component->extension());
       user_dict_list->push_back(name);
@@ -59,18 +59,18 @@ bool UserDictManager::Backup(const string& dict_name) {
       return false;
     }
   }
-  path dir(deployer_->user_data_sync_dir());
+  const path& dir(deployer_->user_data_sync_dir());
   if (!fs::exists(dir)) {
     if (!fs::create_directories(dir)) {
       LOG(ERROR) << "error creating directory '" << dir.string() << "'.";
       return false;
     }
   }
-  string snapshot_file = dict_name + UserDb::snapshot_extension();
-  return db->Backup((dir / snapshot_file).string());
+  path snapshot_file = path(dict_name + UserDb::snapshot_extension());
+  return db->Backup(dir / snapshot_file);
 }
 
-bool UserDictManager::Restore(const string& snapshot_file) {
+bool UserDictManager::Restore(const path& snapshot_file) {
   the<Db> temp(user_db_component_->Create(".temp"));
   if (temp->Exists())
     temp->Remove();
@@ -104,7 +104,7 @@ bool UserDictManager::Restore(const string& snapshot_file) {
   return true;
 }
 
-int UserDictManager::Export(const string& dict_name, const string& text_file) {
+int UserDictManager::Export(const string& dict_name, const path& text_file) {
   the<Db> db(user_db_component_->Create(dict_name));
   if (!db->OpenReadOnly())
     return -1;
@@ -128,7 +128,7 @@ int UserDictManager::Export(const string& dict_name, const string& text_file) {
   return num_entries;
 }
 
-int UserDictManager::Import(const string& dict_name, const string& text_file) {
+int UserDictManager::Import(const string& dict_name, const path& text_file) {
   the<Db> db(user_db_component_->Create(dict_name));
   if (!db->Open())
     return -1;
@@ -169,10 +169,10 @@ bool UserDictManager::UpgradeUserDict(const string& dict_name) {
       return false;
     }
   }
-  string snapshot_file = dict_name + UserDb::snapshot_extension();
+  path snapshot_file = path(dict_name + UserDb::snapshot_extension());
   path snapshot_path = trash / snapshot_file;
-  return legacy_db->Backup(snapshot_path.string()) && legacy_db->Close() &&
-         legacy_db->Remove() && Restore(snapshot_path.string());
+  return legacy_db->Backup(snapshot_path) && legacy_db->Close() &&
+         legacy_db->Remove() && Restore(snapshot_path);
 }
 
 bool UserDictManager::Synchronize(const string& dict_name) {
@@ -187,15 +187,15 @@ bool UserDictManager::Synchronize(const string& dict_name) {
     }
   }
   // *.userdb.txt
-  string snapshot_file = dict_name + UserDb::snapshot_extension();
+  path snapshot_file = path(dict_name + UserDb::snapshot_extension());
   for (fs::directory_iterator it(sync_dir), end; it != end; ++it) {
     if (!fs::is_directory(it->path()))
       continue;
     path file_path = it->path() / snapshot_file;
     if (fs::exists(file_path)) {
-      LOG(INFO) << "merging snapshot file: " << file_path.string();
-      if (!Restore(file_path.string())) {
-        LOG(ERROR) << "failed to merge snapshot file: " << file_path.string();
+      LOG(INFO) << "merging snapshot file: " << file_path;
+      if (!Restore(file_path)) {
+        LOG(ERROR) << "failed to merge snapshot file: " << file_path;
         success = false;
       }
     }

--- a/src/rime/lever/user_dict_manager.h
+++ b/src/rime/lever/user_dict_manager.h
@@ -26,12 +26,12 @@ class RIME_API UserDictManager {
 
   // CAVEAT: the user dict should be closed before the following operations
   bool Backup(const string& dict_name);
-  bool Restore(const string& snapshot_file);
+  bool Restore(const path& snapshot_file);
   bool UpgradeUserDict(const string& dict_name);
   // returns num of exported entries, -1 denotes failure
-  int Export(const string& dict_name, const string& text_file);
+  int Export(const string& dict_name, const path& text_file);
   // returns num of imported entries, -1 denotes failure
-  int Import(const string& dict_name, const string& text_file);
+  int Import(const string& dict_name, const path& text_file);
 
   bool Synchronize(const string& dict_name);
   bool SynchronizeAll();

--- a/src/rime/lever/user_dict_manager.h
+++ b/src/rime/lever/user_dict_manager.h
@@ -7,7 +7,7 @@
 #ifndef RIME_USER_DICT_MANAGER_H_
 #define RIME_USER_DICT_MANAGER_H_
 
-#include <filesystem>
+#include <rime/common.h>
 #include <rime/dict/user_db.h>
 
 namespace rime {
@@ -38,7 +38,7 @@ class RIME_API UserDictManager {
 
  protected:
   Deployer* deployer_;
-  std::filesystem::path path_;
+  path path_;
   UserDb::Component* user_db_component_;
 };
 

--- a/src/rime/resource.cc
+++ b/src/rime/resource.cc
@@ -10,7 +10,7 @@
 namespace rime {
 
 string ResourceResolver::ToResourceId(const string& file_path) const {
-  string path_string = std::filesystem::path(file_path).generic_string();
+  string path_string = path(file_path).generic_string();
   bool has_prefix = boost::starts_with(path_string, type_.prefix);
   bool has_suffix = boost::ends_with(path_string, type_.suffix);
   size_t start = (has_prefix ? type_.prefix.length() : 0);
@@ -19,7 +19,7 @@ string ResourceResolver::ToResourceId(const string& file_path) const {
 }
 
 string ResourceResolver::ToFilePath(const string& resource_id) const {
-  std::filesystem::path file_path(resource_id);
+  path file_path(resource_id);
   bool missing_prefix = !file_path.has_parent_path() &&
                         !boost::starts_with(resource_id, type_.prefix);
   bool missing_suffix = !boost::ends_with(resource_id, type_.suffix);
@@ -27,19 +27,16 @@ string ResourceResolver::ToFilePath(const string& resource_id) const {
          (missing_suffix ? type_.suffix : "");
 }
 
-std::filesystem::path ResourceResolver::ResolvePath(const string& resource_id) {
+path ResourceResolver::ResolvePath(const string& resource_id) {
   return std::filesystem::absolute(
-      root_path_ /
-      std::filesystem::path(type_.prefix + resource_id + type_.suffix));
+      root_path_ / path(type_.prefix + resource_id + type_.suffix));
 }
 
-std::filesystem::path FallbackResourceResolver::ResolvePath(
-    const string& resource_id) {
+path FallbackResourceResolver::ResolvePath(const string& resource_id) {
   auto default_path = ResourceResolver::ResolvePath(resource_id);
   if (!std::filesystem::exists(default_path)) {
     auto fallback_path = std::filesystem::absolute(
-        fallback_root_path_ /
-        std::filesystem::path(type_.prefix + resource_id + type_.suffix));
+        fallback_root_path_ / path(type_.prefix + resource_id + type_.suffix));
     if (std::filesystem::exists(fallback_path)) {
       return fallback_path;
     }

--- a/src/rime/resource.cc
+++ b/src/rime/resource.cc
@@ -28,15 +28,15 @@ string ResourceResolver::ToFilePath(const string& resource_id) const {
 }
 
 path ResourceResolver::ResolvePath(const string& resource_id) {
-  return std::filesystem::absolute(
-      root_path_ / path(type_.prefix + resource_id + type_.suffix));
+  return std::filesystem::absolute(root_path_ /
+                                   (type_.prefix + resource_id + type_.suffix));
 }
 
 path FallbackResourceResolver::ResolvePath(const string& resource_id) {
   auto default_path = ResourceResolver::ResolvePath(resource_id);
   if (!std::filesystem::exists(default_path)) {
     auto fallback_path = std::filesystem::absolute(
-        fallback_root_path_ / path(type_.prefix + resource_id + type_.suffix));
+        fallback_root_path_ / (type_.prefix + resource_id + type_.suffix));
     if (std::filesystem::exists(fallback_path)) {
       return fallback_path;
     }

--- a/src/rime/resource.cc
+++ b/src/rime/resource.cc
@@ -10,17 +10,16 @@
 namespace rime {
 
 string ResourceResolver::ToResourceId(const string& file_path) const {
-  string path_string = path(file_path).generic_string();
-  bool has_prefix = boost::starts_with(path_string, type_.prefix);
-  bool has_suffix = boost::ends_with(path_string, type_.suffix);
+  string string_path = path(file_path).generic_u8string();
+  bool has_prefix = boost::starts_with(string_path, type_.prefix);
+  bool has_suffix = boost::ends_with(string_path, type_.suffix);
   size_t start = (has_prefix ? type_.prefix.length() : 0);
-  size_t end = path_string.length() - (has_suffix ? type_.suffix.length() : 0);
-  return path_string.substr(start, end);
+  size_t end = string_path.length() - (has_suffix ? type_.suffix.length() : 0);
+  return string_path.substr(start, end);
 }
 
 string ResourceResolver::ToFilePath(const string& resource_id) const {
-  path file_path(resource_id);
-  bool missing_prefix = !file_path.has_parent_path() &&
+  bool missing_prefix = !path(resource_id).has_parent_path() &&
                         !boost::starts_with(resource_id, type_.prefix);
   bool missing_suffix = !boost::ends_with(resource_id, type_.suffix);
   return (missing_prefix ? type_.prefix : "") + resource_id +

--- a/src/rime/resource.h
+++ b/src/rime/resource.h
@@ -6,7 +6,6 @@
 #ifndef RIME_RESOURCE_H_
 #define RIME_RESOURCE_H_
 
-#include <filesystem>
 #include <rime_api.h>
 #include <rime/common.h>
 
@@ -24,17 +23,15 @@ class RIME_API ResourceResolver {
  public:
   explicit ResourceResolver(const ResourceType type) : type_(type) {}
   virtual ~ResourceResolver() {}
-  virtual std::filesystem::path ResolvePath(const string& resource_id);
+  virtual path ResolvePath(const string& resource_id);
   string ToResourceId(const string& file_path) const;
   string ToFilePath(const string& resource_id) const;
-  void set_root_path(std::filesystem::path root_path) {
-    root_path_ = root_path;
-  }
-  std::filesystem::path root_path() const { return root_path_; }
+  void set_root_path(path root_path) { root_path_ = root_path; }
+  path root_path() const { return root_path_; }
 
  protected:
   const ResourceType type_;
-  std::filesystem::path root_path_;
+  path root_path_;
 };
 
 // try fallback path if target file doesn't exist in root path
@@ -42,13 +39,13 @@ class RIME_API FallbackResourceResolver : public ResourceResolver {
  public:
   explicit FallbackResourceResolver(const ResourceType& type)
       : ResourceResolver(type) {}
-  std::filesystem::path ResolvePath(const string& resource_id) override;
-  void set_fallback_root_path(std::filesystem::path fallback_root_path) {
+  path ResolvePath(const string& resource_id) override;
+  void set_fallback_root_path(path fallback_root_path) {
     fallback_root_path_ = fallback_root_path;
   }
 
  private:
-  std::filesystem::path fallback_root_path_;
+  path fallback_root_path_;
 };
 
 }  // namespace rime

--- a/src/rime/setup.cc
+++ b/src/rime/setup.cc
@@ -49,9 +49,9 @@ RIME_API void SetupDeployer(RimeTraits* traits) {
     return;
   Deployer& deployer(Service::instance().deployer());
   if (PROVIDED(traits, shared_data_dir))
-    deployer.shared_data_dir = traits->shared_data_dir;
+    deployer.shared_data_dir = path(traits->shared_data_dir);
   if (PROVIDED(traits, user_data_dir))
-    deployer.user_data_dir = traits->user_data_dir;
+    deployer.user_data_dir = path(traits->user_data_dir);
   if (PROVIDED(traits, distribution_name))
     deployer.distribution_name = traits->distribution_name;
   if (PROVIDED(traits, distribution_code_name))
@@ -59,14 +59,13 @@ RIME_API void SetupDeployer(RimeTraits* traits) {
   if (PROVIDED(traits, distribution_version))
     deployer.distribution_version = traits->distribution_version;
   if (PROVIDED(traits, prebuilt_data_dir))
-    deployer.prebuilt_data_dir = traits->prebuilt_data_dir;
+    deployer.prebuilt_data_dir = path(traits->prebuilt_data_dir);
   else
-    deployer.prebuilt_data_dir =
-        (path(deployer.shared_data_dir) / "build").string();
+    deployer.prebuilt_data_dir = deployer.shared_data_dir / "build";
   if (PROVIDED(traits, staging_dir))
-    deployer.staging_dir = traits->staging_dir;
+    deployer.staging_dir = path(traits->staging_dir);
   else
-    deployer.staging_dir = (path(deployer.user_data_dir) / "build").string();
+    deployer.staging_dir = deployer.user_data_dir / "build";
 }
 
 RIME_API void SetupLogging(const char* app_name,

--- a/src/rime/setup.cc
+++ b/src/rime/setup.cc
@@ -14,14 +14,11 @@
 #include <glog/logging.h>
 #endif  // RIME_ENABLE_LOGGING
 
-#include <filesystem>
 #include <rime_api.h>
 #include <rime/deployer.h>
 #include <rime/module.h>
 #include <rime/service.h>
 #include <rime/setup.h>
-
-namespace fs = std::filesystem;
 
 namespace rime {
 
@@ -65,12 +62,11 @@ RIME_API void SetupDeployer(RimeTraits* traits) {
     deployer.prebuilt_data_dir = traits->prebuilt_data_dir;
   else
     deployer.prebuilt_data_dir =
-        (fs::path(deployer.shared_data_dir) / "build").string();
+        (path(deployer.shared_data_dir) / "build").string();
   if (PROVIDED(traits, staging_dir))
     deployer.staging_dir = traits->staging_dir;
   else
-    deployer.staging_dir =
-        (fs::path(deployer.user_data_dir) / "build").string();
+    deployer.staging_dir = (path(deployer.user_data_dir) / "build").string();
 }
 
 RIME_API void SetupLogging(const char* app_name,

--- a/src/rime_api.cc
+++ b/src/rime_api.cc
@@ -810,27 +810,37 @@ RIME_API Bool RimeRunTask(const char* task_name) {
 
 RIME_API const char* RimeGetSharedDataDir() {
   Deployer& deployer(Service::instance().deployer());
-  return deployer.shared_data_dir.c_str();
+  static string string_path;
+  string_path = deployer.shared_data_dir.string();
+  return string_path.c_str();
 }
 
 RIME_API const char* RimeGetUserDataDir() {
   Deployer& deployer(Service::instance().deployer());
-  return deployer.user_data_dir.c_str();
+  static string string_path;
+  string_path = deployer.user_data_dir.string();
+  return string_path.c_str();
 }
 
 RIME_API const char* RimeGetPrebuiltDataDir() {
   Deployer& deployer(Service::instance().deployer());
-  return deployer.prebuilt_data_dir.c_str();
+  static string string_path;
+  string_path = deployer.prebuilt_data_dir.string();
+  return string_path.c_str();
 }
 
 RIME_API const char* RimeGetStagingDir() {
   Deployer& deployer(Service::instance().deployer());
-  return deployer.staging_dir.c_str();
+  static string string_path;
+  string_path = deployer.staging_dir.string();
+  return string_path.c_str();
 }
 
 RIME_API const char* RimeGetSyncDir() {
   Deployer& deployer(Service::instance().deployer());
-  return deployer.sync_dir.c_str();
+  static string string_path;
+  string_path = deployer.sync_dir.string();
+  return string_path.c_str();
 }
 
 RIME_API const char* RimeGetUserId() {
@@ -840,7 +850,34 @@ RIME_API const char* RimeGetUserId() {
 
 RIME_API void RimeGetUserDataSyncDir(char* dir, size_t buffer_size) {
   Deployer& deployer(Service::instance().deployer());
-  strncpy(dir, deployer.user_data_sync_dir().c_str(), buffer_size);
+  string string_path = deployer.user_data_sync_dir().string();
+  strncpy(dir, string_path.c_str(), buffer_size);
+}
+
+void RimeGetSharedDataDirSecure(char* dir, size_t buffer_size) {
+  string string_path = Service::instance().deployer().shared_data_dir.string();
+  strncpy(dir, string_path.c_str(), buffer_size);
+}
+
+void RimeGetUserDataDirSecure(char* dir, size_t buffer_size) {
+  string string_path = Service::instance().deployer().user_data_dir.string();
+  strncpy(dir, string_path.c_str(), buffer_size);
+}
+
+void RimeGetPrebuiltDataDirSecure(char* dir, size_t buffer_size) {
+  string string_path =
+      Service::instance().deployer().prebuilt_data_dir.string();
+  strncpy(dir, string_path.c_str(), buffer_size);
+}
+
+void RimeGetStagingDirSecure(char* dir, size_t buffer_size) {
+  string string_path = Service::instance().deployer().staging_dir.string();
+  strncpy(dir, string_path.c_str(), buffer_size);
+}
+
+void RimeGetSyncDirSecure(char* dir, size_t buffer_size) {
+  string string_path = Service::instance().deployer().sync_dir.string();
+  strncpy(dir, string_path.c_str(), buffer_size);
 }
 
 RIME_API Bool RimeConfigInit(RimeConfig* config) {
@@ -1189,6 +1226,11 @@ RIME_API RimeApi* rime_get_api() {
     s_api.delete_candidate_on_current_page = &RimeDeleteCandidateOnCurrentPage;
     s_api.get_state_label_abbreviated = &RimeGetStateLabelAbbreviated;
     s_api.set_input = &RimeSetInput;
+    s_api.get_shared_data_dir_s = &RimeGetSharedDataDirSecure;
+    s_api.get_user_data_dir_s = &RimeGetUserDataDirSecure;
+    s_api.get_prebuilt_data_dir_s = &RimeGetPrebuiltDataDirSecure;
+    s_api.get_staging_dir_s = &RimeGetStagingDirSecure;
+    s_api.get_sync_dir_s = &RimeGetSyncDirSecure;
   }
   return &s_api;
 }

--- a/src/rime_api.cc
+++ b/src/rime_api.cc
@@ -95,7 +95,7 @@ RIME_API Bool RimeStartMaintenance(Bool full_check) {
   }
   if (!full_check) {
     TaskInitializer args{
-        vector<string>{
+        vector<path>{
             deployer.user_data_dir,
             deployer.shared_data_dir,
         },

--- a/src/rime_api.h
+++ b/src/rime_api.h
@@ -413,9 +413,13 @@ RIME_API RimeModule* RimeFindModule(const char* module_name);
 //! Run a registered task
 RIME_API Bool RimeRunTask(const char* task_name);
 
+//! \deprecated use RimeApi::get_shared_data_dir_s instead.
 RIME_API const char* RimeGetSharedDataDir(void);
+//! \deprecated use RimeApi::get_user_data_dir_s instead.
 RIME_API const char* RimeGetUserDataDir(void);
+//! \deprecated use RimeApi::get_sync_dir_s instead.
 RIME_API const char* RimeGetSyncDir(void);
+
 RIME_API const char* RimeGetUserId(void);
 
 /*! The API structure
@@ -543,9 +547,14 @@ typedef struct rime_api_t {
   RimeModule* (*find_module)(const char* module_name);
 
   Bool (*run_task)(const char* task_name);
+
+  //! \deprecated use get_shared_data_dir_s instead.
   const char* (*get_shared_data_dir)(void);
+  //! \deprecated use get_user_data_dir_s instead.
   const char* (*get_user_data_dir)(void);
+  //! \deprecated use get_sync_dir_s instead.
   const char* (*get_sync_dir)(void);
+
   const char* (*get_user_id)(void);
   void (*get_user_data_sync_dir)(char* dir, size_t buffer_size);
 
@@ -618,11 +627,13 @@ typedef struct rime_api_t {
                                     int index);
 
   //! prebuilt data directory.
+  //! \deprecated use get_prebuilt_data_dir_s instead.
   const char* (*get_prebuilt_data_dir)(void);
   //! staging directory, stores data files deployed to a Rime client.
+  //! \deprecated use get_staging_dir_s instead.
   const char* (*get_staging_dir)(void);
 
-  //! Deprecated: for capnproto API, use "proto" module from librime-proto
+  //! \deprecated for capnproto API, use "proto" module from librime-proto
   //! plugin.
   void (*commit_proto)(RimeSessionId session_id,
                        RIME_PROTO_BUILDER* commit_builder);
@@ -647,6 +658,12 @@ typedef struct rime_api_t {
                                                  Bool abbreviated);
 
   Bool (*set_input)(RimeSessionId session_id, const char* input);
+
+  void (*get_shared_data_dir_s)(char* dir, size_t buffer_size);
+  void (*get_user_data_dir_s)(char* dir, size_t buffer_size);
+  void (*get_prebuilt_data_dir_s)(char* dir, size_t buffer_size);
+  void (*get_staging_dir_s)(char* dir, size_t buffer_size);
+  void (*get_sync_dir_s)(char* dir, size_t buffer_size);
 } RimeApi;
 
 //! API entry

--- a/test/config_test.cc
+++ b/test/config_test.cc
@@ -174,11 +174,11 @@ TEST(RimeConfigWriterTest, Greetings) {
   // will not create subkeys over an existing value node
   EXPECT_FALSE(config->SetItem("zergs/going/home", zerg_greetings));
   // saving
-  EXPECT_TRUE(config->SaveToFile("config_writer_test.yaml"));
+  EXPECT_TRUE(config->SaveToFile(path{"config_writer_test.yaml"}));
   // verify
   the<Config> config2(new Config);
   ASSERT_TRUE(bool(config2));
-  EXPECT_TRUE(config2->LoadFromFile("config_writer_test.yaml"));
+  EXPECT_TRUE(config2->LoadFromFile(path{"config_writer_test.yaml"}));
   string the_greetings;
   EXPECT_TRUE(config2->GetString("greetings", &the_greetings));
   EXPECT_EQ("Greetings, Terrans!", the_greetings);
@@ -195,11 +195,11 @@ TEST(RimeConfigWriterTest, Greetings) {
   EXPECT_TRUE(config2->SetInt("zergs/statistics/population", population / 2));
   EXPECT_TRUE(config2->SetString("protoss/residence", "Aiur"));
   EXPECT_TRUE(config2->SetItem("zergs/overmind", nullptr));
-  EXPECT_TRUE(config2->SaveToFile("config_rewriter_test.yaml"));
+  EXPECT_TRUE(config2->SaveToFile(path{"config_rewriter_test.yaml"}));
   // verify
   the<Config> config3(new Config);
   ASSERT_TRUE(bool(config3));
-  EXPECT_TRUE(config3->LoadFromFile("config_rewriter_test.yaml"));
+  EXPECT_TRUE(config3->LoadFromFile(path{"config_rewriter_test.yaml"}));
   EXPECT_TRUE(config3->GetInt("zergs/statistics/population", &population));
   EXPECT_EQ(500000, population);
   string value;
@@ -235,8 +235,8 @@ TEST(RimeConfigxxTest, Operations) {
   an<ConfigItem> v2(config["nested"]["greetings"]);
   EXPECT_EQ(v1, v2);
   EXPECT_TRUE(config.modified());
-  EXPECT_TRUE(config.SaveToFile("rime_configxx_test.yaml"));
-  EXPECT_TRUE(config.LoadFromFile("rime_configxx_test.yaml"));
+  EXPECT_TRUE(config.SaveToFile(path{"rime_configxx_test.yaml"}));
+  EXPECT_TRUE(config.LoadFromFile(path{"rime_configxx_test.yaml"}));
   EXPECT_TRUE(config["str"].IsNull());
   EXPECT_FALSE(config.modified());
   EXPECT_EQ("Hello!", config["nested"]["greetings"].ToString());

--- a/test/corrector_test.cc
+++ b/test/corrector_test.cc
@@ -23,7 +23,8 @@ class RimeCorrectorSearchTest : public ::testing::Test {
       syllable_id_[syllables[i]] = i;
     }
 
-    prism_.reset(new rime::Prism("corrector_simple_test.prism.bin"));
+    rime::path file_path("corrector_simple_test.prism.bin");
+    prism_.reset(new rime::Prism(file_path));
     rime::set<rime::string> keyset;
     std::copy(syllables.begin(), syllables.end(),
               std::inserter(keyset, keyset.begin()));
@@ -53,7 +54,8 @@ class RimeCorrectorTest : public ::testing::Test {
       syllable_id_[syllables[i]] = i;
     }
 
-    prism_.reset(new rime::Prism("corrector_test.prism.bin"));
+    rime::path file_path("corrector_test.prism.bin");
+    prism_.reset(new rime::Prism(file_path));
     rime::set<rime::string> keyset;
     std::copy(syllables.begin(), syllables.end(),
               std::inserter(keyset, keyset.begin()));

--- a/test/dictionary_test.cc
+++ b/test/dictionary_test.cc
@@ -18,8 +18,8 @@ class RimeDictionaryTest : public ::testing::Test {
       dict_.reset(new rime::Dictionary(
           "dictionary_test",
           {},
-          {rime::New<rime::Table>(rime::path("dictionary_test.table.bin"))},
-          rime::New<rime::Prism>(rime::path("dictionary_test.prism.bin"))));
+          {rime::New<rime::Table>(rime::path{"dictionary_test.table.bin"})},
+          rime::New<rime::Prism>(rime::path{"dictionary_test.prism.bin"})));
     }
     if (!rebuilt_) {
       dict_->Remove();

--- a/test/dictionary_test.cc
+++ b/test/dictionary_test.cc
@@ -18,13 +18,13 @@ class RimeDictionaryTest : public ::testing::Test {
       dict_.reset(new rime::Dictionary(
           "dictionary_test",
           {},
-          {rime::New<rime::Table>("dictionary_test.table.bin")},
-          rime::New<rime::Prism>("dictionary_test.prism.bin")));
+          {rime::New<rime::Table>(rime::path("dictionary_test.table.bin"))},
+          rime::New<rime::Prism>(rime::path("dictionary_test.prism.bin"))));
     }
     if (!rebuilt_) {
       dict_->Remove();
       rime::DictCompiler dict_compiler(dict_.get());
-      dict_compiler.Compile("");  // no schema file
+      dict_compiler.Compile(rime::path());  // no schema file
       rebuilt_ = true;
     }
     dict_->Load();

--- a/test/prism_test.cc
+++ b/test/prism_test.cc
@@ -15,7 +15,7 @@ class RimePrismTest : public ::testing::Test {
   RimePrismTest() {}
 
   virtual void SetUp() {
-    prism_.reset(new Prism("prism_test.bin"));
+    prism_.reset(new Prism(path("prism_test.bin")));
     prism_->Remove();
     
     set<string> keyset;
@@ -40,7 +40,7 @@ class RimePrismTest : public ::testing::Test {
 TEST_F(RimePrismTest, SaveAndLoad) {
   EXPECT_TRUE(prism_->Save());
 
-  Prism test(prism_->file_name());
+  Prism test(prism_->file_path());
   EXPECT_TRUE(test.Load());
 
   EXPECT_EQ(prism_->array_size(), test.array_size());

--- a/test/prism_test.cc
+++ b/test/prism_test.cc
@@ -15,7 +15,7 @@ class RimePrismTest : public ::testing::Test {
   RimePrismTest() {}
 
   virtual void SetUp() {
-    prism_.reset(new Prism(path("prism_test.bin")));
+    prism_.reset(new Prism(path{"prism_test.bin"}));
     prism_->Remove();
     
     set<string> keyset;

--- a/test/resource_resolver_test.cc
+++ b/test/resource_resolver_test.cc
@@ -14,7 +14,7 @@ static const ResourceType kMineralsType = ResourceType{
 
 TEST(RimeResourceResolverTest, ResolvePath) {
   ResourceResolver rr(kMineralsType);
-  rr.set_root_path(path("/starcraft"));
+  rr.set_root_path(path{"/starcraft"});
   auto actual = rr.ResolvePath("enough");
   path expected = fs::absolute(fs::current_path())
       .root_name()
@@ -25,7 +25,7 @@ TEST(RimeResourceResolverTest, ResolvePath) {
 
 TEST(RimeResourceResolverTest, FallbackRootPath) {
   FallbackResourceResolver rr(kMineralsType);
-  rr.set_fallback_root_path(path("fallback"));
+  rr.set_fallback_root_path(path{"fallback"});
   fs::create_directory("fallback");
   {
     path nonexistent_default("not_present.minerals");

--- a/test/resource_resolver_test.cc
+++ b/test/resource_resolver_test.cc
@@ -14,21 +14,21 @@ static const ResourceType kMineralsType = ResourceType{
 
 TEST(RimeResourceResolverTest, ResolvePath) {
   ResourceResolver rr(kMineralsType);
-  rr.set_root_path("/starcraft");
+  rr.set_root_path(path("/starcraft"));
   auto actual = rr.ResolvePath("enough");
-  fs::path expected =
-      fs::absolute(fs::current_path()).root_name().string() +
-      "/starcraft/not_enough.minerals";
+  path expected = fs::absolute(fs::current_path())
+      .root_name()
+      .concat("/starcraft/not_enough.minerals");
   EXPECT_TRUE(actual.is_absolute());
   EXPECT_TRUE(expected == actual);
 }
 
 TEST(RimeResourceResolverTest, FallbackRootPath) {
   FallbackResourceResolver rr(kMineralsType);
-  rr.set_fallback_root_path("fallback");
+  rr.set_fallback_root_path(path("fallback"));
   fs::create_directory("fallback");
   {
-    fs::path nonexistent_default = "not_present.minerals";
+    path nonexistent_default("not_present.minerals");
     fs::remove(nonexistent_default);
     auto fallback = fs::absolute("fallback/not_present.minerals");
     std::ofstream(fallback.string()).close();

--- a/test/syllabifier_test.cc
+++ b/test/syllabifier_test.cc
@@ -30,7 +30,8 @@ class RimeSyllabifierTest : public ::testing::Test {
       syllable_id_[syllables[i]] = i;
     }
 
-    prism_.reset(new rime::Prism("syllabifier_test.bin"));
+    rime::path file_path("syllabifier_test.bin");
+    prism_.reset(new rime::Prism(file_path));
     rime::set<rime::string> keyset;
     std::copy(syllables.begin(), syllables.end(),
               std::inserter(keyset, keyset.begin()));

--- a/test/table_test.cc
+++ b/test/table_test.cc
@@ -13,7 +13,7 @@ class RimeTableTest : public ::testing::Test {
  public:
   virtual void SetUp() {
     if (!table_) {
-      table_.reset(new rime::Table(rime::path("table_test.bin")));
+      table_.reset(new rime::Table(rime::path{"table_test.bin"}));
       table_->Remove();
       rime::Syllabary syll;
       rime::Vocabulary voc;
@@ -94,7 +94,7 @@ void RimeTableTest::PrepareSampleVocabulary(rime::Syllabary& syll,
 }
 
 TEST_F(RimeTableTest, IntegrityTest) {
-  table_.reset(new rime::Table(rime::path("table_test.bin")));
+  table_.reset(new rime::Table(rime::path{"table_test.bin"}));
   ASSERT_TRUE(bool(table_));
   ASSERT_TRUE(table_->Load());
 }

--- a/test/table_test.cc
+++ b/test/table_test.cc
@@ -13,7 +13,7 @@ class RimeTableTest : public ::testing::Test {
  public:
   virtual void SetUp() {
     if (!table_) {
-      table_.reset(new rime::Table(file_name));
+      table_.reset(new rime::Table(rime::path("table_test.bin")));
       table_->Remove();
       rime::Syllabary syll;
       rime::Vocabulary voc;
@@ -28,7 +28,6 @@ class RimeTableTest : public ::testing::Test {
   }
  protected:
   static const int total_num_entries = 8;
-  static const char file_name[];
 
   static void PrepareSampleVocabulary(rime::Syllabary& syll,
                                       rime::Vocabulary& voc);
@@ -37,8 +36,6 @@ class RimeTableTest : public ::testing::Test {
   }
   static rime::the<rime::Table> table_;
 };
-
-const char RimeTableTest::file_name[] = "table_test.bin";
 
 rime::the<rime::Table> RimeTableTest::table_;
 
@@ -97,7 +94,7 @@ void RimeTableTest::PrepareSampleVocabulary(rime::Syllabary& syll,
 }
 
 TEST_F(RimeTableTest, IntegrityTest) {
-  table_.reset(new rime::Table(file_name));
+  table_.reset(new rime::Table(rime::path("table_test.bin")));
   ASSERT_TRUE(bool(table_));
   ASSERT_TRUE(table_->Load());
 }

--- a/test/user_db_test.cc
+++ b/test/user_db_test.cc
@@ -14,7 +14,7 @@ using namespace rime;
 using TestDb = UserDbWrapper<TextDb>;
 
 TEST(RimeUserDbTest, AccessRecordByKey) {
-  TestDb db("user_db_test.txt", "user_db_test");
+  TestDb db(path("user_db_test.txt"), "user_db_test");
   if (db.Exists())
     db.Remove();
   ASSERT_FALSE(db.Exists());
@@ -41,7 +41,7 @@ TEST(RimeUserDbTest, AccessRecordByKey) {
 }
 
 TEST(RimeUserDbTest, Query) {
-  TestDb db("user_db_test.txt", "user_db_test");
+  TestDb db(path("user_db_test.txt"), "user_db_test");
   if (db.Exists())
     db.Remove();
   ASSERT_FALSE(db.Exists());

--- a/test/user_db_test.cc
+++ b/test/user_db_test.cc
@@ -14,7 +14,7 @@ using namespace rime;
 using TestDb = UserDbWrapper<TextDb>;
 
 TEST(RimeUserDbTest, AccessRecordByKey) {
-  TestDb db(path("user_db_test.txt"), "user_db_test");
+  TestDb db(path{"user_db_test.txt"}, "user_db_test");
   if (db.Exists())
     db.Remove();
   ASSERT_FALSE(db.Exists());
@@ -41,7 +41,7 @@ TEST(RimeUserDbTest, AccessRecordByKey) {
 }
 
 TEST(RimeUserDbTest, Query) {
-  TestDb db(path("user_db_test.txt"), "user_db_test");
+  TestDb db(path{"user_db_test.txt"}, "user_db_test");
   if (db.Exists())
     db.Remove();
   ASSERT_FALSE(db.Exists());

--- a/tools/rime_deployer.cc
+++ b/tools/rime_deployer.cc
@@ -5,15 +5,12 @@
 // 2012-07-07 GONG Chen <chen.sst@gmail.com>
 //
 #include <iostream>
-#include <filesystem>
 #include <rime/config.h>
 #include <rime/deployer.h>
 #include <rime/service.h>
 #include <rime/setup.h>
 #include <rime/lever/deployment_tasks.h>
 #include "codepage.h"
-
-namespace fs = std::filesystem;
 
 using namespace rime;
 
@@ -75,10 +72,10 @@ static void setup_deployer(Deployer* deployer, int argc, char* argv[]) {
     deployer->staging_dir = argv[2];
   } else {
     deployer->staging_dir =
-        (fs::path(deployer->user_data_dir) / "build").string();
+        (path(deployer->user_data_dir) / "build").string();
   }
   deployer->prebuilt_data_dir =
-      (fs::path(deployer->shared_data_dir) / "build").string();
+      (path(deployer->shared_data_dir) / "build").string();
 }
 
 int main(int argc, char* argv[]) {

--- a/tools/rime_deployer.cc
+++ b/tools/rime_deployer.cc
@@ -16,7 +16,7 @@ using namespace rime;
 
 int add_schema(int count, char* schemas[]) {
   Config config;
-  if (!config.LoadFromFile("default.custom.yaml")) {
+  if (!config.LoadFromFile(path{"default.custom.yaml"})) {
     LOG(INFO) << "creating new file 'default.custom.yaml'.";
   }
   ConfigMapEntryRef schema_list(config["patch"]["schema_list"]);
@@ -39,7 +39,7 @@ int add_schema(int count, char* schemas[]) {
     schema_list[schema_list.size()]["schema"] = new_schema_id;
     LOG(INFO) << "added schema: " << new_schema_id;
   }
-  if (!config.SaveToFile("default.custom.yaml")) {
+  if (!config.SaveToFile(path{"default.custom.yaml"})) {
     LOG(ERROR) << "failed to save schema list.";
     return 1;
   }
@@ -48,11 +48,11 @@ int add_schema(int count, char* schemas[]) {
 
 int set_active_schema(const string& schema_id) {
   Config config;
-  if (!config.LoadFromFile("user.yaml")) {
+  if (!config.LoadFromFile(path{"user.yaml"})) {
     LOG(INFO) << "creating new file 'user.yaml'.";
   }
   config["var"]["previously_selected_schema"] = schema_id;
-  if (!config.SaveToFile("user.yaml")) {
+  if (!config.SaveToFile(path{"user.yaml"})) {
     LOG(ERROR) << "failed to set active schema: " << schema_id;
     return 1;
   }

--- a/tools/rime_deployer.cc
+++ b/tools/rime_deployer.cc
@@ -61,21 +61,19 @@ int set_active_schema(const string& schema_id) {
 
 static void setup_deployer(Deployer* deployer, int argc, char* argv[]) {
   if (argc > 0) {
-    deployer->user_data_dir = argv[0];
+    deployer->user_data_dir = path(argv[0]);
   }
   if (argc > 1) {
-    deployer->shared_data_dir = argv[1];
+    deployer->shared_data_dir = path(argv[1]);
   } else if (argc > 0) {
-    deployer->shared_data_dir = argv[0];
+    deployer->shared_data_dir = path(argv[0]);
   }
   if (argc > 2) {
-    deployer->staging_dir = argv[2];
+    deployer->staging_dir = path(argv[2]);
   } else {
-    deployer->staging_dir =
-        (path(deployer->user_data_dir) / "build").string();
+    deployer->staging_dir = deployer->user_data_dir / "build";
   }
-  deployer->prebuilt_data_dir =
-      (path(deployer->shared_data_dir) / "build").string();
+  deployer->prebuilt_data_dir = deployer->shared_data_dir / "build";
 }
 
 int main(int argc, char* argv[]) {
@@ -146,7 +144,7 @@ int main(int argc, char* argv[]) {
     Deployer& deployer(Service::instance().deployer());
     setup_deployer(&deployer, argc - 1, argv + 1);
     LoadModules(kDeployerModules);
-    string schema_file(argv[0]);
+    path schema_file(argv[0]);
     SchemaUpdate update(schema_file);
     update.set_verbose(true);
     int res = update.Run(&deployer) ? 0 : 1;

--- a/tools/rime_dict_manager.cc
+++ b/tools/rime_dict_manager.cc
@@ -86,13 +86,13 @@ int main(int argc, char* argv[]) {
   }
   if (argc == 3 && (option == "-r" || option == "--restore")) {
     SetConsoleOutputCodePage(codepage);
-    if (mgr.Restore(arg1))
+    if (mgr.Restore(path(arg1)))
       return 0;
     else
       return 1;
   }
   if (argc == 4 && (option == "-e" || option == "--export")) {
-    int n = mgr.Export(arg1, arg2);
+    int n = mgr.Export(arg1, path(arg2));
     SetConsoleOutputCodePage(codepage);
     if (n == -1)
       return 1;
@@ -100,7 +100,7 @@ int main(int argc, char* argv[]) {
     return 0;
   }
   if (argc == 4 && (option == "-i" || option == "--import")) {
-    int n = mgr.Import(arg1, arg2);
+    int n = mgr.Import(arg1, path(arg2));
     SetConsoleOutputCodePage(codepage);
     if (n == -1)
       return 1;

--- a/tools/rime_dict_manager.cc
+++ b/tools/rime_dict_manager.cc
@@ -45,7 +45,7 @@ int main(int argc, char* argv[]) {
   Deployer& deployer(Service::instance().deployer());
   {
     Config config;
-    if (config.LoadFromFile("installation.yaml")) {
+    if (config.LoadFromFile(path{"installation.yaml"})) {
       config.GetString("installation_id", &deployer.user_id);
       string sync_dir;
       if (config.GetString("sync_dir", &sync_dir)) {

--- a/tools/rime_dict_manager.cc
+++ b/tools/rime_dict_manager.cc
@@ -47,7 +47,10 @@ int main(int argc, char* argv[]) {
     Config config;
     if (config.LoadFromFile("installation.yaml")) {
       config.GetString("installation_id", &deployer.user_id);
-      config.GetString("sync_dir", &deployer.sync_dir);
+      string sync_dir;
+      if (config.GetString("sync_dir", &sync_dir)) {
+        deployer.sync_dir = path(sync_dir);
+      }
     }
   }
   UserDictManager mgr(&deployer);

--- a/tools/rime_table_decompiler.cc
+++ b/tools/rime_table_decompiler.cc
@@ -76,6 +76,16 @@ void traversal(rime::Table* table, std::ofstream& fout) {
   recursion(table, &query, fout);
 }
 
+rime::path InferredOutputPath(rime::path input_path) {
+  if (input_path.extension() == ".bin") {
+    input_path.replace_extension();
+    if (input_path.extension() == ".table") {
+      return input_path.replace_extension(".dict.yaml");
+    }
+  }
+  return input_path.concat(".yaml");
+}
+
 int main(int argc, char* argv[]) {
   unsigned int codepage = SetConsoleOutputCodePage();
   if (argc < 2 || argc > 3) {
@@ -88,8 +98,8 @@ int main(int argc, char* argv[]) {
     return 0;
   }
 
-  std::string fileName(argv[1]);
-  rime::Table table(fileName);
+  rime::path file_path(argv[1]);
+  rime::Table table(file_path);
   bool success = table.Load();
   if (!success) {
     std::cerr << "Failed to load table." << std::endl;
@@ -97,35 +107,27 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  // Remove the extension ".table.bin" if present.
-  const size_t table_bin_idx = fileName.rfind(".table.bin");
-  if (std::string::npos != table_bin_idx) {
-    fileName.erase(table_bin_idx);
-  }
-  const std::string outputName = (argc == 3) ? argv[2] : fileName + ".yaml";
+  rime::path output_path =
+    (argc == 3) ? rime::path(argv[2]) : InferredOutputPath(file_path);
 
   std::ofstream fout;
-  fout.open(outputName);
+  fout.open(output_path.c_str());
   if (!fout.is_open()) {
-    std::cerr << "Failed to open file " << outputName << std::endl;
+    std::cerr << "Failed to open file " << output_path << std::endl;
     SetConsoleOutputCodePage(codepage);
     return 1;
   }
 
   // schema id
-  const size_t last_slash_idx = fileName.find_last_of("\\/");
-  if (std::string::npos != last_slash_idx) {
-    fileName.erase(0, last_slash_idx + 1);
-  }
   fout << "# Rime dictionary\n\n";
   fout << "---\n"
           "name: "
-       << fileName
+       << file_path.stem().u8string()
        << "\n"
           "version: \"1.0\"\n"
           "...\n\n";
   traversal(&table, fout);
-  std::cout << "Save to: " << outputName << std::endl;
+  std::cout << "Save to: " << output_path << std::endl;
   fout.close();
   SetConsoleOutputCodePage(codepage);
   return 0;


### PR DESCRIPTION
Follow @fxliang 's PR, use `u8path` on Windows to convert UTF-8 string to Windows native path.
Closes #804

Fixes rime/weasel#576
Fixes rime/weasel#1080

BREAKING CHANGE: `installation.yaml` should be UTF-8 encoded.

Previouly on Windows, the file can be written in local encoding to enable paths with non-ASCII characters. It should be updated to UTF-8 after this change.

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
