### PR TITLE
feat(translator): allow a translator to take multiple tags

### DIFF
--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -194,7 +194,7 @@ an<Translation> ScriptTranslator::Query(const string& input,
                                         const Segment& segment) {
   if (!dict_ || !dict_->loaded())
     return nullptr;
-  if (!segment.HasTag(tag_))
+  if (!segment.HasAnyTagIn(tags_))
     return nullptr;
   DLOG(INFO) << "input = '" << input << "', [" << segment.start << ", "
              << segment.end << ")";

--- a/src/rime/gear/table_translator.cc
+++ b/src/rime/gear/table_translator.cc
@@ -241,7 +241,7 @@ static bool starts_with_completion(an<Translation> translation) {
 
 an<Translation> TableTranslator::Query(const string& input,
                                        const Segment& segment) {
-  if (!segment.HasTag(tag_))
+  if (!segment.HasAnyTagIn(tags_))
     return nullptr;
   DLOG(INFO) << "input = '" << input << "', [" << segment.start << ", "
              << segment.end << ")";

--- a/src/rime/gear/translator_commons.cc
+++ b/src/rime/gear/translator_commons.cc
@@ -118,7 +118,6 @@ TranslatorOptions::TranslatorOptions(const Ticket& ticket) {
   if (Config* config = ticket.schema->config()) {
     config->GetString(ticket.name_space + "/delimiter", &delimiters_) ||
         config->GetString("speller/delimiter", &delimiters_);
-    config->GetString(ticket.name_space + "/tag", &tag_);
     config->GetBool(ticket.name_space + "/contextual_suggestions",
                     &contextual_suggestions_);
     config->GetBool(ticket.name_space + "/enable_completion",
@@ -132,6 +131,20 @@ TranslatorOptions::TranslatorOptions(const Ticket& ticket) {
         config->GetList(ticket.name_space + "/comment_format"));
     user_dict_disabling_patterns_.Load(
         config->GetList(ticket.name_space + "/disable_user_dict_for_patterns"));
+    string tag;
+    if (config->GetString(ticket.name_space + "/tag", &tag)) {
+      // replace the first tag, and understand /tags as extra tags
+      tags_[0] = tag;
+    } else {
+      // replace all of the default tags
+      tags_.clear();
+    }
+    if (auto list = config->GetList(ticket.name_space + "/tags"))
+      for (size_t i = 0; i < list->size(); ++i)
+        if (auto value = As<ConfigValue>(list->GetAt(i)))
+          tags_.push_back(value->str());
+    if (tags_.empty())
+      tags_.push_back("abc");
   }
   if (delimiters_.empty()) {
     delimiters_ = " ";

--- a/src/rime/gear/translator_commons.h
+++ b/src/rime/gear/translator_commons.h
@@ -146,8 +146,15 @@ class TranslatorOptions {
   bool IsUserDictDisabledFor(const string& input) const;
 
   const string& delimiters() const { return delimiters_; }
-  const string& tag() const { return tag_; }
-  void set_tag(const string& tag) { tag_ = tag; }
+  vector<string> tags() const { return tags_; }
+  void set_tags(const vector<string>& tags) {
+    tags_ = tags;
+    if (tags_.size() == 0) {
+      tags_.push_back("abc");
+    }
+  }
+  const string& tag() const { return tags_[0]; }
+  void set_tag(const string& tag) { tags_[0] = tag; }
   bool contextual_suggestions() const { return contextual_suggestions_; }
   void set_contextual_suggestions(bool enabled) {
     contextual_suggestions_ = enabled;
@@ -163,7 +170,7 @@ class TranslatorOptions {
 
  protected:
   string delimiters_;
-  string tag_ = "abc";
+  vector<string> tags_{"abc"};  // invariant: non-empty
   bool contextual_suggestions_ = false;
   bool enable_completion_ = true;
   bool strict_spelling_ = false;

--- a/src/rime/segmentation.h
+++ b/src/rime/segmentation.h
@@ -48,6 +48,10 @@ struct Segment {
   bool Reopen(size_t caret_pos);
 
   bool HasTag(const string& tag) const { return tags.find(tag) != tags.end(); }
+  bool HasAnyTagIn(const vector<string>& tags) const {
+    return std::any_of(tags.begin(), tags.end(),
+                       [this](const string& tag) { return HasTag(tag); });
+  }
 
   an<Candidate> GetCandidateAt(size_t index) const;
   an<Candidate> GetSelectedCandidate() const;


### PR DESCRIPTION
## Pull request

#### Feature

Allow script_translator and table_translator to take multiple tags.

```
translator:
  tags: [abc, tag1, tag2, tag3]
```

To keep compatibility:

1. if there is only `tag`: tags is set to that tag
2. if there is only `tags`: tags is set to that list
3. if there are both `tag` and `tags`: tag is the first element in the list, and `tags` is understood similar to `extra_tags`

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
5. GitHub Action CI pass
6. At least one contributor reviews and votes
7. Can be merged clean without conflicts
8. PR will be merged by rebase upstream base

#### Additional Info
