### PR TITLE
fix(chord_composer): ignore repeated keys

### DIFF
--- a/src/rime/gear/chord_composer.cc
+++ b/src/rime/gear/chord_composer.cc
@@ -108,17 +108,28 @@ ProcessResult ChordComposer::ProcessChordingKey(const KeyEvent& key_event) {
   if (is_key_up) {
     if (finish_chord_on_first_key_release_) {
       if (pressed_.find(ch) != pressed_.end()) {
+        pressed_.erase(ch);
+        prev_pressed_ = pressed_;
         FinishChord();
         pressed_.clear();
+      } else if (prev_pressed_.find(ch) != prev_pressed_.end()) {
+        prev_pressed_.erase(ch);
       }
     } else if (pressed_.erase(ch) != 0 && pressed_.empty()) {
       FinishChord();
     }
   } else {  // key down
-    pressed_.insert(ch);
-    bool updated = chord_.insert(ch).second;
-    if (updated)
-      UpdateChord();
+    if (finish_chord_on_first_key_release_) {
+      // ignore the repeated keys inside prev_pressed_
+      if (prev_pressed_.find(ch) == prev_pressed_.end())
+        goto insert_;
+    } else {
+    insert_:
+      pressed_.insert(ch);
+      bool updated = chord_.insert(ch).second;
+      if (updated)
+        UpdateChord();
+    }
   }
   editing_chord_ = false;
   return kAccepted;

--- a/src/rime/gear/chord_composer.cc
+++ b/src/rime/gear/chord_composer.cc
@@ -84,6 +84,16 @@ inline static int get_base_layer_key_code(const KeyEvent& key_event) {
                                                 : ch;
 }
 
+inline static bool finish_chord_on_all_keys_released(
+    const ChordingState& state) {
+  return state.pressed_keys.empty();
+}
+
+bool ChordComposer::FinishChordConditionIsMet() const {
+  return finish_chord_on_first_key_release_ ||
+         finish_chord_on_all_keys_released(state_);
+}
+
 ProcessResult ChordComposer::ProcessChordingKey(const KeyEvent& key_event) {
   if (key_event.ctrl() || key_event.alt() || key_event.super() ||
       key_event.caps()) {
@@ -106,29 +116,13 @@ ProcessResult ChordComposer::ProcessChordingKey(const KeyEvent& key_event) {
   editing_chord_ = true;
   bool is_key_up = key_event.release();
   if (is_key_up) {
-    if (finish_chord_on_first_key_release_) {
-      if (pressed_.find(ch) != pressed_.end()) {
-        pressed_.erase(ch);
-        prev_pressed_ = pressed_;
-        FinishChord();
-        pressed_.clear();
-      } else if (prev_pressed_.find(ch) != prev_pressed_.end()) {
-        prev_pressed_.erase(ch);
-      }
-    } else if (pressed_.erase(ch) != 0 && pressed_.empty()) {
-      FinishChord();
+    if (state_.ReleaseKey(ch) && FinishChordConditionIsMet() &&
+        !state_.recognized_chord.empty()) {
+      FinishChord(state_.recognized_chord);
     }
-  } else {  // key down
-    if (finish_chord_on_first_key_release_) {
-      // ignore the repeated keys inside prev_pressed_
-      if (prev_pressed_.find(ch) == prev_pressed_.end())
-        goto insert_;
-    } else {
-    insert_:
-      pressed_.insert(ch);
-      bool updated = chord_.insert(ch).second;
-      if (updated)
-        UpdateChord();
+  } else {  // key down, ignore repeated key down events
+    if (state_.PressKey(ch) && state_.AddKeyToChord(ch)) {
+      UpdateChord(state_.recognized_chord);
     }
   }
   editing_chord_ = false;
@@ -158,10 +152,10 @@ ProcessResult ChordComposer::ProcessKeyEvent(const KeyEvent& key_event) {
   return ProcessFunctionKey(key_event);
 }
 
-string ChordComposer::SerializeChord() {
+string ChordComposer::SerializeChord(const Chord& chord) {
   KeySequence key_sequence;
   for (KeyEvent key : chording_keys_) {
-    if (chord_.find(key.keycode()) != chord_.end())
+    if (chord.find(key.keycode()) != chord.end())
       key_sequence.push_back(key);
   }
   string code = key_sequence.repr();
@@ -169,12 +163,12 @@ string ChordComposer::SerializeChord() {
   return code;
 }
 
-void ChordComposer::UpdateChord() {
+void ChordComposer::UpdateChord(const Chord& chord) {
   if (!engine_)
     return;
   Context* ctx = engine_->context();
   Composition& comp = ctx->composition();
-  string code = SerializeChord();
+  string code = SerializeChord(chord);
   prompt_format_.Apply(&code);
   if (comp.empty()) {
     // add a placeholder segment
@@ -189,10 +183,10 @@ void ChordComposer::UpdateChord() {
   last_segment.prompt = code;
 }
 
-void ChordComposer::FinishChord() {
+void ChordComposer::FinishChord(const Chord& chord) {
   if (!engine_)
     return;
-  string code = SerializeChord();
+  string code = SerializeChord(chord);
   output_format_.Apply(&code);
   ClearChord();
 
@@ -212,8 +206,7 @@ void ChordComposer::FinishChord() {
 }
 
 void ChordComposer::ClearChord() {
-  pressed_.clear();
-  chord_.clear();
+  state_.ClearChord();
   if (!engine_)
     return;
   Context* ctx = engine_->context();

--- a/src/rime/gear/chord_composer.h
+++ b/src/rime/gear/chord_composer.h
@@ -15,6 +15,25 @@
 
 namespace rime {
 
+using Chord = set<int>;
+
+struct ChordingState {
+  Chord pressed_keys;
+  Chord recognized_chord;
+
+  bool IsPressed(int ch) const {
+    return pressed_keys.find(ch) != pressed_keys.end();
+  }
+
+  bool PressKey(int ch) { return pressed_keys.insert(ch).second; }
+
+  bool ReleaseKey(int ch) { return pressed_keys.erase(ch) != 0; }
+
+  bool AddKeyToChord(int ch) { return recognized_chord.insert(ch).second; }
+
+  void ClearChord() { recognized_chord.clear(); }
+};
+
 class ChordComposer : public Processor {
  public:
   ChordComposer(const Ticket& ticket);
@@ -23,11 +42,12 @@ class ChordComposer : public Processor {
   virtual ProcessResult ProcessKeyEvent(const KeyEvent& key_event);
 
  protected:
+  bool FinishChordConditionIsMet() const;
   ProcessResult ProcessChordingKey(const KeyEvent& key_event);
   ProcessResult ProcessFunctionKey(const KeyEvent& key_event);
-  string SerializeChord();
-  void UpdateChord();
-  void FinishChord();
+  string SerializeChord(const Chord& chord);
+  void UpdateChord(const Chord& chord);
+  void FinishChord(const Chord& chord);
   void ClearChord();
   bool DeleteLastSyllable();
   void OnContextUpdate(Context* ctx);
@@ -45,9 +65,7 @@ class ChordComposer : public Processor {
   bool use_caps_ = false;
   bool finish_chord_on_first_key_release_ = false;
 
-  set<int> pressed_;
-  set<int> prev_pressed_;
-  set<int> chord_;
+  ChordingState state_;
   bool editing_chord_ = false;
   bool sending_chord_ = false;
   bool composing_ = false;

--- a/src/rime/gear/chord_composer.h
+++ b/src/rime/gear/chord_composer.h
@@ -46,6 +46,7 @@ class ChordComposer : public Processor {
   bool finish_chord_on_first_key_release_ = false;
 
   set<int> pressed_;
+  set<int> prev_pressed_;
   set<int> chord_;
   bool editing_chord_ = false;
   bool sending_chord_ = false;


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

with #828 `chord_composer/finish_chord_on_first_key_release: true`, the left keys of previous chord, may be inserted
to the new chord.

test procedure (`combo_pinyin`):

1.  press `w` `l` , get `ce` not finishchord
2. release `l`, get `ce` finishchord, `w` saved to the prev_pressed_
3. hold the `w` key, system may resend keydown event of `w`, as it still in the prev_pressed_, it will not be insert to new chord pressed_
4. press `s` `d` `j`, get `shi` not finishchord
5. the held `w` will repeat keydown event, will still be ignored.
6. release `d`, finish current chord, save `sj` to prev_pressed_(with `w` deleted), repeat the new loop on and on.
 
#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
