### PR TITLE
key_binder: add whences first_page, not_first_page, last_page, not_last_page

### DIFF
--- a/src/rime/gear/key_binder.cc
+++ b/src/rime/gear/key_binder.cc
@@ -15,6 +15,7 @@
 #include <rime/switcher.h>
 #include <rime/switches.h>
 #include <rime/gear/key_binder.h>
+#include <rime/menu.h>
 
 namespace rime {
 
@@ -24,6 +25,10 @@ enum KeyBindingCondition {
   kWhenPaging,      // user has changed page
   kWhenHasMenu,     // at least one candidate
   kWhenComposing,   // input string is not empty
+  kWhenFirstPage,
+  kWhenNotFirstPage,
+  kWhenLastPage,
+  kWhenNotLastPage,
   kAlways,
 };
 
@@ -34,6 +39,10 @@ static struct KeyBindingConditionDef {
                              {kWhenPaging, "paging"},
                              {kWhenHasMenu, "has_menu"},
                              {kWhenComposing, "composing"},
+                             {kWhenFirstPage, "first_page"},
+                             {kWhenNotFirstPage, "not_first_page"},
+                             {kWhenLastPage, "last_page"},
+                             {kWhenNotLastPage, "not_last_page"},
                              {kAlways, "always"},
                              {kNever, NULL}};
 
@@ -235,10 +244,11 @@ KeyBinder::KeyBinder(const Ticket& ticket)
 
 class KeyBindingConditions : public set<KeyBindingCondition> {
  public:
-  explicit KeyBindingConditions(Context* ctx);
+  explicit KeyBindingConditions(Engine* engine);
 };
 
-KeyBindingConditions::KeyBindingConditions(Context* ctx) {
+KeyBindingConditions::KeyBindingConditions(Engine* engine) {
+  Context* ctx = engine->context();
   insert(kAlways);
 
   if (ctx->IsComposing()) {
@@ -249,6 +259,22 @@ KeyBindingConditions::KeyBindingConditions(Context* ctx) {
     insert(kWhenHasMenu);
   }
 
+  if (ctx->HasMenu()) {
+    const auto& seg(ctx->composition().back());
+    int page_size = engine->schema()->page_size();
+    int page_no = seg.selected_index / page_size;
+    the<Page> page(seg.menu->CreatePage(page_size, page_no));
+    if (page) {
+      if (!page_no)
+        insert(kWhenFirstPage);  // first page
+      else
+        insert(kWhenNotFirstPage);
+      if (Bool(page->is_last_page))
+        insert(kWhenLastPage);  // last page
+      else
+        insert(kWhenNotLastPage);
+    }
+  }
   Composition& comp = ctx->composition();
   if (!comp.empty()) {
     const Segment& last_seg = comp.back();
@@ -268,7 +294,7 @@ ProcessResult KeyBinder::ProcessKeyEvent(const KeyEvent& key_event) {
     return kNoop;
   if (key_bindings_->find(key_event) == key_bindings_->end())
     return kNoop;
-  KeyBindingConditions conditions(engine_->context());
+  KeyBindingConditions conditions(engine_);
   for (const KeyBinding& binding : (*key_bindings_)[key_event]) {
     if (conditions.find(binding.whence) == conditions.end())
       continue;


### PR DESCRIPTION

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request
add whences: `first_page`, `not_first_page`, `last_page`, `not_last_page`

it would be helpful when pattern like `recognizer/patterns/money: '^/dx\d+(\.\d{0,2})?$'` is set, when `comma` / `period` is binding to page up / page down. 

```yaml
    - { when: paging, accept: comma, send: Page_Up }
    - { when: not_last_page, accept: period, send: Page_Down }
````


#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
