### PR TITLE
fix fcitx5 Ctrl+Shift switches to rime and toggles ascii mode

### DIFF
--- a/src/rime/gear/ascii_composer.cc
+++ b/src/rime/gear/ascii_composer.cc
@@ -82,7 +82,9 @@ ProcessResult AsciiComposer::ProcessKeyEvent(const KeyEvent& key_event) {
     if (key_event.release()) {
       if (shift_key_pressed_ || ctrl_key_pressed_) {
         auto now = std::chrono::steady_clock::now();
-        if (now < toggle_expired_) {
+        if (((is_shift && shift_key_pressed_) ||
+             (is_ctrl && ctrl_key_pressed_)) &&
+            now < toggle_expired_) {
           ToggleAsciiModeWithKey(ch);
         }
         shift_key_pressed_ = ctrl_key_pressed_ = false;


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #935

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- In fcitx5, set 切换启用/禁用输入法 to Ctrl+Shift_L, remove Shift_L from 临时在当前和第一个输入法之间切换
- Use a schema that uses Shift_L to toggle ascii mode
- Increase the 500ms limit to 5000ms
- Use Ctrl+Shift_L to switch from rime to keyboard-us
- Press Ctrl, press Shift_L, release Ctrl, release Shift_L within 5s
- master behavior: switch from keyboard-us to rime ascii mode, pr behavior: switch from keyboard-us to rime normal mode

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
