### PR TITLE
fix log files named as UNKNOWN

### DIFF
--- a/src/rime/setup.cc
+++ b/src/rime/setup.cc
@@ -85,9 +85,9 @@ RIME_API void SetupLogging(const char* app_name,
     }
   }
   google::SetLogFilenameExtension(".log");
-  google::SetLogSymlink(GLOG_INFO, app_name);
-  google::SetLogSymlink(GLOG_WARNING, app_name);
-  google::SetLogSymlink(GLOG_ERROR, app_name);
+  google::SetLogSymlink(google::GLOG_INFO, app_name);
+  google::SetLogSymlink(google::GLOG_WARNING, app_name);
+  google::SetLogSymlink(google::GLOG_ERROR, app_name);
   // Do not allow other users to read/write log files created by current
   // process.
   FLAGS_logfile_mode = 0600;

--- a/src/rime/setup.cc
+++ b/src/rime/setup.cc
@@ -85,6 +85,9 @@ RIME_API void SetupLogging(const char* app_name,
     }
   }
   google::SetLogFilenameExtension(".log");
+  google::SetLogSymlink(0, app_name);
+  google::SetLogSymlink(1, app_name);
+  google::SetLogSymlink(2, app_name);
   // Do not allow other users to read/write log files created by current
   // process.
   FLAGS_logfile_mode = 0600;

--- a/src/rime/setup.cc
+++ b/src/rime/setup.cc
@@ -85,9 +85,9 @@ RIME_API void SetupLogging(const char* app_name,
     }
   }
   google::SetLogFilenameExtension(".log");
-  google::SetLogSymlink(0, app_name);
-  google::SetLogSymlink(1, app_name);
-  google::SetLogSymlink(2, app_name);
+  google::SetLogSymlink(GLOG_INFO, app_name);
+  google::SetLogSymlink(GLOG_WARNING, app_name);
+  google::SetLogSymlink(GLOG_ERROR, app_name);
   // Do not allow other users to read/write log files created by current
   // process.
   FLAGS_logfile_mode = 0600;


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

#### Feature
Fix an issue where the symlink of log files are names as `UNKNOWN.INFO`, `UNKNOWN.WARNING`, or `UNKNOWN.ERROR`

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
