### PR TITLE
Consistent `caret_pos`

### DIFF
--- a/src/rime/composition.cc
+++ b/src/rime/composition.cc
@@ -88,7 +88,7 @@ Preedit Composition::GetPreedit(const string& full_input,
     if (preedit.caret_pos < preedit.sel_end) {
       preedit.sel_start += prompt.length();
       preedit.sel_end += prompt.length();
-      preedit.caret_pos = preedit.sel_start;
+      preedit.caret_pos = preedit.sel_start - caret.length();
     }
   }
   return preedit;


### PR DESCRIPTION
Make the variable `caret_pos` consistent when soft cursor is present (i.e. always equals to the location right BEFORE the soft cursor). Currently, when the caret is at the start/end of set_range, caret_pos equals to the location right after/before the soft cursor, respectively.

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
