### PR TITLE
feat: rime_api_console simulate key down and up, by '>' or '<'

### DIFF
--- a/tools/rime_api_console.cc
+++ b/tools/rime_api_console.cc
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <rime_api.h>
+#include <rime/key_event.h>
 #include "codepage.h"
 
 void print_status(RimeStatus* status) {
@@ -227,7 +228,14 @@ reload:
     }
     if (execute_special_command(line, session_id))
       continue;
-    if (rime->simulate_key_sequence(session_id, line)) {
+    // simulate key down and up
+    if (line[1] && (line[0] == '>' || line[0] == '<')) {
+      std::string key_repr = std::string(&line[1]);
+      rime::KeyEvent key = rime::KeyEvent(key_repr);
+      key.modifier(line[0] == '>' ? 0 : kReleaseMask);
+      rime->process_key(session_id, key.keycode(), key.modifier());
+      print(session_id);
+    } else if (rime->simulate_key_sequence(session_id, line)) {
       print(session_id);
     } else {
       fprintf(stderr, "Error processing key sequence: %s\n", line);


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request
simulate key down and up by `>` and `<`
e.g., 
`>a` to simulate `a` down
`<a` to simulate `a` up
#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
