### PR TITLE
Create stdbool flag

### DIFF
--- a/src/rime_api.h
+++ b/src/rime_api.h
@@ -32,7 +32,12 @@ extern "C" {
 
 typedef uintptr_t RimeSessionId;
 
+#ifdef STDBOOL
+#include <stdbool.h>
+typedef bool Bool;
+#else
 typedef int Bool;
+#endif
 
 #ifndef False
 #define False 0


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Use a flag `STDBOOL` to gate type definition for `Bool`. The current def to `int` causes compiler confusion in interoperation with Swift.
Ideally, Bool should use standard C bool instead of int. The use of a flag gate is for compatibility consideration.
Feel free to change the design if this is not the best practice

#### Unit test
- [ ] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
squirrel can be successfully setup to export this flag
https://github.com/LEOYoon-Tsaw/squirrel/commit/39a51fceca01d09030d5e8445421542e3576bc6e