### PR TITLE
fix(switcher): superfluously load saved options

### DIFF
--- a/src/rime/config/config_component.cc
+++ b/src/rime/config/config_component.cc
@@ -23,6 +23,10 @@ Config::~Config() {}
 
 Config::Config(an<ConfigData> data) : ConfigItemRef(data.get()), data_(data) {}
 
+bool Config::Save() {
+  return data_->Save();
+}
+
 bool Config::LoadFromStream(std::istream& stream) {
   return data_->LoadFromStream(stream);
 }

--- a/src/rime/config/config_component.h
+++ b/src/rime/config/config_component.h
@@ -28,6 +28,8 @@ class Config : public Class<Config, const string&>, public ConfigItemRef {
   // in the ConfigComponent
   explicit Config(an<ConfigData> data);
 
+  // returns whether actually saved to file.
+  bool Save();
   bool LoadFromStream(std::istream& stream);
   bool SaveToStream(std::ostream& stream);
   RIME_API bool LoadFromFile(const path& file_path);

--- a/src/rime/config/config_data.cc
+++ b/src/rime/config/config_data.cc
@@ -22,8 +22,12 @@ an<ConfigItem> ConvertFromYaml(const YAML::Node& yaml_node,
 void EmitYaml(an<ConfigItem> node, YAML::Emitter* emitter, int depth);
 
 ConfigData::~ConfigData() {
-  if (auto_save_ && modified_ && !file_path_.empty())
-    SaveToFile(file_path_);
+  if (auto_save_)
+    Save();
+}
+
+bool ConfigData::Save() {
+  return modified_ && !file_path_.empty() && SaveToFile(file_path_);
 }
 
 bool ConfigData::LoadFromStream(std::istream& stream) {

--- a/src/rime/config/config_data.h
+++ b/src/rime/config/config_data.h
@@ -19,6 +19,8 @@ class ConfigData {
   ConfigData() = default;
   ~ConfigData();
 
+  // returns whether actually saved to file.
+  bool Save();
   bool LoadFromStream(std::istream& stream);
   bool SaveToStream(std::ostream& stream);
   bool LoadFromFile(const path& file_path, ConfigCompiler* compiler);

--- a/src/rime/context.cc
+++ b/src/rime/context.cc
@@ -288,6 +288,7 @@ void Context::set_input(const string& value) {
 
 void Context::set_option(const string& name, bool value) {
   options_[name] = value;
+  DLOG(INFO) << "Context::set_option " << name << " = " << value;
   option_update_notifier_(this, name);
 }
 
@@ -313,8 +314,10 @@ string Context::get_property(const string& name) const {
 }
 
 void Context::ClearTransientOptions() {
+  DLOG(INFO) << "Context::ClearTransientOptions";
   auto opt = options_.lower_bound("_");
   while (opt != options_.end() && !opt->first.empty() && opt->first[0] == '_') {
+    DLOG(INFO) << "cleared opption: " << opt->first;
     options_.erase(opt++);
   }
   auto prop = properties_.lower_bound("_");

--- a/src/rime/switcher.cc
+++ b/src/rime/switcher.cc
@@ -29,7 +29,6 @@ Switcher::Switcher(const Ticket& ticket) : Processor(ticket) {
   user_config_.reset(Config::Require("user_config")->Create("user"));
   InitializeComponents();
   LoadSettings();
-  RestoreSavedOptions();
 }
 
 Switcher::~Switcher() {
@@ -161,6 +160,15 @@ int Switcher::ForEachSchemaListEntry(
       break;
   }
   return num_processed_entries;
+}
+
+void Switcher::SetActiveSchema(const string& schema_id) {
+  if (user_config_) {
+    user_config_->SetString("var/previously_selected_schema", schema_id);
+    user_config_->SetInt("var/schema_access_time/" + schema_id, time(NULL));
+    // persist recently used schema and options that have changed
+    user_config_->Save();
+  }
 }
 
 Schema* Switcher::CreateSchema() {

--- a/src/rime/switcher.h
+++ b/src/rime/switcher.h
@@ -31,9 +31,11 @@ class Switcher : public Processor, public Engine {
       Config* config,
       function<bool(const string& schema_id)> process_entry);
 
+  void SetActiveSchema(const string& schema_id);
   Schema* CreateSchema();
   void SelectNextSchema();
   bool IsAutoSave(const string& option) const;
+  void RestoreSavedOptions();
 
   void RefreshMenu();
   void Activate();
@@ -46,7 +48,7 @@ class Switcher : public Processor, public Engine {
  protected:
   void InitializeComponents();
   void LoadSettings();
-  void RestoreSavedOptions();
+
   void HighlightNextSchema();
   void OnSelect(Context* ctx);
 


### PR DESCRIPTION
## Pull request

#### Issue tracker
the issue is mentioned here https://github.com/rime/librime/issues/818#issuecomment-1986713080

#### Feature
let `Switcher` object live across schema switching.
restore saved options only after input session is created.
save options on schema switching as before, but called explicitly.

#### Unit test
- [ ] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
