### PR TITLE
Format with clang-foramt 18.1

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - name: Checkout last commit
         uses: actions/checkout@v4
-      - name: Install clang-format
-        run: brew install clang-format
-      - name: Lint
+      - name: Install latest lang-format
+        run: brew update && brew install clang-format
+      - name: Code style lint
         run: make clang-format-lint
 
   linux:

--- a/src/rime/algo/encoder.cc
+++ b/src/rime/algo/encoder.cc
@@ -255,13 +255,13 @@ bool TableEncoder::DfsEncode(const string& phrase,
     }
     string encoded;
     if (Encode(*code, &encoded)) {
-      DLOG(INFO) << "encode '" << phrase << "': "
-                 << "[" << code->ToString() << "] -> [" << encoded << "]";
+      DLOG(INFO) << "encode '" << phrase << "': " << "[" << code->ToString()
+                 << "] -> [" << encoded << "]";
       collector_->CreateEntry(phrase, encoded, value);
       return true;
     } else {
-      DLOG(WARNING) << "failed to encode '" << phrase << "': "
-                    << "[" << code->ToString() << "]";
+      DLOG(WARNING) << "failed to encode '" << phrase << "': " << "["
+                    << code->ToString() << "]";
       return false;
     }
   }

--- a/src/rime/dict/dict_compiler.cc
+++ b/src/rime/dict/dict_compiler.cc
@@ -123,8 +123,8 @@ bool DictCompiler::Compile(const path& schema_file) {
   } else {
     rebuild_prism = true;
   }
-  LOG(INFO) << dict_file << "[" << dict_files.size() << " file(s)]"
-            << " (" << dict_file_checksum << ")";
+  LOG(INFO) << dict_file << "[" << dict_files.size() << " file(s)]" << " ("
+            << dict_file_checksum << ")";
   LOG(INFO) << schema_file << " (" << schema_file_checksum << ")";
   {
     the<ResourceResolver> resolver(

--- a/src/rime/dict/entry_collector.cc
+++ b/src/rime/dict/entry_collector.cc
@@ -114,8 +114,8 @@ void EntryCollector::Collect(const path& dict_file) {
       encode_queue.push({word, weight_str});
     }
     if (!stem_str.empty() && !code_str.empty()) {
-      DLOG(INFO) << "add stem '" << word << "': "
-                 << "[" << code_str << "] = [" << stem_str << "]";
+      DLOG(INFO) << "add stem '" << word << "': " << "[" << code_str << "] = ["
+                 << stem_str << "]";
       stems[word].insert(stem_str);
     }
   }


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

Format code with clang-format 18.1.

**It's hard for Homebrew to pin or install the older version formula.**

Maybe we can use other solution to install specific clang-format version?
 
#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
