### PR TITLE
move some headers

### DIFF
--- a/src/rime_api.cc
+++ b/src/rime_api.cc
@@ -9,7 +9,6 @@
 #include <rime/common.h>
 #include <rime/module.h>
 #include <rime/setup.h>
-#include "rime_api.h"
 
 #include "rime_api_impl.h"
 

--- a/src/rime_api_impl.h
+++ b/src/rime_api_impl.h
@@ -16,6 +16,8 @@
 #include <rime/signature.h>
 #include <rime/switches.h>
 
+#include "rime_api.h"
+
 using namespace rime;
 
 void rime_declare_module_dependencies();

--- a/src/rime_api_stdbool.cc
+++ b/src/rime_api_stdbool.cc
@@ -1,4 +1,3 @@
 #include "rime_api_stdbool.h"
-#include "rime_api.h"
 // implements stdbool flavored API
 #include "rime_api_impl.h"


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature

`rime_api_impl.h` uses definitions like `RIME_DEPRECATED` defined in `rime_api.h`. However, it doesn't include `rime_api.h`, so when opening this file editor complains.
After including `rime_api.h` in `rime_api_impl.h`, wherever `rime_api_impl.h` is included, there is no need to include `rime_api.h`, so they are removed.

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
