### PR TITLE
fix(context): tag selected segment after editing

### DIFF
--- a/src/rime/context.h
+++ b/src/rime/context.h
@@ -50,8 +50,8 @@ class RIME_API Context {
   // return false if there's no candidate for current segment
   bool ConfirmCurrentSelection();
   bool DeleteCurrentSelection();
-
-  bool ConfirmPreviousSelection();
+  void BeginEditing();
+  bool ConfirmPreviousSelection();  // deprecated
   bool ReopenPreviousSegment();
   bool ClearPreviousSegment();
   bool ReopenPreviousSelection();

--- a/src/rime/gear/editor.cc
+++ b/src/rime/gear/editor.cc
@@ -123,7 +123,8 @@ bool Editor::CommitComposition(Context* ctx) {
 }
 
 bool Editor::RevertLastEdit(Context* ctx) {
-  // different behavior in regard to previous operation type
+  // revert last selection or delete last input character
+  // depending on recent operation type
   ctx->ReopenPreviousSelection() ||
       (ctx->PopInput() && ctx->ReopenPreviousSegment());
   return true;
@@ -181,7 +182,7 @@ ProcessResult Editor::DirectCommit(Context* ctx, int ch) {
 
 ProcessResult Editor::AddToInput(Context* ctx, int ch) {
   ctx->PushInput(ch);
-  ctx->ConfirmPreviousSelection();
+  ctx->BeginEditing();
   return kAccepted;
 }
 

--- a/src/rime/gear/navigator.cc
+++ b/src/rime/gear/navigator.cc
@@ -123,7 +123,7 @@ bool Navigator::End(Context* ctx) {
 }
 
 void Navigator::BeginMove(Context* ctx) {
-  ctx->ConfirmPreviousSelection();
+  ctx->BeginEditing();
   // update spans
   if (input_ != ctx->input() || ctx->caret_pos() > spans_.end()) {
     input_ = ctx->input();

--- a/src/rime/gear/speller.cc
+++ b/src/rime/gear/speller.cc
@@ -121,8 +121,7 @@ ProcessResult Speller::ProcessKeyEvent(const KeyEvent& key_event) {
   }
   DLOG(INFO) << "add to input: '" << (char)ch << "', " << key_event.repr();
   ctx->PushInput(ch);
-  ctx->ConfirmPreviousSelection();  // so that next BackSpace won't revert
-                                    // previous selection
+  ctx->BeginEditing();
   if (AutoSelectPreviousMatch(ctx, &previous_segment)) {
     DLOG(INFO) << "auto-select previous match.";
     // after auto-selecting, if only the current non-initial key is left,


### PR DESCRIPTION
call Context::BeginEditing when input is edited after selection. move cursor also counts as edit.

the tag is used to tell if BackSpace should delete the last input character or revert a recent selection.

the information was previously denoted by kConfirmed status which caused the side-effect of breaking a user phrase into individual segments.

fixed #746, fixed #830
