### PR TITLE
fix(script_translator): correction can cause segfault

### DIFF
--- a/src/rime/algo/syllabifier.h
+++ b/src/rime/algo/syllabifier.h
@@ -20,7 +20,7 @@ class Corrector;
 using SyllableId = int32_t;
 
 struct EdgeProperties : SpellingProperties {
-  EdgeProperties(SpellingProperties sup) : SpellingProperties(sup){};
+  EdgeProperties(SpellingProperties sup) : SpellingProperties(sup) {};
   EdgeProperties() = default;
   bool is_correction = false;
 };

--- a/src/rime/algo/syllabifier.h
+++ b/src/rime/algo/syllabifier.h
@@ -20,7 +20,7 @@ class Corrector;
 using SyllableId = int32_t;
 
 struct EdgeProperties : SpellingProperties {
-  EdgeProperties(SpellingProperties sup) : SpellingProperties(sup) {};
+  EdgeProperties(SpellingProperties sup) : SpellingProperties(sup){};
   EdgeProperties() = default;
   bool is_correction = false;
 };

--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -431,7 +431,7 @@ bool ScriptTranslation::Next() {
   } while (enable_correction_ &&
            syllabifier_->IsCandidateCorrection(*candidate_) &&
            // limit the number of correction candidates
-           ++correction_count_ > max_corrections_);
+           ++correction_count_ < max_corrections_);
   ++candidate_index_;
   return !CheckEmpty();
 }
@@ -528,6 +528,8 @@ bool ScriptTranslation::PrepareCandidate() {
     candidate_->set_quality(std::exp(entry->weight) +
                             translator_->initial_quality() +
                             (IsNormalSpelling() ? 0 : -1));
+  } else {
+    return false;
   }
   return true;
 }

--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -431,7 +431,7 @@ bool ScriptTranslation::Next() {
   } while (enable_correction_ &&
            syllabifier_->IsCandidateCorrection(*candidate_) &&
            // limit the number of correction candidates
-           ++correction_count_ < max_corrections_);
+           ++correction_count_ > max_corrections_);
   ++candidate_index_;
   return !CheckEmpty();
 }


### PR DESCRIPTION
Previously, the correction count limit doesn't really work, and it will take all candidates. When finding the candidates for the last page, ScriptTranslation::PrepareCandidate can return nullptr, leading to segfault.

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
