### PR TITLE
feat(table_translator): Allow sorting completions

### DIFF
--- a/src/rime/algo/algebra.cc
+++ b/src/rime/algo/algebra.cc
@@ -53,7 +53,7 @@ void Script::Dump(const path& file_path) const {
     bool first = true;
     for (const Spelling& s : v.second) {
       out << (first ? v.first : "") << '\t' << s.str << '\t'
-          << "-ac?!"[s.properties.type] << '\t' << s.properties.credibility
+          << "-fac?!"[s.properties.type] << '\t' << s.properties.credibility
           << '\t' << s.properties.tips << std::endl;
       first = false;
     }

--- a/src/rime/dict/dictionary.cc
+++ b/src/rime/dict/dictionary.cc
@@ -269,11 +269,12 @@ size_t Dictionary::LookupWords(DictEntryIterator* result,
     while (!accessor.exhausted()) {
       SyllableId syllable_id = accessor.syllable_id();
       SpellingType type = accessor.properties().type;
+      bool is_sorted_completion = predictive && type == kCompletion;
       accessor.Next();
-      if (type > kNormalSpelling)
+      if (type > kNormalSpelling && !is_sorted_completion)
         continue;
       string remaining_code;
-      if (match.length > code_length) {
+      if (match.length > code_length || is_sorted_completion) {
         string syllable = primary_table()->GetSyllableById(syllable_id);
         if (syllable.length() > code_length)
           remaining_code = syllable.substr(code_length);

--- a/src/rime/dict/dictionary.h
+++ b/src/rime/dict/dictionary.h
@@ -77,6 +77,7 @@ class Dictionary : public Class<Dictionary, const Ticket&> {
   // if predictive is true, do an expand search with limit,
   // otherwise do an exact match.
   // return num of matching keys.
+  // kCompletion spellings are considered iff predictive=true.
   RIME_API size_t LookupWords(DictEntryIterator* result,
                               const string& str_code,
                               bool predictive,

--- a/src/rime/gear/translator_commons.cc
+++ b/src/rime/gear/translator_commons.cc
@@ -123,6 +123,8 @@ TranslatorOptions::TranslatorOptions(const Ticket& ticket) {
                     &contextual_suggestions_);
     config->GetBool(ticket.name_space + "/enable_completion",
                     &enable_completion_);
+    config->GetBool(ticket.name_space + "/sort_completions",
+                    &sort_completions_);
     config->GetBool(ticket.name_space + "/strict_spelling", &strict_spelling_);
     config->GetDouble(ticket.name_space + "/initial_quality",
                       &initial_quality_);

--- a/src/rime/gear/translator_commons.h
+++ b/src/rime/gear/translator_commons.h
@@ -148,6 +148,7 @@ class TranslatorOptions {
   string tag_ = "abc";
   bool contextual_suggestions_ = false;
   bool enable_completion_ = true;
+  bool sort_completions_ = false;
   bool strict_spelling_ = false;
   double initial_quality_ = 0.;
   Projection preedit_formatter_;


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #820

#### Feature
Describe feature of pull request

Add a new boolean option `sort_completions`. When enabled (requiring
`enable_completion` also to be enabled), completion candidates will be
sorted according to the weights specified in the dictionary.

This is done by automatically generating kCompletion spellings in the
prism, as if they were generated from spelling algebra written by the
user.

Previously, the order was arbitrary (but more-or-less in alphabet
order).


#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
