### PR TITLE
set log filename extension and avoid deleting incorrect files

### DIFF
--- a/src/rime/deployer.h
+++ b/src/rime/deployer.h
@@ -39,9 +39,9 @@ class Deployer : public Messenger {
   path sync_dir;
   string user_id;
   string distribution_name;
-  string app_name;
   string distribution_code_name;
   string distribution_version;
+  string app_name;
   // }
 
   RIME_API Deployer();

--- a/src/rime/deployer.h
+++ b/src/rime/deployer.h
@@ -39,6 +39,7 @@ class Deployer : public Messenger {
   path sync_dir;
   string user_id;
   string distribution_name;
+  string app_name;
   string distribution_code_name;
   string distribution_version;
   // }

--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -633,6 +633,7 @@ bool CleanOldLogFiles::Run(Deployer* deployer) {
   DLOG(INFO) << "scanning " << dirs.size() << " temp directory for log files.";
 
   int removed = 0;
+  const string& app_name = deployer->app_name;
   for (const auto& dir : dirs) {
     // avoid iteration on non-existing directory, which may cause error
     if (!fs::exists(fs::path(dir)))
@@ -644,7 +645,8 @@ bool CleanOldLogFiles::Run(Deployer* deployer) {
       for (const auto& entry : fs::directory_iterator(dir)) {
         const string& file_name(entry.path().filename().string());
         if (entry.is_regular_file() && !entry.is_symlink() &&
-            boost::starts_with(file_name, "rime.") &&
+            boost::starts_with(file_name, app_name) &&
+            boost::ends_with(file_name, ".log") &&
             !boost::contains(file_name, today)) {
           files.push_back(entry.path());
         }

--- a/src/rime/setup.cc
+++ b/src/rime/setup.cc
@@ -53,12 +53,12 @@ RIME_API void SetupDeployer(RimeTraits* traits) {
     deployer.user_data_dir = path(traits->user_data_dir);
   if (PROVIDED(traits, distribution_name))
     deployer.distribution_name = traits->distribution_name;
-  if (PROVIDED(traits, app_name))
-    deployer.app_name = traits->app_name;
   if (PROVIDED(traits, distribution_code_name))
     deployer.distribution_code_name = traits->distribution_code_name;
   if (PROVIDED(traits, distribution_version))
     deployer.distribution_version = traits->distribution_version;
+  if (PROVIDED(traits, app_name))
+    deployer.app_name = traits->app_name;
   if (PROVIDED(traits, prebuilt_data_dir))
     deployer.prebuilt_data_dir = path(traits->prebuilt_data_dir);
   else

--- a/src/rime/setup.cc
+++ b/src/rime/setup.cc
@@ -53,6 +53,8 @@ RIME_API void SetupDeployer(RimeTraits* traits) {
     deployer.user_data_dir = path(traits->user_data_dir);
   if (PROVIDED(traits, distribution_name))
     deployer.distribution_name = traits->distribution_name;
+  if (PROVIDED(traits, app_name))
+    deployer.app_name = traits->app_name;
   if (PROVIDED(traits, distribution_code_name))
     deployer.distribution_code_name = traits->distribution_code_name;
   if (PROVIDED(traits, distribution_version))

--- a/src/rime/setup.cc
+++ b/src/rime/setup.cc
@@ -82,6 +82,7 @@ RIME_API void SetupLogging(const char* app_name,
       FLAGS_log_dir = log_dir;
     }
   }
+  google::SetLogFilenameExtension(".log");
   // Do not allow other users to read/write log files created by current
   // process.
   FLAGS_logfile_mode = 0600;


### PR DESCRIPTION
- close rime/home#1484
- avoid deleting incorrect files, some cases like rime.lua with rime_api_console 