### PR TITLE
fix(navigator): wrong spans after selection

### DIFF
--- a/src/rime/gear/navigator.cc
+++ b/src/rime/gear/navigator.cc
@@ -60,6 +60,9 @@ Navigator::Navigator(const Ticket& ticket)
   Config* config = engine_->schema()->config();
   LoadConfig(config, "navigator", Horizontal);
   LoadConfig(config, "navigator/vertical", Vertical);
+
+  engine_->context()->select_notifier().connect(
+      [this](Context* ctx) { OnSelect(ctx); });
 }
 
 ProcessResult Navigator::ProcessKeyEvent(const KeyEvent& key_event) {
@@ -72,6 +75,10 @@ ProcessResult Navigator::ProcessKeyEvent(const KeyEvent& key_event) {
       ctx->get_option("_vertical") ? Vertical : Horizontal;
   return KeyBindingProcessor::ProcessKeyEvent(key_event, ctx, text_orientation,
                                               FallbackOptions::All);
+}
+
+void Navigator::OnSelect(Context* ctx) {
+  spans_.Clear();
 }
 
 bool Navigator::LeftBySyllable(Context* ctx) {

--- a/src/rime/gear/navigator.h
+++ b/src/rime/gear/navigator.h
@@ -42,6 +42,7 @@ class Navigator : public Processor, public KeyBindingProcessor<Navigator, 2> {
   bool MoveRight(Context* ctx);
   bool GoHome(Context* ctx);
   bool GoToEnd(Context* ctx);
+  void OnSelect(Context*);
 
   string input_;
   Spans spans_;


### PR DESCRIPTION
The cached spans can be wrong if not invalidated after selection. 

Consider: aabbccdd which can be understood as both 'aa'bb'cc'dd' and 'aab'bcc'dd'.

Suppose the first candidate is from 'aa'bb'cc'dd'. Now do {Control+Right}{Right}{Space} to select the first candidate of aab. Now do {Control+Right} again:

+ Expected: [aab]bcc|dd
+ Actual: [aab]b|ccdd (| is the caret)

This is because the spans are not recomputed even if we have picked a specific kind of segmentation. This PR adds a select handler and clears the spans to force the recomputation of the spans.

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
