### PR TITLE
fix: chord_composer should stop at super and caps by default

### DIFF
--- a/src/rime/gear/chord_composer.cc
+++ b/src/rime/gear/chord_composer.cc
@@ -83,12 +83,13 @@ inline static int get_base_layer_key_code(const KeyEvent& key_event) {
 }
 
 ProcessResult ChordComposer::ProcessChordingKey(const KeyEvent& key_event) {
-  if (key_event.ctrl() || key_event.alt() || key_event.super() || key_event.caps()) {
+  if (key_event.ctrl() || key_event.alt() || key_event.super() ||
+      key_event.caps()) {
     raw_sequence_.clear();
   }
   if ((key_event.ctrl() && !use_control_) || (key_event.alt() && !use_alt_) ||
-      (key_event.shift() && !use_shift_) || (key_event.super() && !use_super_) ||
-      (key_event.caps() && !use_caps_)) {
+      (key_event.shift() && !use_shift_) ||
+      (key_event.super() && !use_super_) || (key_event.caps() && !use_caps_)) {
     ClearChord();
     return kNoop;
   }

--- a/src/rime/gear/chord_composer.cc
+++ b/src/rime/gear/chord_composer.cc
@@ -25,6 +25,8 @@ ChordComposer::ChordComposer(const Ticket& ticket) : Processor(ticket) {
     config->GetBool("chord_composer/use_control", &use_control_);
     config->GetBool("chord_composer/use_alt", &use_alt_);
     config->GetBool("chord_composer/use_shift", &use_shift_);
+    config->GetBool("chord_composer/use_super", &use_super_);
+    config->GetBool("chord_composer/use_caps", &use_caps_);
     config->GetString("speller/delimiter", &delimiter_);
     algebra_.Load(config->GetList("chord_composer/algebra"));
     output_format_.Load(config->GetList("chord_composer/output_format"));
@@ -81,11 +83,12 @@ inline static int get_base_layer_key_code(const KeyEvent& key_event) {
 }
 
 ProcessResult ChordComposer::ProcessChordingKey(const KeyEvent& key_event) {
-  if (key_event.ctrl() || key_event.alt()) {
+  if (key_event.ctrl() || key_event.alt() || key_event.super() || key_event.caps()) {
     raw_sequence_.clear();
   }
   if ((key_event.ctrl() && !use_control_) || (key_event.alt() && !use_alt_) ||
-      (key_event.shift() && !use_shift_)) {
+      (key_event.shift() && !use_shift_) || (key_event.super() && !use_super_) ||
+      (key_event.caps() && !use_caps_)) {
     ClearChord();
     return kNoop;
   }

--- a/src/rime/gear/chord_composer.h
+++ b/src/rime/gear/chord_composer.h
@@ -41,6 +41,8 @@ class ChordComposer : public Processor {
   bool use_control_ = false;
   bool use_alt_ = false;
   bool use_shift_ = false;
+  bool use_super_ = false;
+  bool use_caps_ = false;
 
   set<int> pressed_;
   set<int> chord_;


### PR DESCRIPTION
## Pull request
Stop composing chord when a key event is super or caps modified, just like ctrl, alt, and shift.

Currently, super+any key will be consumed by rime when chord typing.

#### Unit test
- [x] Done

#### Manual test
- [x] Done

Type `super+a` the raw sequence will be cleared and the key can be forwarded to the client application.

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
