### PR TITLE
fix(plugins): load plugins in relative path

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -173,7 +173,7 @@ jobs:
             -DBUILD_SHARED_LIBS:BOOL=ON
           cmake --build build
           cmake --install build
-          cd build && cp ./lib/librime.dll ./test
+          cd build && cp ./bin/librime.dll ./test
           ctest --output-on-failure
 
       - name: Create distributable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,8 @@ option(ENABLE_EXTERNAL_PLUGINS "Enable loading of externally built Rime plugins 
 option(ENABLE_THREADING "Enable threading for deployer" ON)
 option(ENABLE_TIMESTAMP "Embed timestamp to schema artifacts" ON)
 
-set(RIME_DATA_DIR "${CMAKE_INSTALL_FULL_DATADIR}/rime-data" CACHE STRING "Target directory for Rime data")
-set(RIME_PLUGINS_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/rime-plugins" CACHE STRING "Target directory for externally built Rime plugins")
+set(RIME_DATA_DIR "rime-data" CACHE STRING "Target directory for Rime data")
+set(RIME_PLUGINS_DIR "rime-plugins" CACHE STRING "Target directory for externally built Rime plugins")
 
 if(WIN32)
   set(ext ".exe")
@@ -205,8 +205,8 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD|DragonFly|GNU|Darwin" OR MINGW)
   set(exec_prefix "${CMAKE_INSTALL_PREFIX}")
   set(bindir "${CMAKE_INSTALL_FULL_BINDIR}")
   set(libdir "${CMAKE_INSTALL_FULL_LIBDIR}")
-  set(pkgdatadir "${RIME_DATA_DIR}")
-  set(pluginsdir "${RIME_PLUGINS_DIR}")
+  set(pkgdatadir "${CMAKE_INSTALL_FULL_DATADIR}/${RIME_DATA_DIR}")
+  set(pluginsdir "${CMAKE_INSTALL_FULL_LIBDIR}/${RIME_PLUGINS_DIR}")
   set(includedir "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
   configure_file(
       ${PROJECT_SOURCE_DIR}/rime.pc.in
@@ -238,7 +238,7 @@ endif()
 
 if(BUILD_DATA)
   file(GLOB rime_preset_data_files ${PROJECT_SOURCE_DIR}/data/preset/*.yaml)
-  install(FILES ${rime_preset_data_files} DESTINATION ${RIME_DATA_DIR})
+  install(FILES ${rime_preset_data_files} DESTINATION ${CMAKE_INSTALL_FULL_DATADIR}/${RIME_DATA_DIR})
 endif()
 
 if(BUILD_SHARED_LIBS)

--- a/README-windows.md
+++ b/README-windows.md
@@ -49,7 +49,7 @@ This builds dependent libraries in `librime\deps\*`, and copies artifacts to
 ``` batch
 build.bat librime
 ```
-This creates `build\lib\Release\rime.dll`.
+This creates `build\bin\Release\rime.dll`.
 
 Build artifacts - the shared library along with API headers and supporting files
 are gathered in `dist` directory.
@@ -60,7 +60,6 @@ are gathered in `dist` directory.
 is working.
 
 ``` batch
-copy /Y build\lib\Release\rime.dll build\bin
 cd build\bin
 echo congmingdeRime{space}shurufa | Release\rime_api_console.exe > output.txt
 ```

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(RIME_SOURCE_DIR ${PROJECT_SOURCE_DIR})
-set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 
 # work around CMake build issues on macOS
 set(rime_plugin_boilerplate_src "plugin.cc")
@@ -55,10 +54,14 @@ foreach(plugin ${plugins})
     message(STATUS "Plugin ${plugin_name} provides modules: ${plugin_modules}")
     add_library(${plugin_name} ${rime_plugin_boilerplate_src} ${plugin_objs})
     target_link_libraries(${plugin_name} ${plugin_deps})
+    set_target_properties(${plugin_name}
+      PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib/${RIME_PLUGINS_DIR}
+      RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin/${RIME_PLUGINS_DIR})
     if(XCODE_VERSION)
       set_target_properties(${plugin_name} PROPERTIES INSTALL_NAME_DIR "@rpath")
     endif(XCODE_VERSION)
-    install(TARGETS ${plugin_name} DESTINATION ${RIME_PLUGINS_DIR})
+    install(TARGETS ${plugin_name} DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/${RIME_PLUGINS_DIR})
   endif()
 endforeach(plugin)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,3 @@
-set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
-
 aux_source_directory(. rime_api_src)
 aux_source_directory(rime rime_base_src)
 aux_source_directory(rime/algo rime_algo_src)
@@ -82,7 +80,9 @@ if(BUILD_SHARED_LIBS)
   set_target_properties(rime PROPERTIES
     DEFINE_SYMBOL "RIME_EXPORTS"
     VERSION ${rime_version}
-    SOVERSION ${rime_soversion})
+    SOVERSION ${rime_soversion}
+    LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib
+    RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
   if(XCODE_VERSION)
     set_target_properties(rime PROPERTIES INSTALL_NAME_DIR "@rpath")
   endif()
@@ -95,7 +95,9 @@ if(BUILD_SHARED_LIBS)
       ${rime_library})
     set_target_properties(rime-dict PROPERTIES
       VERSION ${rime_version}
-      SOVERSION ${rime_soversion})
+      SOVERSION ${rime_soversion}
+      LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib
+      RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
     if(XCODE_VERSION)
       set_target_properties(rime-dict PROPERTIES INSTALL_NAME_DIR "@rpath")
     endif()
@@ -108,7 +110,9 @@ if(BUILD_SHARED_LIBS)
       ${rime_dict_library})
     set_target_properties(rime-gears PROPERTIES
       VERSION ${rime_version}
-      SOVERSION ${rime_soversion})
+      SOVERSION ${rime_soversion}
+      LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib
+      RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
     if(XCODE_VERSION)
       set_target_properties(rime-gears PROPERTIES INSTALL_NAME_DIR "@rpath")
     endif()
@@ -121,7 +125,9 @@ if(BUILD_SHARED_LIBS)
       ${rime_dict_library})
     set_target_properties(rime-levers PROPERTIES
       VERSION ${rime_version}
-      SOVERSION ${rime_soversion})
+      SOVERSION ${rime_soversion}
+      LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib
+      RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
     if(XCODE_VERSION)
       set_target_properties(rime-levers PROPERTIES INSTALL_NAME_DIR "@rpath")
     endif()
@@ -138,7 +144,9 @@ if(BUILD_SHARED_LIBS)
         ${rime_gears_library})
       set_target_properties(rime-plugins PROPERTIES
         VERSION ${rime_version}
-        SOVERSION ${rime_soversion})
+        SOVERSION ${rime_soversion}
+        LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib
+        RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
       if(XCODE_VERSION)
         set_target_properties(rime-plugins PROPERTIES INSTALL_NAME_DIR "@rpath")
       endif()
@@ -148,6 +156,8 @@ if(BUILD_SHARED_LIBS)
 else()
   add_library(rime-static STATIC ${rime_src})
   target_link_libraries(rime-static ${rime_deps})
-  set_target_properties(rime-static PROPERTIES OUTPUT_NAME "rime" PREFIX "lib")
+  set_target_properties(rime-static PROPERTIES
+    OUTPUT_NAME "rime" PREFIX "lib"
+    ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
   install(TARGETS rime-static DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
 endif()


### PR DESCRIPTION
in cmake config set RIME_PLUGINS_DIR as relative to libdir

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
