### PR TITLE
feat(dict_compiler): rebuild packs on demand

### DIFF
--- a/src/rime/dict/dict_compiler.cc
+++ b/src/rime/dict/dict_compiler.cc
@@ -150,10 +150,10 @@ bool DictCompiler::Compile(const path& schema_file) {
     }
     syllabary = std::move(collector.syllabary);
   } else if (packs_.size() > 0) {
-    primary_table->Load();
-    if (!tables_[0]->GetSyllabary(&syllabary))
+    if (primary_table->Load() && primary_table->GetSyllabary(&syllabary))
+      primary_table->Close();
+    else
       LOG(WARNING) << "couldn't load syllabary from '" << schema_file << "'";
-    primary_table->Close();
   }
   if (rebuild_prism &&
       !BuildPrism(schema_file, dict_file_checksum, schema_file_checksum)) {


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Rebuild packs if the pack source dict file is updated, even if the primary table is not updated.

Previously, packs are only rebuilt after the primary table is rebuilt.

#### Unit test
- [x] Done

#### Manual test
- [x] Done

Tested with:
- no packs
- one pack, build successful, able to use words in the pack
- one pack, unmodified, won't rebuild
- one pack, remove source file, able to use the prebuilt table
- one pack, modified, can rebuild automatically
- multiple packs, remove one source file, the other can still be used
- multiple packs, only modified pack gets rebuilt
- modified primary dict, all packs will be rebuilt except those lacking source files (I'm not sure if this is safe, but the current design of dictionary packs is also vulnerable to this kind of problem.)

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
To test, create two dict.yaml files:

```
# Rime dict
---
name: sample_pack1
version: '1.0'
sort: original
use_preset_vocabulary: false
...

粗鄙之語	cu bi zhi yu
```

```
---
name: sample_pack2
version: '1.0'
sort: original
use_preset_vocabulary: false
...

粗鄙之語児	cu bi zhi yu er
```

Edit `luna_pinyin.schema.yaml` so the packs can be built and loaded:

```
translator:
  #...
  packs:
    - sample_pack1
    - sample_pack2
```

<img width="338" alt="image" src="https://github.com/rime/librime/assets/23358293/6a0c3b89-e52c-420a-979b-f64d930fbe2b">

