### PR TITLE
fix(build): limit default parallelism to 8 cores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ prefix ?= $(DESTDIR)/usr
 endif
 
 ifndef NOPARALLEL
-export MAKEFLAGS+=" -j$(( $(nproc) + 1)) "
+export MAKEFLAGS+=" -j$$(( $$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || echo 8) + 1)) "
 endif
 
 debug install-debug uninstall-debug test-debug: build ?= debug

--- a/deps.mk
+++ b/deps.mk
@@ -4,7 +4,7 @@ rime_root = $(CURDIR)
 src_dir = $(rime_root)/deps
 
 ifndef NOPARALLEL
-export MAKEFLAGS+=" -j$(( $(nproc) + 1)) "
+export MAKEFLAGS+=" -j$$(( $$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || echo 8) + 1)) "
 endif
 
 build ?= build


### PR DESCRIPTION
On systems where nproc is not available, it will leave only -j which causes unlimited parallelism.

Note: macos CI build already uses ninja which properly handles parallelism.

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #856 

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
