### PR TITLE
Fix prefix for FreeBSD, OpenBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,7 +204,7 @@ configure_file(
 add_custom_target(remove
   COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD|DragonFly|GNU|Darwin" OR MINGW)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD|OpenBSD|DragonFly|GNU|Darwin" OR MINGW)
   set(prefix "${CMAKE_INSTALL_PREFIX}")
   set(exec_prefix "${CMAKE_INSTALL_PREFIX}")
   set(bindir "${CMAKE_INSTALL_FULL_BINDIR}")

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ RIME_ROOT ?= $(CURDIR)
 
 RIME_SOURCE_PATH = plugins sample src test tools
 
-ifeq ($(shell uname),Darwin) # for macOS
+OS_NAME = $(shell uname)
+ifeq ($(OS_NAME),Darwin) # for macOS
 prefix ?= $(RIME_ROOT)/dist
 
 ifdef BOOST_ROOT
@@ -22,6 +23,10 @@ export CMAKE_OSX_ARCHITECTURES = arm64;x86_64
 endif
 else ifeq ($(shell test -n "$$PREFIX" && echo "$$PREFIX" | grep -q "/data/data/com.termux" && echo "termux"),termux)
 prefix ?= $(PREFIX)
+else ifeq ($(OS_NAME),FreeBSD)
+prefix ?= $(DESTDIR)/usr/local
+else ifeq ($(OS_NAME),OpenBSD)
+prefix ?= $(DESTDIR)/usr/local
 else # for Linux
 prefix ?= $(DESTDIR)/usr
 endif


### PR DESCRIPTION
FreeBSD and OpenBSD typically use /usr/local as the prefix. This patch modifies the prefix.