### PR TITLE
fix(api): delete_candidate and delete_candidate_on_current_page

### DIFF
--- a/src/rime/common.h
+++ b/src/rime/common.h
@@ -14,9 +14,9 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
-#include <utility>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>

--- a/src/rime/context.cc
+++ b/src/rime/context.cc
@@ -143,27 +143,27 @@ bool Context::Highlight(size_t index) {
   return true;
 }
 
-bool Context::DeleteCandidate(
-    function<an<Candidate>(Segment& seg)> get_candidate) {
+bool Context::DeleteCandidate(std::optional<size_t> index) {
   if (composition_.empty())
     return false;
   Segment& seg(composition_.back());
-  if (auto cand = get_candidate(seg)) {
-    DLOG(INFO) << "Deleting candidate: '" << cand->text();
-    delete_notifier_(this);
-    return true;  // CAVEAT: this doesn't mean anything is deleted for sure
+  auto cand = index ? seg.GetCandidateAt(*index) : seg.GetSelectedCandidate();
+  if (!cand)
+    return false;
+  DLOG(INFO) << "Deleting candidate: " << cand->text();
+  if (index) {
+    seg.selected_index = *index;
   }
-  return false;
+  delete_notifier_(this);
+  return true;  // CAVEAT: this doesn't mean anything is deleted for sure
 }
 
 bool Context::DeleteCandidate(size_t index) {
-  return DeleteCandidate(
-      [index](Segment& seg) { return seg.GetCandidateAt(index); });
+  return DeleteCandidate(std::optional{index});
 }
 
 bool Context::DeleteCurrentSelection() {
-  return DeleteCandidate(
-      [](Segment& seg) { return seg.GetSelectedCandidate(); });
+  return DeleteCandidate({});
 }
 
 bool Context::ConfirmCurrentSelection() {

--- a/src/rime/context.h
+++ b/src/rime/context.h
@@ -92,7 +92,7 @@ class RIME_API Context {
 
  private:
   string GetSoftCursor() const;
-  bool DeleteCandidate(function<an<Candidate>(Segment& seg)> get_candidate);
+  bool DeleteCandidate(std::optional<size_t> index);
 
   string input_;
   size_t caret_pos_ = 0;

--- a/tools/rime_api_console.cc
+++ b/tools/rime_api_console.cc
@@ -165,6 +165,26 @@ bool execute_special_command(const char* line, RimeSessionId session_id) {
   if (!strcmp(line, "synchronize")) {
     return rime->sync_user_data();
   }
+  const char* kDeleteCandidateOnCurrentPage = "delete on current page ";
+  command_length = strlen(kDeleteCandidateOnCurrentPage);
+  if (!strncmp(line, kDeleteCandidateOnCurrentPage, command_length)) {
+    const char* index_str = line + command_length;
+    int index = atoi(index_str);
+    if (!rime->delete_candidate_on_current_page(session_id, index)) {
+      fprintf(stderr, "failed to delete\n");
+    }
+    return true;
+  }
+  const char* kDeleteCandidate = "delete ";
+  command_length = strlen(kDeleteCandidate);
+  if (!strncmp(line, kDeleteCandidate, command_length)) {
+    const char* index_str = line + command_length;
+    int index = atoi(index_str);
+    if (!rime->delete_candidate(session_id, index)) {
+      fprintf(stderr, "failed to delete\n");
+    }
+    return true;
+  }
   return false;
 }
 


### PR DESCRIPTION
Previously, the two APIs will always delete the currently selected candidate, regardless of what its argument is.

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #899 

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
