### PR TITLE
fix(speller): consider genuine simple cands when auto select

### DIFF
--- a/src/rime/gear/speller.cc
+++ b/src/rime/gear/speller.cc
@@ -39,7 +39,8 @@ static inline bool is_table_entry(const an<Candidate>& cand) {
 }
 
 static inline bool is_simple_candidate(const an<Candidate>& cand) {
-  return bool(As<SimpleCandidate>(cand));
+  auto genuine = Candidate::GetGenuineCandidate(cand);
+  return bool(As<SimpleCandidate>(genuine));
 }
 
 static bool is_auto_selectable(const an<Candidate>& cand,


### PR DESCRIPTION
#894 forgot to consider uniquified candidates but it should.

This fixes some more cases where the output of `history_translator` cannot be auto-selected.