### PR TITLE
Add Hook: "Commit script while keeping the transforms" （選單中的輸入預變換上屏）

### DIFF
--- a/src/rime/composition.cc
+++ b/src/rime/composition.cc
@@ -9,7 +9,6 @@
 #include <rime/candidate.h>
 #include <rime/composition.h>
 #include <rime/menu.h>
-#include <iostream>
 
 namespace rime {
 

--- a/src/rime/composition.cc
+++ b/src/rime/composition.cc
@@ -9,6 +9,7 @@
 #include <rime/candidate.h>
 #include <rime/composition.h>
 #include <rime/menu.h>
+#include <iostream>
 
 namespace rime {
 
@@ -119,7 +120,7 @@ string Composition::GetCommitText() const {
   return result;
 }
 
-string Composition::GetScriptText() const {
+string Composition::GetScriptText(bool keep_selection) const {
   string result;
   size_t start = 0;
   size_t end = 0;
@@ -127,7 +128,9 @@ string Composition::GetScriptText() const {
     auto cand = seg.GetSelectedCandidate();
     start = end;
     end = cand ? cand->end() : seg.end;
-    if (cand && !cand->preedit().empty())
+    if (keep_selection && cand && !cand->text().empty() && seg.status >= Segment::kSelected)
+      result += cand->text();
+    else if (cand && !cand->preedit().empty())
       result += boost::erase_first_copy(cand->preedit(), "\t");
     else
       result += input_.substr(start, end - start);

--- a/src/rime/composition.h
+++ b/src/rime/composition.h
@@ -28,7 +28,8 @@ class Composition : public Segmentation {
                      const string& caret) const;
   string GetPrompt() const;
   string GetCommitText() const;
-  string GetScriptText() const;
+  string GetScriptText(bool keep_selection) const;
+  string GetScriptText() const { return GetScriptText(false); }
   RIME_API string GetDebugText() const;
   // Returns text of the last segment before the given position.
   string GetTextBefore(size_t pos) const;

--- a/src/rime/gear/editor.cc
+++ b/src/rime/gear/editor.cc
@@ -23,6 +23,7 @@ static Editor::ActionDef editor_action_definitions[] = {
     {"commit_raw_input", &Editor::CommitRawInput},
     {"commit_script_text", &Editor::CommitScriptText},
     {"commit_composition", &Editor::CommitComposition},
+    {"commit_script_text_keep_selection", &Editor::CommitScriptTextKeepSelection},
     {"revert", &Editor::RevertLastEdit},
     {"back", &Editor::BackToPreviousInput},
     {"back_syllable", &Editor::BackToPreviousSyllable},
@@ -106,6 +107,12 @@ bool Editor::CommitComment(Context* ctx) {
 
 bool Editor::CommitScriptText(Context* ctx) {
   engine_->sink()(ctx->GetScriptText());
+  ctx->Clear();
+  return true;
+}
+
+bool Editor::CommitScriptTextKeepSelection(Context* ctx) {
+  engine_->sink()(ctx->composition().GetScriptText(true));
   ctx->Clear();
   return true;
 }

--- a/src/rime/gear/editor.h
+++ b/src/rime/gear/editor.h
@@ -29,6 +29,7 @@ class Editor : public Processor, public KeyBindingProcessor<Editor> {
   Handler ToggleSelection;
   Handler CommitComment;
   Handler CommitScriptText;
+  Handler CommitScriptTextKeepSelection;
   Handler CommitRawInput;
   Handler CommitComposition;
   Handler RevertLastEdit;


### PR DESCRIPTION
## Pull request

#### Feature
Add **Commit script while keeping the transforms**: when `commit_script_text_keep_selection` is called, the transformed input goes to the box instead of raw inputs.

Essential for Japanese Romaji-based input.

功能：當 `commit_script_text_keep_selection` 被調用時（例如：
```yaml
  "editor/bindings/Return": commit_script_text_keep_selection
```
時按下 **Return**），可實現預變換輸入上屏。

比較直接的應用是在使用 Rime 輸入日語時可以將 Romaji 預變換的假名上屏。

E.g.
<img width="171" alt="Screenshot 2024-08-08 at 23 04 14" src="https://github.com/user-attachments/assets/835de7ba-edbe-4e9a-b001-84a50ad019f9">
⬇️ Press **Return** ⬇️
<img width="156" alt="Screenshot 2024-08-08 at 23 04 22" src="https://github.com/user-attachments/assets/754013e2-4814-404f-ba76-d2906cda69ee">

Config used here: [My customization](https://github.com/xrq-phys/rime-hifumi) of [gkovacs/rime-japanese](https://github.com/gkovacs/rime-japanese).

#### Unit test
- [ ] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
