### PR TITLE
Apply clang format in rime source code

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install clang-format
         run: sudo apt install -y clang-format
       - name: Lint
-        run: find src -name '*.cc' -o -name '*.h' | xargs clang-format -Werror --dry-run || { echo Please lint your code by '"'"find src -name '*.cc' -o -name '*.h' | xargs clang-format -i"'"'.; false; }
+        run: make clang-format-lint
 
   linux:
     needs: lint

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -10,12 +10,12 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - name: Checkout last commit
         uses: actions/checkout@v4
       - name: Install clang-format
-        run: sudo apt install -y clang-format
+        run: brew install clang-format
       - name: Lint
         run: make clang-format-lint
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 RIME_ROOT ?= $(CURDIR)
 
+RIME_SOURCE_PATH = plugins sample src test tools
+
 ifeq ($(shell uname),Darwin) # for macOS
 prefix ?= $(RIME_ROOT)/dist
 
@@ -36,6 +38,12 @@ release debug test install uninstall \
 install-debug uninstall-debug
 
 all: release
+
+clang-format-lint:
+	find ${RIME_SOURCE_PATH} -name '*.cc' -o -name '*.h' | xargs clang-format -Werror --dry-run || { echo Please lint your code by '"'"make clang-format-apply"'"'.; false; }
+
+clang-format-apply:
+	find ${RIME_SOURCE_PATH} -name '*.cc' -o -name '*.h' | xargs clang-format --verbose -i
 
 deps:
 	$(MAKE) -f deps.mk

--- a/plugins/plugins_module.cc
+++ b/plugins/plugins_module.cc
@@ -46,8 +46,8 @@ void PluginManager::LoadPlugins(path plugins_dir) {
         DLOG(INFO) << "found plugin: " << plugin_file;
         string plugin_name = plugin_name_of(plugin_file);
         if (plugin_libs_.find(plugin_name) == plugin_libs_.end()) {
-          LOG(INFO) << "loading plugin '" << plugin_name
-                    << "' from " << plugin_file;
+          LOG(INFO) << "loading plugin '" << plugin_name << "' from "
+                    << plugin_file;
           try {
             auto plugin_lib = boost::dll::shared_library(plugin_file);
             plugin_libs_[plugin_name] = plugin_lib;

--- a/sample/src/sample_module.cc
+++ b/sample/src/sample_module.cc
@@ -19,7 +19,6 @@ static void rime_sample_initialize() {
   r.Register("trivial_translator", new Component<sample::TrivialTranslator>);
 }
 
-static void rime_sample_finalize() {
-}
+static void rime_sample_finalize() {}
 
 RIME_REGISTER_MODULE(sample)

--- a/sample/src/trivial_translator.cc
+++ b/sample/src/trivial_translator.cc
@@ -15,38 +15,34 @@ namespace sample {
 
 TrivialTranslator::TrivialTranslator(const Ticket& ticket)
     : Translator(ticket) {
-  dictionary_["yi"] = "\xe4\xb8\x80";  // 一
-  dictionary_["er"] = "\xe4\xba\x8c";  // 二
-  dictionary_["san"] = "\xe4\xb8\x89";  // 三
-  dictionary_["si"] = "\xe5\x9b\x9b";  // 四
-  dictionary_["wu"] = "\xe4\xba\x94";  // 五
-  dictionary_["liu"] = "\xe5\x85\xad";  // 六
-  dictionary_["qi"] = "\xe4\xb8\x83";  // 七
-  dictionary_["ba"] = "\xe5\x85\xab";  // 八
-  dictionary_["jiu"] = "\xe4\xb9\x9d";  // 九
+  dictionary_["yi"] = "\xe4\xb8\x80";    // 一
+  dictionary_["er"] = "\xe4\xba\x8c";    // 二
+  dictionary_["san"] = "\xe4\xb8\x89";   // 三
+  dictionary_["si"] = "\xe5\x9b\x9b";    // 四
+  dictionary_["wu"] = "\xe4\xba\x94";    // 五
+  dictionary_["liu"] = "\xe5\x85\xad";   // 六
+  dictionary_["qi"] = "\xe4\xb8\x83";    // 七
+  dictionary_["ba"] = "\xe5\x85\xab";    // 八
+  dictionary_["jiu"] = "\xe4\xb9\x9d";   // 九
   dictionary_["ling"] = "\xe3\x80\x87";  // 〇
-  dictionary_["shi"] = "\xe5\x8d\x81";  // 十
-  dictionary_["bai"] = "\xe7\x99\xbe";  // 百
+  dictionary_["shi"] = "\xe5\x8d\x81";   // 十
+  dictionary_["bai"] = "\xe7\x99\xbe";   // 百
   dictionary_["qian"] = "\xe5\x8d\x83";  // 千
-  dictionary_["wan"] = "\xe8\x90\xac";  // 萬
+  dictionary_["wan"] = "\xe8\x90\xac";   // 萬
 }
 
 an<Translation> TrivialTranslator::Query(const string& input,
                                          const Segment& segment) {
   if (!segment.HasTag("abc"))
     return nullptr;
-  DLOG(INFO) << "input = '" << input
-             << "', [" << segment.start << ", " << segment.end << ")";
+  DLOG(INFO) << "input = '" << input << "', [" << segment.start << ", "
+             << segment.end << ")";
   string output = Translate(input);
   if (output.empty()) {
     return nullptr;
   }
-  auto candidate = New<SimpleCandidate>(
-      "trivial",
-      segment.start,
-      segment.end,
-      output,
-      ":-)");
+  auto candidate = New<SimpleCandidate>("trivial", segment.start, segment.end,
+                                        output, ":-)");
   return New<UniqueTranslation>(candidate);
 }
 
@@ -55,10 +51,10 @@ string TrivialTranslator::Translate(const string& input) {
   const size_t kMaxPinyinLength = 6;
   string result;
   size_t input_len = input.length();
-  for (size_t i = 0; i < input_len; ) {
+  for (size_t i = 0; i < input_len;) {
     int translated = 0;
     size_t len = (std::max)(kMaxPinyinLength, input_len - i);
-    for ( ; len >= kMinPinyinLength; --len) {
+    for (; len >= kMinPinyinLength; --len) {
       auto it = dictionary_.find(input.substr(i, len));
       if (it != dictionary_.end()) {
         result += it->second;
@@ -68,8 +64,7 @@ string TrivialTranslator::Translate(const string& input) {
     }
     if (translated) {
       i += translated;
-    }
-    else {
+    } else {
       return string();
     }
   }

--- a/sample/src/trivial_translator.h
+++ b/sample/src/trivial_translator.h
@@ -22,8 +22,7 @@ class TrivialTranslator : public Translator {
  public:
   TrivialTranslator(const Ticket& ticket);
 
-  virtual an<Translation> Query(const string& input,
-                                const Segment& segment);
+  virtual an<Translation> Query(const string& input, const Segment& segment);
 
  private:
   string Translate(const string& input);

--- a/sample/test/trivial_translator_test.cc
+++ b/sample/test/trivial_translator_test.cc
@@ -15,7 +15,7 @@
 
 using namespace rime;
 
-TEST(/*DISABLED_*/TrivialTranslatorTest, Query) {
+TEST(/*DISABLED_*/ TrivialTranslatorTest, Query) {
   // make sure the component has been registered
   auto component = Translator::Require("trivial_translator");
   ASSERT_TRUE(component != NULL);
@@ -26,13 +26,14 @@ TEST(/*DISABLED_*/TrivialTranslatorTest, Query) {
   // lookup test
   const string test_input("yiqianerbaisanshisi");
   // 一千二百三十四
-  const string expected_output("\xe4\xb8\x80"
-                               "\xe5\x8d\x83"
-                               "\xe4\xba\x8c"
-                               "\xe7\x99\xbe"
-                               "\xe4\xb8\x89"
-                               "\xe5\x8d\x81"
-                               "\xe5\x9b\x9b");
+  const string expected_output(
+      "\xe4\xb8\x80"
+      "\xe5\x8d\x83"
+      "\xe4\xba\x8c"
+      "\xe7\x99\xbe"
+      "\xe4\xb8\x89"
+      "\xe5\x8d\x81"
+      "\xe5\x9b\x9b");
   Segment segment(0, test_input.length());
   segment.tags.insert("abc");
   auto translation = translator->Query(test_input, segment);

--- a/sample/tools/sample_console.cc
+++ b/sample/tools/sample_console.cc
@@ -8,60 +8,62 @@
 #include <string.h>
 #include <rime_api.h>
 
-void print_status(RimeStatus *status) {
-  printf("schema: %s / %s\n",
-         status->schema_id, status->schema_name);
+void print_status(RimeStatus* status) {
+  printf("schema: %s / %s\n", status->schema_id, status->schema_name);
   printf("status: ");
-  if (status->is_disabled) printf("disabled ");
-  if (status->is_composing) printf("composing ");
-  if (status->is_ascii_mode) printf("ascii ");
-  if (status->is_full_shape) printf("full_shape ");
-  if (status->is_simplified) printf("simplified ");
+  if (status->is_disabled)
+    printf("disabled ");
+  if (status->is_composing)
+    printf("composing ");
+  if (status->is_ascii_mode)
+    printf("ascii ");
+  if (status->is_full_shape)
+    printf("full_shape ");
+  if (status->is_simplified)
+    printf("simplified ");
   printf("\n");
 }
 
-void print_composition(RimeComposition *composition) {
-  const char *preedit = composition->preedit;
-  if (!preedit) return;
+void print_composition(RimeComposition* composition) {
+  const char* preedit = composition->preedit;
+  if (!preedit)
+    return;
   size_t len = strlen(preedit);
   size_t start = composition->sel_start;
   size_t end = composition->sel_end;
-  //size_t cursor = composition->cursor_pos;
+  // size_t cursor = composition->cursor_pos;
   for (size_t i = 0; i <= len; ++i) {
     if (start < end) {
-      if (i == start) putchar('[');
-      else if (i == end) putchar(']');
+      if (i == start)
+        putchar('[');
+      else if (i == end)
+        putchar(']');
     }
-    //if (i == cursor) putchar('|');
+    // if (i == cursor) putchar('|');
     if (i < len)
-        putchar(preedit[i]);
+      putchar(preedit[i]);
   }
   printf("\n");
 }
 
-void print_menu(RimeMenu *menu) {
-  if (menu->num_candidates == 0) return;
-  printf("page: %d%c (of size %d)\n",
-         menu->page_no + 1,
-         menu->is_last_page ? '$' : ' ',
-         menu->page_size);
+void print_menu(RimeMenu* menu) {
+  if (menu->num_candidates == 0)
+    return;
+  printf("page: %d%c (of size %d)\n", menu->page_no + 1,
+         menu->is_last_page ? '$' : ' ', menu->page_size);
   for (int i = 0; i < menu->num_candidates; ++i) {
     bool highlighted = i == menu->highlighted_candidate_index;
-    printf("%d. %c%s%c%s\n",
-           i + 1,
-           highlighted ? '[' : ' ',
-           menu->candidates[i].text,
-           highlighted ? ']' : ' ',
+    printf("%d. %c%s%c%s\n", i + 1, highlighted ? '[' : ' ',
+           menu->candidates[i].text, highlighted ? ']' : ' ',
            menu->candidates[i].comment ? menu->candidates[i].comment : "");
   }
 }
 
-void print_context(RimeContext *context) {
+void print_context(RimeContext* context) {
   if (context->composition.length > 0) {
     print_composition(&context->composition);
     print_menu(&context->menu);
-  }
-  else {
+  } else {
     printf("(not composing)\n");
   }
 }
@@ -96,8 +98,8 @@ bool execute_special_command(const char* line, RimeSessionId session_id) {
     if (rime->get_schema_list(&list)) {
       printf("schema list:\n");
       for (size_t i = 0; i < list.size; ++i) {
-        printf("%lu. %s [%s]\n", (i + 1),
-               list.list[i].name, list.list[i].schema_id);
+        printf("%lu. %s [%s]\n", (i + 1), list.list[i].name,
+               list.list[i].schema_id);
       }
       rime->free_schema_list(&list);
     }
@@ -126,7 +128,7 @@ void on_message(void* context_object,
 
 static RIME_MODULE_LIST(sample_modules, "default", "sample");
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   RimeApi* rime = rime_get_api();
 
   RIME_STRUCT(RimeTraits, traits);
@@ -152,7 +154,7 @@ int main(int argc, char *argv[]) {
   const int kMaxLength = 99;
   char line[kMaxLength + 1] = {0};
   while (fgets(line, kMaxLength, stdin) != NULL) {
-    for (char *p = line; *p; ++p) {
+    for (char* p = line; *p; ++p) {
       if (*p == '\r' || *p == '\n') {
         *p = '\0';
         break;
@@ -164,8 +166,7 @@ int main(int argc, char *argv[]) {
       continue;
     if (!rime->simulate_key_sequence(session_id, line)) {
       fprintf(stderr, "Error processing key sequence: %s\n", line);
-    }
-    else {
+    } else {
       print(session_id);
     }
   }

--- a/src/rime/common.h
+++ b/src/rime/common.h
@@ -100,19 +100,11 @@ class path : public std::filesystem::path {
   explicit path(const char* utf8_path) : fs_path(utf8_path) {}
 #endif
 
-  path& operator/=(const path& p) {
-    return *this = fs_path::operator/=(p);
-  }
-  path& operator/=(const fs_path& p) {
-    return *this = fs_path::operator/=(p);
-  }
+  path& operator/=(const path& p) { return *this = fs_path::operator/=(p); }
+  path& operator/=(const fs_path& p) { return *this = fs_path::operator/=(p); }
   // convert UTF-8 encoded string to native encoding, then append.
-  path& operator/=(const std::string& p) {
-    return *this /= path(p);
-  }
-  path& operator/=(const char* p) {
-    return *this /= path(p);
-  }
+  path& operator/=(const std::string& p) { return *this /= path(p); }
+  path& operator/=(const char* p) { return *this /= path(p); }
 
   friend path operator/(const path& lhs, const path& rhs) {
     return path(lhs) /= rhs;

--- a/src/rime/dict/table.h
+++ b/src/rime/dict/table.h
@@ -14,13 +14,21 @@
 #include <rime/dict/vocabulary.h>
 #include <rime/dict/string_table.h>
 
-#define RIME_TABLE_UNION(U, V, A, a, B, b)                           \
-  struct U {                                                         \
-    V value;                                                         \
-    const A& a() const { return *reinterpret_cast<const A*>(this); } \
-    const B& b() const { return *reinterpret_cast<const B*>(this); } \
-    A& a() { return *reinterpret_cast<A*>(this); }                   \
-    B& b() { return *reinterpret_cast<B*>(this); }                   \
+#define RIME_TABLE_UNION(U, V, A, a, B, b)      \
+  struct U {                                    \
+    V value;                                    \
+    const A& a() const {                        \
+      return *reinterpret_cast<const A*>(this); \
+    }                                           \
+    const B& b() const {                        \
+      return *reinterpret_cast<const B*>(this); \
+    }                                           \
+    A& a() {                                    \
+      return *reinterpret_cast<A*>(this);       \
+    }                                           \
+    B& b() {                                    \
+      return *reinterpret_cast<B*>(this);       \
+    }                                           \
   }
 
 namespace rime {

--- a/test/algebra_test.cc
+++ b/test/algebra_test.cc
@@ -15,11 +15,9 @@ static const char* kTransformation = "xform/^([zcs])h(.*)$/$1$2/";
 
 static const int kNumOfInstructions = 5;
 static const char* kInstructions[kNumOfInstructions] = {
-  "xform/^(\\l+)\\d$/$1/",
-  "erase/^[wxy].*$/",
-  "derive/^([zcs])h(.*)$/$1$2/",
-  "abbrev/^(\\l).+$/$1/",
-  "abbrev/^([zcs]h).+$/$1/",
+    "xform/^(\\l+)\\d$/$1/",       "erase/^[wxy].*$/",
+    "derive/^([zcs])h(.*)$/$1$2/", "abbrev/^(\\l).+$/$1/",
+    "abbrev/^([zcs]h).+$/$1/",
 };
 
 TEST(RimeAlgebraTest, SpellingManipulation) {

--- a/test/component_test.cc
+++ b/test/component_test.cc
@@ -20,11 +20,9 @@ using HelloMessage = pair<string, string>;
 
 class Hello : public Greeting {
  public:
-  Hello(const HelloMessage& msg) : word_(msg.first), name_(msg.second) {
-  }
-  string Say() {
-    return word_ + ", " + name_ + "!";
-  }
+  Hello(const HelloMessage& msg) : word_(msg.first), name_(msg.second) {}
+  string Say() { return word_ + ", " + name_ + "!"; }
+
  private:
   string word_;
   string name_;
@@ -38,10 +36,10 @@ class HelloComponent : public Hello::Component {
   Hello* Create(const string& name) {
     return new Hello(make_pair(word_, name));
   }
+
  private:
   string word_;
 };
-
 
 TEST(RimeComponentTest, UsingComponent) {
   Registry& r = Registry::instance();

--- a/test/config_compiler_test.cc
+++ b/test/config_compiler_test.cc
@@ -27,9 +27,7 @@ class RimeConfigCompilerTestBase : public ::testing::Test {
 
 class RimeConfigCompilerTest : public RimeConfigCompilerTestBase {
  protected:
-  string test_config_id() const override {
-    return "config_compiler_test";
-  }
+  string test_config_id() const override { return "config_compiler_test"; }
 };
 
 TEST_F(RimeConfigCompilerTest, IncludeLocalReference) {
@@ -111,9 +109,7 @@ TEST_F(RimeConfigCompilerTest, PatchList) {
 
 class RimeConfigDependencyTest : public RimeConfigCompilerTestBase {
  protected:
-  string test_config_id() const override {
-    return "config_dependency_test";
-  }
+  string test_config_id() const override { return "config_dependency_test"; }
 };
 
 TEST_F(RimeConfigDependencyTest, DependencyChaining) {
@@ -162,9 +158,7 @@ TEST_F(RimeConfigOptionalReferenceTest, OptionalReference) {
 
 class RimeConfigMergeTest : public RimeConfigCompilerTestBase {
  protected:
-  string test_config_id() const override {
-    return "config_merge_test";
-  }
+  string test_config_id() const override { return "config_merge_test"; }
 };
 
 TEST_F(RimeConfigMergeTest, AppendWithInclude) {

--- a/test/config_test.cc
+++ b/test/config_test.cc
@@ -20,8 +20,7 @@ class RimeConfigTest : public ::testing::Test {
     config_.reset(component_->Create("config_test"));
   }
 
-  virtual void TearDown() {
-  }
+  virtual void TearDown() {}
 
   the<Config::Component> component_;
   the<Config> config_;
@@ -30,12 +29,9 @@ class RimeConfigTest : public ::testing::Test {
 TEST(RimeConfigComponentTest, RoundTrip) {
   // registration
   Registry& r = Registry::instance();
-  r.Register(
-      "test_config",
-      new ConfigComponent<ConfigLoader, UserConfigResourceProvider>(
-          [](ConfigLoader* loader) {
-            loader->set_auto_save(true);
-          }));
+  r.Register("test_config",
+             new ConfigComponent<ConfigLoader, UserConfigResourceProvider>(
+                 [](ConfigLoader* loader) { loader->set_auto_save(true); }));
   // find component
   Config::Component* cc = Config::Require("test_config");
   ASSERT_TRUE(cc != NULL);
@@ -131,7 +127,6 @@ TEST_F(RimeConfigTest, Config_GetList) {
   ASSERT_TRUE(bool(element));
   ASSERT_TRUE(element->GetString(&value));
   EXPECT_EQ("arbiter", value);
-
 }
 
 TEST_F(RimeConfigTest, Config_GetMap) {

--- a/test/corrector_test.cc
+++ b/test/corrector_test.cc
@@ -33,6 +33,7 @@ class RimeCorrectorSearchTest : public ::testing::Test {
     corrector_.reset(new rime::NearSearchCorrector);
   }
   void TearDown() override {}
+
  protected:
   rime::map<rime::string, rime::SyllableId> syllable_id_;
   rime::the<rime::Prism> prism_;
@@ -43,12 +44,12 @@ class RimeCorrectorTest : public ::testing::Test {
  public:
   void SetUp() override {
     rime::vector<rime::string> syllables;
-    syllables.emplace_back("j");      // 0 == id
-    syllables.emplace_back("ji");     // 1
-    syllables.emplace_back("jie");    // 2
-    syllables.emplace_back("ju");     // 3
-    syllables.emplace_back("jue");    // 4
-    syllables.emplace_back("shen");   // 5
+    syllables.emplace_back("j");     // 0 == id
+    syllables.emplace_back("ji");    // 1
+    syllables.emplace_back("jie");   // 2
+    syllables.emplace_back("ju");    // 3
+    syllables.emplace_back("jue");   // 4
+    syllables.emplace_back("shen");  // 5
     std::sort(syllables.begin(), syllables.end());
     for (size_t i = 0; i < syllables.size(); ++i) {
       syllable_id_[syllables[i]] = i;
@@ -138,7 +139,7 @@ TEST_F(RimeCorrectorTest, CaseMultipleEdges1) {
   rime::Syllabifier s;
   s.EnableCorrection(corrector_.get());
   rime::SyllableGraph g;
-  const rime::string input("jiejue"); // jie'jue jie'jie jue'jue jue'jie
+  const rime::string input("jiejue");  // jie'jue jie'jie jue'jue jue'jie
   s.BuildSyllableGraph(input, *prism_, &g);
   EXPECT_EQ(input.length(), g.input_length);
   EXPECT_EQ(input.length(), g.interpreted_length);

--- a/test/dictionary_test.cc
+++ b/test/dictionary_test.cc
@@ -16,8 +16,7 @@ class RimeDictionaryTest : public ::testing::Test {
   virtual void SetUp() {
     if (!dict_) {
       dict_.reset(new rime::Dictionary(
-          "dictionary_test",
-          {},
+          "dictionary_test", {},
           {rime::New<rime::Table>(rime::path{"dictionary_test.table.bin"})},
           rime::New<rime::Prism>(rime::path{"dictionary_test.prism.bin"})));
     }
@@ -29,9 +28,8 @@ class RimeDictionaryTest : public ::testing::Test {
     }
     dict_->Load();
   }
-  virtual void TearDown() {
-    dict_.reset();
-  }
+  virtual void TearDown() { dict_.reset(); }
+
  protected:
   static rime::the<rime::Dictionary> dict_;
   static bool rebuilt_;

--- a/test/key_event_test.cc
+++ b/test/key_event_test.cc
@@ -121,8 +121,7 @@ TEST(RimeKeySequenceTest, Stringification) {
   ASSERT_TRUE(ks.Parse("z y,x."));
   ks.push_back(KeyEvent("{"));
   ks.push_back(KeyEvent("}"));
-  EXPECT_STREQ("z y,x.{braceleft}{braceright}",
-               ks.repr().c_str());
+  EXPECT_STREQ("z y,x.{braceleft}{braceright}", ks.repr().c_str());
 }
 
 TEST(RimeKeySequenceTest, Serialization) {

--- a/test/prism_test.cc
+++ b/test/prism_test.cc
@@ -17,22 +17,21 @@ class RimePrismTest : public ::testing::Test {
   virtual void SetUp() {
     prism_.reset(new Prism(path{"prism_test.bin"}));
     prism_->Remove();
-    
+
     set<string> keyset;
-    keyset.insert("google");     // 4
-    keyset.insert("good");       // 2
-    keyset.insert("goodbye");    // 3
+    keyset.insert("google");   // 4
+    keyset.insert("good");     // 2
+    keyset.insert("goodbye");  // 3
     keyset.insert("microsoft");
     keyset.insert("macrosoft");
-    keyset.insert("adobe");      // 0 == id
+    keyset.insert("adobe");  // 0 == id
     keyset.insert("yahoo");
-    keyset.insert("baidu");      // 1
+    keyset.insert("baidu");  // 1
 
     prism_->Build(keyset);
   }
 
-  virtual void TearDown() {
-  }
+  virtual void TearDown() {}
 
   the<Prism> prism_;
 };
@@ -68,11 +67,11 @@ TEST_F(RimePrismTest, CommonPrefixMatch) {
   vector<Prism::Match> result;
 
   prism_->CommonPrefixSearch("goodbye", &result);
-  //result is good and goodbye.
+  // result is good and goodbye.
   ASSERT_EQ(result.size(), 2);
-  EXPECT_EQ(result[0].value, 2);  // good
+  EXPECT_EQ(result[0].value, 2);   // good
   EXPECT_EQ(result[0].length, 4);  // good
-  EXPECT_EQ(result[1].value, 3);  // goodbye
+  EXPECT_EQ(result[1].value, 3);   // goodbye
   EXPECT_EQ(result[1].length, 7);  // goodbye
 }
 
@@ -80,12 +79,12 @@ TEST_F(RimePrismTest, ExpandSearch) {
   vector<Prism::Match> result;
 
   prism_->ExpandSearch("goo", &result, 10);
-  //result is good, google and goodbye (ordered by length asc).
+  // result is good, google and goodbye (ordered by length asc).
   ASSERT_EQ(result.size(), 3);
-  EXPECT_EQ(result[0].value, 2);  // good
+  EXPECT_EQ(result[0].value, 2);   // good
   EXPECT_EQ(result[0].length, 4);  // good
-  EXPECT_EQ(result[1].value, 4);  // google
+  EXPECT_EQ(result[1].value, 4);   // google
   EXPECT_EQ(result[1].length, 6);  // google
-  EXPECT_EQ(result[2].value, 3);  // goodbye
+  EXPECT_EQ(result[2].value, 3);   // goodbye
   EXPECT_EQ(result[2].length, 7);  // goodbye
 }

--- a/test/resource_resolver_test.cc
+++ b/test/resource_resolver_test.cc
@@ -7,9 +7,9 @@ namespace fs = std::filesystem;
 using namespace rime;
 
 static const ResourceType kMineralsType = ResourceType{
-  "minerals",
-  "not_",
-  ".minerals",
+    "minerals",
+    "not_",
+    ".minerals",
 };
 
 TEST(RimeResourceResolverTest, ResolvePath) {
@@ -17,8 +17,8 @@ TEST(RimeResourceResolverTest, ResolvePath) {
   rr.set_root_path(path{"/starcraft"});
   auto actual = rr.ResolvePath("enough");
   path expected = fs::absolute(fs::current_path())
-      .root_name()
-      .concat("/starcraft/not_enough.minerals");
+                      .root_name()
+                      .concat("/starcraft/not_enough.minerals");
   EXPECT_TRUE(actual.is_absolute());
   EXPECT_TRUE(expected == actual);
 }

--- a/test/rime_test_main.cc
+++ b/test/rime_test_main.cc
@@ -2,15 +2,13 @@
 #include <rime_api.h>
 #include <rime/setup.h>
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
 
   RIME_STRUCT(RimeTraits, traits);
   // put all files in the working directory ($build/test).
-  traits.shared_data_dir =
-      traits.user_data_dir =
-          traits.prebuilt_data_dir =
-              traits.staging_dir = ".";
+  traits.shared_data_dir = traits.user_data_dir = traits.prebuilt_data_dir =
+      traits.staging_dir = ".";
   rime::SetupDeployer(&traits);
   rime::SetupLogging("rime.test");
   rime::LoadModules(rime::kDefaultModules);

--- a/test/syllabifier_test.cc
+++ b/test/syllabifier_test.cc
@@ -38,8 +38,7 @@ class RimeSyllabifierTest : public ::testing::Test {
     prism_->Build(keyset);
   }
 
-  virtual void TearDown() {
-  }
+  virtual void TearDown() {}
 
  protected:
   rime::map<rime::string, rime::SyllableId> syllable_id_;

--- a/test/table_test.cc
+++ b/test/table_test.cc
@@ -8,7 +8,6 @@
 #include <rime/algo/syllabifier.h>
 #include <rime/dict/table.h>
 
-
 class RimeTableTest : public ::testing::Test {
  public:
   virtual void SetUp() {
@@ -23,9 +22,8 @@ class RimeTableTest : public ::testing::Test {
     }
     table_->Load();
   }
-  virtual void TearDown() {
-    table_->Close();
-  }
+  virtual void TearDown() { table_->Close(); }
+
  protected:
   static const int total_num_entries = 8;
 
@@ -89,7 +87,7 @@ void RimeTableTest::PrepareSampleVocabulary(rime::Syllabary& syll,
   d->code.resize(3);
   d->code.push_back(2);
   d->code.push_back(1);
-  d->text  = "yi-er-san-er-yi";
+  d->text = "yi-er-san-er-yi";
   (*lv4)[-1].entries.push_back(d);
 }
 

--- a/tools/rime_table_decompiler.cc
+++ b/tools/rime_table_decompiler.cc
@@ -108,7 +108,7 @@ int main(int argc, char* argv[]) {
   }
 
   rime::path output_path =
-    (argc == 3) ? rime::path(argv[2]) : InferredOutputPath(file_path);
+      (argc == 3) ? rime::path(argv[2]) : InferredOutputPath(file_path);
 
   std::ofstream fout;
   fout.open(output_path.c_str());


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request
Apply clang format in rime source code.

Add targets in Makefile, to format code, just use command.
```
make clang-format-apply
```

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
