### PR TITLE
fix deleting current candidate

### DIFF
--- a/src/rime/common.h
+++ b/src/rime/common.h
@@ -14,7 +14,6 @@
 #include <list>
 #include <map>
 #include <memory>
-#include <optional>
 #include <set>
 #include <string>
 #include <unordered_map>

--- a/src/rime/context.cc
+++ b/src/rime/context.cc
@@ -163,7 +163,7 @@ bool Context::DeleteCandidate(size_t index) {
 }
 
 bool Context::DeleteCurrentSelection() {
-  return DeleteCandidate({});
+  return DeleteCandidate(std::nullopt);
 }
 
 bool Context::ConfirmCurrentSelection() {

--- a/src/rime/context.cc
+++ b/src/rime/context.cc
@@ -143,27 +143,26 @@ bool Context::Highlight(size_t index) {
   return true;
 }
 
-bool Context::DeleteCandidate(std::optional<size_t> index) {
-  if (composition_.empty())
-    return false;
-  Segment& seg(composition_.back());
-  auto cand = index ? seg.GetCandidateAt(*index) : seg.GetSelectedCandidate();
+bool Context::DeleteCandidate(an<Candidate> cand) {
   if (!cand)
     return false;
   DLOG(INFO) << "Deleting candidate: " << cand->text();
-  if (index) {
-    seg.selected_index = *index;
-  }
   delete_notifier_(this);
   return true;  // CAVEAT: this doesn't mean anything is deleted for sure
 }
 
 bool Context::DeleteCandidate(size_t index) {
-  return DeleteCandidate(std::optional{index});
+  if (composition_.empty())
+    return false;
+  Segment& seg(composition_.back());
+  return DeleteCandidate(seg.GetCandidateAt(index));
 }
 
 bool Context::DeleteCurrentSelection() {
-  return DeleteCandidate(std::nullopt);
+  if (composition_.empty())
+    return false;
+  Segment& seg(composition_.back());
+  return DeleteCandidate(seg.GetSelectedCandidate());
 }
 
 bool Context::ConfirmCurrentSelection() {

--- a/src/rime/context.h
+++ b/src/rime/context.h
@@ -94,7 +94,7 @@ class RIME_API Context {
 
  private:
   string GetSoftCursor() const;
-  bool DeleteCandidate(std::optional<size_t> index);
+  bool DeleteCandidate(an<Candidate> cand);
 
   string input_;
   size_t caret_pos_ = 0;


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature

As in practice when both
```cpp
DeleteCandidate(size_t index)
```
and
```cpp
DeleteCandidate(std::optional<size_t> index)
```
exists, `DeleteCandidate({})` is translated to `DeleteCandidate(0)` at least for clang on macOS. 🌚

#### Unit test
- [ ] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
