### PR TITLE
feat(translator_commons): support excluding tags from translation

### DIFF
--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -194,7 +194,7 @@ an<Translation> ScriptTranslator::Query(const string& input,
                                         const Segment& segment) {
   if (!dict_ || !dict_->loaded())
     return nullptr;
-  if (!segment.HasAnyTagIn(tags_))
+  if (!segment.HasAnyTagIn(tags_) || segment.HasAnyTagIn(exclude_tags_))
     return nullptr;
   DLOG(INFO) << "input = '" << input << "', [" << segment.start << ", "
              << segment.end << ")";

--- a/src/rime/gear/table_translator.cc
+++ b/src/rime/gear/table_translator.cc
@@ -241,7 +241,7 @@ static bool starts_with_completion(an<Translation> translation) {
 
 an<Translation> TableTranslator::Query(const string& input,
                                        const Segment& segment) {
-  if (!segment.HasAnyTagIn(tags_))
+  if (!segment.HasAnyTagIn(tags_) || segment.HasAnyTagIn(exclude_tags_))
     return nullptr;
   DLOG(INFO) << "input = '" << input << "', [" << segment.start << ", "
              << segment.end << ")";

--- a/src/rime/gear/translator_commons.cc
+++ b/src/rime/gear/translator_commons.cc
@@ -145,6 +145,10 @@ TranslatorOptions::TranslatorOptions(const Ticket& ticket) {
           tags_.push_back(value->str());
     if (tags_.empty())
       tags_.push_back("abc");
+    if (auto list = config->GetList(ticket.name_space + "/exclude_tags"))
+      for (size_t i = 0; i < list->size(); ++i)
+        if (auto value = As<ConfigValue>(list->GetAt(i)))
+          exclude_tags_.push_back(value->str());
   }
   if (delimiters_.empty()) {
     delimiters_ = " ";

--- a/src/rime/gear/translator_commons.h
+++ b/src/rime/gear/translator_commons.h
@@ -155,6 +155,8 @@ class TranslatorOptions {
   }
   const string& tag() const { return tags_[0]; }
   void set_tag(const string& tag) { tags_[0] = tag; }
+  vector<string> exclude_tags() const { return exclude_tags_; }
+  void set_exclude_tags(const vector<string>& tags) { exclude_tags_ = tags; }
   bool contextual_suggestions() const { return contextual_suggestions_; }
   void set_contextual_suggestions(bool enabled) {
     contextual_suggestions_ = enabled;
@@ -171,6 +173,7 @@ class TranslatorOptions {
  protected:
   string delimiters_;
   vector<string> tags_{"abc"};  // invariant: non-empty
+  vector<string> exclude_tags_{};
   bool contextual_suggestions_ = false;
   bool enable_completion_ = true;
   bool strict_spelling_ = false;


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request
tl,dr: 允许script/table_translator跳过特定的tag

例如，场景： 
>输入orydarenosiwaza（ory是日语副翻译器引导前缀）
> 
>此时的候选
>
>[だれのしわざ]|
>
>page: 1  (of size 5)
>
>1. [誰の仕業]
>
>2.  誰 
>
> ...
>
>假如此时我选了2
>
>此时的composition: [{japanese,phony}ok|{japanese,partial}dare=>誰|{abc,japanese}nosiwaza=>諾斯哇咋]
>
>候选
>
>誰[no si wa za]|
>
>page: 1  (of size 5)
>
>1. [諾斯哇咋]
>
>2.  の仕業 
>
> ...
> 
> 后续的segment由于带有abc tag，翻译受到了主翻译器的影响

本次pr使得用户可通过配置
```YAML
translator/exclude_tags: [japanese]
```
让主翻译器不再处理带特定tag的segment

#### Unit test
- [ ] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
