### PR TITLE
fix(deployment_tasks): do not clean up log when not specify log dir

### DIFF
--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -616,7 +616,7 @@ bool CleanupTrash::Run(Deployer* deployer) {
 bool CleanOldLogFiles::Run(Deployer* deployer) {
   bool success = true;
 #ifdef RIME_ENABLE_LOGGING
-  if (FLAGS_logtostderr) {
+  if (FLAGS_logtostderr || FLAGS_log_dir.empty()) {
     return success;
   }
 


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes # N/A

#### Feature
Describe feature of pull request

We now use `google::LogToStderr()` instead of `FLAGS_logtostderr`, thus when not specify log dir on RimeTraits, `FLAGS_log_dir` must be empty, so use it to judge instead. 

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
