### PR TITLE
add param `chord_composer/finish_chord_on_first_key_release` for chord_composer, first release to finish chord

### DIFF
--- a/src/rime/gear/chord_composer.cc
+++ b/src/rime/gear/chord_composer.cc
@@ -27,6 +27,8 @@ ChordComposer::ChordComposer(const Ticket& ticket) : Processor(ticket) {
     config->GetBool("chord_composer/use_shift", &use_shift_);
     config->GetBool("chord_composer/use_super", &use_super_);
     config->GetBool("chord_composer/use_caps", &use_caps_);
+    config->GetBool("chord_composer/finish_chord_on_first_key_release",
+                    &finish_chord_on_first_key_release_);
     config->GetString("speller/delimiter", &delimiter_);
     algebra_.Load(config->GetList("chord_composer/algebra"));
     output_format_.Load(config->GetList("chord_composer/output_format"));
@@ -104,7 +106,12 @@ ProcessResult ChordComposer::ProcessChordingKey(const KeyEvent& key_event) {
   editing_chord_ = true;
   bool is_key_up = key_event.release();
   if (is_key_up) {
-    if (pressed_.erase(ch) != 0 && pressed_.empty()) {
+    if (finish_chord_on_first_key_release_) {
+      if (pressed_.find(ch) != pressed_.end()) {
+        FinishChord();
+        pressed_.clear();
+      }
+    } else if (pressed_.erase(ch) != 0 && pressed_.empty()) {
       FinishChord();
     }
   } else {  // key down

--- a/src/rime/gear/chord_composer.h
+++ b/src/rime/gear/chord_composer.h
@@ -43,6 +43,7 @@ class ChordComposer : public Processor {
   bool use_shift_ = false;
   bool use_super_ = false;
   bool use_caps_ = false;
+  bool finish_chord_on_first_key_release_ = false;
 
   set<int> pressed_;
   set<int> chord_;


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

`chord_composer/finish_chord_on_first_key_release: {bool}`

default `false`, if set `true`,  tested in rime_api_console :

![rime_api_console](https://github.com/rime/librime/assets/4023160/ae2004c6-f439-434f-bf6b-d00f2753e7c3)

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
