### PR TITLE
fix(speller): make simple candidates auto-selectable

### DIFF
--- a/src/rime/gear/speller.cc
+++ b/src/rime/gear/speller.cc
@@ -38,12 +38,17 @@ static inline bool is_table_entry(const an<Candidate>& cand) {
   return type == "table" || type == "user_table";
 }
 
+static inline bool is_simple_candidate(const an<Candidate>& cand) {
+  return bool(As<SimpleCandidate>(cand));
+}
+
 static bool is_auto_selectable(const an<Candidate>& cand,
                                const string& input,
                                const string& delimiters) {
   return
       // reaches end of input
-      cand->end() == input.length() && is_table_entry(cand) &&
+      cand->end() == input.length() &&
+      (is_table_entry(cand) || is_simple_candidate(cand)) &&
       // no delimiters
       input.find_first_of(delimiters, cand->start()) == string::npos;
 }


### PR DESCRIPTION
## Pull request

Previously, the speller only auto-selects Phrases (type "table" and "user_table"), and does not select SimpleCandidate, but history_translator only produces SimpleCandidate, and thus history candidates cannot be auto-selected. This PR corrects this oversight.

(`history_translator` will preserve the old candidate type, e.g. "uniquified", but we cannot access the genuine candidate via SimpleCandidate here, unfortuantely.)

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
