### PR TITLE
fix(api): export librime 0.9 API as extern C

### DIFF
--- a/src/rime/algo/algebra.h
+++ b/src/rime/algo/algebra.h
@@ -19,7 +19,7 @@ class Schema;
 
 class Script : public map<string, vector<Spelling>> {
  public:
-  RIME_API bool AddSyllable(const string& syllable);
+  RIME_DLL bool AddSyllable(const string& syllable);
   void Merge(const string& s,
              const SpellingProperties& sp,
              const vector<Spelling>& v);
@@ -28,11 +28,11 @@ class Script : public map<string, vector<Spelling>> {
 
 class Projection {
  public:
-  RIME_API bool Load(an<ConfigList> settings);
+  RIME_DLL bool Load(an<ConfigList> settings);
   // "spelling" -> "gnilleps"
-  RIME_API bool Apply(string* value);
+  RIME_DLL bool Apply(string* value);
   // {z, y, x} -> {a, b, c, d}
-  RIME_API bool Apply(Script* value);
+  RIME_DLL bool Apply(Script* value);
 
  protected:
   vector<of<Calculation>> calculation_;

--- a/src/rime/algo/calculus.h
+++ b/src/rime/algo/calculus.h
@@ -29,9 +29,9 @@ class Calculation {
 
 class Calculus {
  public:
-  RIME_API Calculus();
+  RIME_DLL Calculus();
   void Register(const string& token, Calculation::Factory* factory);
-  RIME_API Calculation* Parse(const string& definition);
+  RIME_DLL Calculation* Parse(const string& definition);
 
  private:
   map<string, Calculation::Factory*> factories_;

--- a/src/rime/algo/encoder.h
+++ b/src/rime/algo/encoder.h
@@ -15,8 +15,8 @@ namespace rime {
 
 class RawCode : public vector<string> {
  public:
-  RIME_API string ToString() const;
-  RIME_API void FromString(const string& code_str);
+  RIME_DLL string ToString() const;
+  RIME_DLL void FromString(const string& code_str);
 };
 
 class PhraseCollector {
@@ -63,7 +63,7 @@ struct TableEncodingRule {
 };
 
 // for rule-based phrase encoding
-class RIME_API TableEncoder : public Encoder {
+class RIME_DLL TableEncoder : public Encoder {
  public:
   TableEncoder(PhraseCollector* collector = NULL);
 

--- a/src/rime/algo/syllabifier.h
+++ b/src/rime/algo/syllabifier.h
@@ -52,10 +52,10 @@ class Syllabifier {
         enable_completion_(enable_completion),
         strict_spelling_(strict_spelling) {}
 
-  RIME_API int BuildSyllableGraph(const string& input,
+  RIME_DLL int BuildSyllableGraph(const string& input,
                                   Prism& prism,
                                   SyllableGraph* graph);
-  RIME_API void EnableCorrection(Corrector* corrector);
+  RIME_DLL void EnableCorrection(Corrector* corrector);
 
  protected:
   void CheckOverlappedSpellings(SyllableGraph* graph, size_t start, size_t end);

--- a/src/rime/composition.h
+++ b/src/rime/composition.h
@@ -29,7 +29,7 @@ class Composition : public Segmentation {
   string GetPrompt() const;
   string GetCommitText() const;
   string GetScriptText(bool keep_selection = true) const;
-  RIME_API string GetDebugText() const;
+  RIME_DLL string GetDebugText() const;
   // Returns text of the last segment before the given position.
   string GetTextBefore(size_t pos) const;
 };

--- a/src/rime/config/config_component.h
+++ b/src/rime/config/config_component.h
@@ -22,8 +22,8 @@ class Config : public Class<Config, const string&>, public ConfigItemRef {
  public:
   // CAVEAT: Config instances created without argument will NOT
   // be managed by ConfigComponent
-  RIME_API Config();
-  RIME_API virtual ~Config();
+  RIME_DLL Config();
+  RIME_DLL virtual ~Config();
   // instances of Config with identical config id share a copy of config data
   // in the ConfigComponent
   explicit Config(an<ConfigData> data);
@@ -32,33 +32,33 @@ class Config : public Class<Config, const string&>, public ConfigItemRef {
   bool Save();
   bool LoadFromStream(std::istream& stream);
   bool SaveToStream(std::ostream& stream);
-  RIME_API bool LoadFromFile(const path& file_path);
-  RIME_API bool SaveToFile(const path& file_path);
+  RIME_DLL bool LoadFromFile(const path& file_path);
+  RIME_DLL bool SaveToFile(const path& file_path);
 
   // access a tree node of a particular type with "path/to/node"
-  RIME_API bool IsNull(const string& path);
+  RIME_DLL bool IsNull(const string& path);
   bool IsValue(const string& path);
-  RIME_API bool IsList(const string& path);
-  RIME_API bool IsMap(const string& path);
-  RIME_API bool GetBool(const string& path, bool* value);
-  RIME_API bool GetInt(const string& path, int* value);
-  RIME_API bool GetDouble(const string& path, double* value);
-  RIME_API bool GetString(const string& path, string* value);
-  RIME_API size_t GetListSize(const string& path);
+  RIME_DLL bool IsList(const string& path);
+  RIME_DLL bool IsMap(const string& path);
+  RIME_DLL bool GetBool(const string& path, bool* value);
+  RIME_DLL bool GetInt(const string& path, int* value);
+  RIME_DLL bool GetDouble(const string& path, double* value);
+  RIME_DLL bool GetString(const string& path, string* value);
+  RIME_DLL size_t GetListSize(const string& path);
 
   an<ConfigItem> GetItem(const string& path);
   an<ConfigValue> GetValue(const string& path);
-  RIME_API an<ConfigList> GetList(const string& path);
-  RIME_API an<ConfigMap> GetMap(const string& path);
+  RIME_DLL an<ConfigList> GetList(const string& path);
+  RIME_DLL an<ConfigMap> GetMap(const string& path);
 
   // setters
   bool SetBool(const string& path, bool value);
-  RIME_API bool SetInt(const string& path, int value);
+  RIME_DLL bool SetInt(const string& path, int value);
   bool SetDouble(const string& path, double value);
-  RIME_API bool SetString(const string& path, const char* value);
+  RIME_DLL bool SetString(const string& path, const char* value);
   bool SetString(const string& path, const string& value);
   // setter for adding or replacing items in the tree
-  RIME_API bool SetItem(const string& path, an<ConfigItem> item);
+  RIME_DLL bool SetItem(const string& path, an<ConfigItem> item);
   using ConfigItemRef::operator=;
 
  protected:
@@ -73,28 +73,28 @@ class ConfigCompilerPlugin;
 struct ConfigResource;
 
 struct ConfigResourceProvider {
-  RIME_API static const ResourceType kDefaultResourceType;
-  RIME_API static ResourceResolver* CreateResourceResolver(
+  RIME_DLL static const ResourceType kDefaultResourceType;
+  RIME_DLL static ResourceResolver* CreateResourceResolver(
       const ResourceType& resource_type);
 };
 
 struct DeployedConfigResourceProvider {
-  RIME_API static const ResourceType kDefaultResourceType;
-  RIME_API static ResourceResolver* CreateResourceResolver(
+  RIME_DLL static const ResourceType kDefaultResourceType;
+  RIME_DLL static ResourceResolver* CreateResourceResolver(
       const ResourceType& resource_type);
 };
 
 struct UserConfigResourceProvider {
-  RIME_API static const ResourceType kDefaultResourceType;
-  RIME_API static ResourceResolver* CreateResourceResolver(
+  RIME_DLL static const ResourceType kDefaultResourceType;
+  RIME_DLL static ResourceResolver* CreateResourceResolver(
       const ResourceType& resource_type);
 };
 
 class ConfigComponentBase : public Config::Component {
  public:
-  RIME_API ConfigComponentBase(ResourceResolver* resource_resolver);
-  RIME_API virtual ~ConfigComponentBase();
-  RIME_API Config* Create(const string& file_name);
+  RIME_DLL ConfigComponentBase(ResourceResolver* resource_resolver);
+  RIME_DLL virtual ~ConfigComponentBase();
+  RIME_DLL Config* Create(const string& file_name);
 
  protected:
   virtual an<ConfigData> LoadConfig(const string& config_id) = 0;
@@ -127,7 +127,7 @@ class ConfigComponent : public ConfigComponentBase {
 
 class ConfigLoader {
  public:
-  RIME_API an<ConfigData> LoadConfig(ResourceResolver* resource_resolver,
+  RIME_DLL an<ConfigData> LoadConfig(ResourceResolver* resource_resolver,
                                      const string& config_id);
   void set_auto_save(bool auto_save) { auto_save_ = auto_save; }
 
@@ -137,9 +137,9 @@ class ConfigLoader {
 
 class ConfigBuilder {
  public:
-  RIME_API ConfigBuilder();
-  RIME_API virtual ~ConfigBuilder();
-  RIME_API an<ConfigData> LoadConfig(ResourceResolver* resource_resolver,
+  RIME_DLL ConfigBuilder();
+  RIME_DLL virtual ~ConfigBuilder();
+  RIME_DLL an<ConfigData> LoadConfig(ResourceResolver* resource_resolver,
                                      const string& config_id);
   void InstallPlugin(ConfigCompilerPlugin* plugin);
   bool ApplyPlugins(ConfigCompiler* compiler, an<ConfigResource> resource);

--- a/src/rime/config/config_types.h
+++ b/src/rime/config/config_types.h
@@ -34,17 +34,17 @@ class ConfigItem {
 class ConfigValue : public ConfigItem {
  public:
   ConfigValue() : ConfigItem(kScalar) {}
-  RIME_API ConfigValue(bool value);
-  RIME_API ConfigValue(int value);
-  RIME_API ConfigValue(double value);
-  RIME_API ConfigValue(const char* value);
-  RIME_API ConfigValue(const string& value);
+  RIME_DLL ConfigValue(bool value);
+  RIME_DLL ConfigValue(int value);
+  RIME_DLL ConfigValue(double value);
+  RIME_DLL ConfigValue(const char* value);
+  RIME_DLL ConfigValue(const string& value);
 
   // schalar value accessors
   bool GetBool(bool* value) const;
-  RIME_API bool GetInt(int* value) const;
+  RIME_DLL bool GetInt(int* value) const;
   bool GetDouble(double* value) const;
-  RIME_API bool GetString(string* value) const;
+  RIME_DLL bool GetString(string* value) const;
   bool SetBool(bool value);
   bool SetInt(int value);
   bool SetDouble(double value);
@@ -65,14 +65,14 @@ class ConfigList : public ConfigItem {
   using Iterator = Sequence::iterator;
 
   ConfigList() : ConfigItem(kList) {}
-  RIME_API an<ConfigItem> GetAt(size_t i) const;
-  RIME_API an<ConfigValue> GetValueAt(size_t i) const;
-  RIME_API bool SetAt(size_t i, an<ConfigItem> element);
+  RIME_DLL an<ConfigItem> GetAt(size_t i) const;
+  RIME_DLL an<ConfigValue> GetValueAt(size_t i) const;
+  RIME_DLL bool SetAt(size_t i, an<ConfigItem> element);
   bool Insert(size_t i, an<ConfigItem> element);
-  RIME_API bool Append(an<ConfigItem> element);
+  RIME_DLL bool Append(an<ConfigItem> element);
   bool Resize(size_t size);
-  RIME_API bool Clear();
-  RIME_API size_t size() const;
+  RIME_DLL bool Clear();
+  RIME_DLL size_t size() const;
 
   Iterator begin();
   Iterator end();
@@ -90,10 +90,10 @@ class ConfigMap : public ConfigItem {
   using Iterator = Map::iterator;
 
   ConfigMap() : ConfigItem(kMap) {}
-  RIME_API bool HasKey(const string& key) const;
-  RIME_API an<ConfigItem> Get(const string& key) const;
-  RIME_API an<ConfigValue> GetValue(const string& key) const;
-  RIME_API bool Set(const string& key, an<ConfigItem> element);
+  RIME_DLL bool HasKey(const string& key) const;
+  RIME_DLL an<ConfigItem> Get(const string& key) const;
+  RIME_DLL an<ConfigValue> GetValue(const string& key) const;
+  RIME_DLL bool Set(const string& key, an<ConfigItem> element);
   bool Clear();
 
   Iterator begin();
@@ -137,28 +137,28 @@ class ConfigItemRef {
   ConfigListEntryRef operator[](size_t index);
   ConfigMapEntryRef operator[](const string& key);
 
-  RIME_API bool IsNull() const;
+  RIME_DLL bool IsNull() const;
   bool IsValue() const;
-  RIME_API bool IsList() const;
+  RIME_DLL bool IsList() const;
   bool IsMap() const;
 
-  RIME_API bool ToBool() const;
-  RIME_API int ToInt() const;
+  RIME_DLL bool ToBool() const;
+  RIME_DLL int ToInt() const;
   double ToDouble() const;
-  RIME_API string ToString() const;
+  RIME_DLL string ToString() const;
 
-  RIME_API an<ConfigList> AsList();
-  RIME_API an<ConfigMap> AsMap();
-  RIME_API void Clear();
+  RIME_DLL an<ConfigList> AsList();
+  RIME_DLL an<ConfigMap> AsMap();
+  RIME_DLL void Clear();
 
   // list
-  RIME_API bool Append(an<ConfigItem> item);
-  RIME_API size_t size() const;
+  RIME_DLL bool Append(an<ConfigItem> item);
+  RIME_DLL size_t size() const;
   // map
-  RIME_API bool HasKey(const string& key) const;
+  RIME_DLL bool HasKey(const string& key) const;
 
-  RIME_API bool modified() const;
-  RIME_API void set_modified();
+  RIME_DLL bool modified() const;
+  RIME_DLL void set_modified();
 
  protected:
   virtual an<ConfigItem> GetItem() const = 0;

--- a/src/rime/context.h
+++ b/src/rime/context.h
@@ -16,7 +16,7 @@ namespace rime {
 class Candidate;
 class KeyEvent;
 
-class RIME_API Context {
+class RIME_DLL Context {
  public:
   using Notifier = signal<void(Context* ctx)>;
   using OptionUpdateNotifier = signal<void(Context* ctx, const string& option)>;

--- a/src/rime/deployer.h
+++ b/src/rime/deployer.h
@@ -44,8 +44,8 @@ class Deployer : public Messenger {
   string app_name;
   // }
 
-  RIME_API Deployer();
-  RIME_API ~Deployer();
+  RIME_DLL Deployer();
+  RIME_DLL ~Deployer();
 
   bool RunTask(const string& task_name,
                TaskInitializer arg = TaskInitializer());

--- a/src/rime/dict/corrector.h
+++ b/src/rime/dict/corrector.h
@@ -56,7 +56,7 @@ class Corrections : public hash_map<SyllableId, Correction> {
 class Corrector : public Class<Corrector, const Ticket&> {
  public:
   virtual ~Corrector() = default;
-  RIME_API virtual void ToleranceSearch(const Prism& prism,
+  RIME_DLL virtual void ToleranceSearch(const Prism& prism,
                                         const string& key,
                                         corrector::Corrections* results,
                                         size_t tolerance) = 0;
@@ -77,7 +77,7 @@ class CorrectorComponent : public Corrector::Component {
   class Unified : public Corrector {
    public:
     Unified() = default;
-    RIME_API void ToleranceSearch(const Prism& prism,
+    RIME_DLL void ToleranceSearch(const Prism& prism,
                                   const string& key,
                                   corrector::Corrections* results,
                                   size_t tolerance) override;
@@ -94,14 +94,14 @@ class CorrectorComponent : public Corrector::Component {
 class EditDistanceCorrector : public Corrector, public Prism {
  public:
   ~EditDistanceCorrector() override = default;
-  RIME_API explicit EditDistanceCorrector(const path& file_path);
+  RIME_DLL explicit EditDistanceCorrector(const path& file_path);
 
-  RIME_API bool Build(const Syllabary& syllabary,
+  RIME_DLL bool Build(const Syllabary& syllabary,
                       const Script* script = nullptr,
                       uint32_t dict_file_checksum = 0,
                       uint32_t schema_file_checksum = 0);
 
-  RIME_API void ToleranceSearch(const Prism& prism,
+  RIME_DLL void ToleranceSearch(const Prism& prism,
                                 const string& key,
                                 corrector::Corrections* results,
                                 size_t tolerance) override;
@@ -112,7 +112,7 @@ class EditDistanceCorrector : public Corrector, public Prism {
                                          corrector::Distance threshold);
 };
 
-class RIME_API NearSearchCorrector : public Corrector {
+class RIME_DLL NearSearchCorrector : public Corrector {
  public:
   NearSearchCorrector() = default;
   ~NearSearchCorrector() override = default;

--- a/src/rime/dict/db.h
+++ b/src/rime/dict/db.h
@@ -35,8 +35,8 @@ class Db : public Class<Db, const string&> {
   Db(const path& file_path, const string& name);
   virtual ~Db() = default;
 
-  RIME_API bool Exists() const;
-  RIME_API virtual bool Remove();
+  RIME_DLL bool Exists() const;
+  RIME_DLL virtual bool Remove();
 
   virtual bool Open() = 0;
   virtual bool OpenReadOnly() = 0;
@@ -93,7 +93,7 @@ class Recoverable {
 
 class ResourceResolver;
 
-class RIME_API DbComponentBase {
+class RIME_DLL DbComponentBase {
  public:
   DbComponentBase();
   virtual ~DbComponentBase();

--- a/src/rime/dict/dict_compiler.h
+++ b/src/rime/dict/dict_compiler.h
@@ -31,10 +31,10 @@ class DictCompiler {
     kDump = 4,
   };
 
-  RIME_API explicit DictCompiler(Dictionary* dictionary);
-  RIME_API virtual ~DictCompiler();
+  RIME_DLL explicit DictCompiler(Dictionary* dictionary);
+  RIME_DLL virtual ~DictCompiler();
 
-  RIME_API bool Compile(const path& schema_file);
+  RIME_DLL bool Compile(const path& schema_file);
   void set_options(int options) { options_ = options; }
 
  private:

--- a/src/rime/dict/dictionary.h
+++ b/src/rime/dict/dictionary.h
@@ -23,7 +23,7 @@ struct QueryResult;
 
 }  // namespace dictionary
 
-class RIME_API DictEntryIterator : public DictEntryFilterBinder {
+class RIME_DLL DictEntryIterator : public DictEntryFilterBinder {
  public:
   DictEntryIterator();
   virtual ~DictEntryIterator() = default;
@@ -61,32 +61,32 @@ struct Ticket;
 
 class Dictionary : public Class<Dictionary, const Ticket&> {
  public:
-  RIME_API Dictionary(string name,
+  RIME_DLL Dictionary(string name,
                       vector<string> packs,
                       vector<of<Table>> tables,
                       an<Prism> prism);
   virtual ~Dictionary();
 
   bool Exists() const;
-  RIME_API bool Remove();
-  RIME_API bool Load();
+  RIME_DLL bool Remove();
+  RIME_DLL bool Load();
 
-  RIME_API an<DictEntryCollector> Lookup(const SyllableGraph& syllable_graph,
+  RIME_DLL an<DictEntryCollector> Lookup(const SyllableGraph& syllable_graph,
                                          size_t start_pos,
                                          bool predict_word = false,
                                          double initial_credibility = 0.0);
   // if predictive is true, do an expand search with limit,
   // otherwise do an exact match.
   // return num of matching keys.
-  RIME_API size_t LookupWords(DictEntryIterator* result,
+  RIME_DLL size_t LookupWords(DictEntryIterator* result,
                               const string& str_code,
                               bool predictive,
                               size_t limit = 0);
   // translate syllable id sequence to string code
-  RIME_API bool Decode(const Code& code, vector<string>* result);
+  RIME_DLL bool Decode(const Code& code, vector<string>* result);
 
   const string& name() const { return name_; }
-  RIME_API bool loaded() const;
+  RIME_DLL bool loaded() const;
 
   const vector<string>& packs() const { return packs_; }
   const vector<of<Table>>& tables() const { return tables_; }

--- a/src/rime/dict/level_db.cc
+++ b/src/rime/dict/level_db.cc
@@ -326,12 +326,12 @@ bool LevelDb::CommitTransaction() {
 }
 
 template <>
-RIME_API string UserDbComponent<LevelDb>::extension() const {
+RIME_DLL string UserDbComponent<LevelDb>::extension() const {
   return ".userdb";
 }
 
 template <>
-RIME_API UserDbWrapper<LevelDb>::UserDbWrapper(const path& file_path,
+RIME_DLL UserDbWrapper<LevelDb>::UserDbWrapper(const path& file_path,
                                                const string& db_name)
     : LevelDb(file_path, db_name, "userdb") {}
 

--- a/src/rime/dict/mapped_file.h
+++ b/src/rime/dict/mapped_file.h
@@ -80,7 +80,7 @@ struct List {
 
 class MappedFileImpl;
 
-class RIME_API MappedFile {
+class RIME_DLL MappedFile {
  protected:
   explicit MappedFile(const path& file_path);
   virtual ~MappedFile();

--- a/src/rime/dict/prism.h
+++ b/src/rime/dict/prism.h
@@ -67,24 +67,24 @@ class Prism : public MappedFile {
  public:
   using Match = Darts::DoubleArray::result_pair_type;
 
-  RIME_API explicit Prism(const path& file_path);
+  RIME_DLL explicit Prism(const path& file_path);
 
-  RIME_API bool Load();
-  RIME_API bool Save();
-  RIME_API bool Build(const Syllabary& syllabary,
+  RIME_DLL bool Load();
+  RIME_DLL bool Save();
+  RIME_DLL bool Build(const Syllabary& syllabary,
                       const Script* script = nullptr,
                       uint32_t dict_file_checksum = 0,
                       uint32_t schema_file_checksum = 0);
 
-  RIME_API bool HasKey(const string& key);
-  RIME_API bool GetValue(const string& key, int* value) const;
-  RIME_API void CommonPrefixSearch(const string& key, vector<Match>* result);
-  RIME_API void ExpandSearch(const string& key,
+  RIME_DLL bool HasKey(const string& key);
+  RIME_DLL bool GetValue(const string& key, int* value) const;
+  RIME_DLL void CommonPrefixSearch(const string& key, vector<Match>* result);
+  RIME_DLL void ExpandSearch(const string& key,
                              vector<Match>* result,
                              size_t limit);
   SpellingAccessor QuerySpelling(SyllableId spelling_id);
 
-  RIME_API size_t array_size() const;
+  RIME_DLL size_t array_size() const;
 
   uint32_t dict_file_checksum() const;
   uint32_t schema_file_checksum() const;

--- a/src/rime/dict/string_table.h
+++ b/src/rime/dict/string_table.h
@@ -19,7 +19,7 @@ using StringId = marisa::UInt32;
 
 const StringId kInvalidStringId = (StringId)(-1);
 
-class RIME_API StringTable {
+class RIME_DLL StringTable {
  public:
   StringTable() = default;
   virtual ~StringTable() = default;
@@ -38,7 +38,7 @@ class RIME_API StringTable {
   marisa::Trie trie_;
 };
 
-class RIME_API StringTableBuilder : public StringTable {
+class RIME_DLL StringTableBuilder : public StringTable {
  public:
   void Add(const string& key,
            double weight = 1.0,

--- a/src/rime/dict/table.h
+++ b/src/rime/dict/table.h
@@ -114,12 +114,12 @@ class TableAccessor {
                 const table::TailIndex* code_map,
                 double credibility = 0.0);
 
-  RIME_API bool Next();
+  RIME_DLL bool Next();
 
-  RIME_API bool exhausted() const;
-  RIME_API size_t remaining() const;
-  RIME_API const table::Entry* entry() const;
-  RIME_API const table::Code* extra_code() const;
+  RIME_DLL bool exhausted() const;
+  RIME_DLL size_t remaining() const;
+  RIME_DLL const table::Entry* entry() const;
+  RIME_DLL const table::Code* extra_code() const;
   const Code& index_code() const { return index_code_; }
   Code code() const;
   double credibility() const { return credibility_; }
@@ -170,24 +170,24 @@ class TableQuery {
 
 class Table : public MappedFile {
  public:
-  RIME_API Table(const path& file_path);
+  RIME_DLL Table(const path& file_path);
   virtual ~Table();
 
-  RIME_API bool Load();
-  RIME_API bool Save();
-  RIME_API bool Build(const Syllabary& syllabary,
+  RIME_DLL bool Load();
+  RIME_DLL bool Save();
+  RIME_DLL bool Build(const Syllabary& syllabary,
                       const Vocabulary& vocabulary,
                       size_t num_entries,
                       uint32_t dict_file_checksum = 0);
 
   bool GetSyllabary(Syllabary* syllabary);
-  RIME_API string GetSyllableById(int syllable_id);
-  RIME_API TableAccessor QueryWords(int syllable_id);
-  RIME_API TableAccessor QueryPhrases(const Code& code);
-  RIME_API bool Query(const SyllableGraph& syll_graph,
+  RIME_DLL string GetSyllableById(int syllable_id);
+  RIME_DLL TableAccessor QueryWords(int syllable_id);
+  RIME_DLL TableAccessor QueryPhrases(const Code& code);
+  RIME_DLL bool Query(const SyllableGraph& syll_graph,
                       size_t start_pos,
                       TableQueryResult* result);
-  RIME_API string GetEntryText(const table::Entry& entry);
+  RIME_DLL string GetEntryText(const table::Entry& entry);
 
   uint32_t dict_file_checksum() const;
   table::Metadata* metadata() const { return metadata_; }

--- a/src/rime/dict/text_db.h
+++ b/src/rime/dict/text_db.h
@@ -43,25 +43,25 @@ class TextDb : public Db {
          const string& db_name,
          const string& db_type,
          TextFormat format);
-  RIME_API virtual ~TextDb();
+  RIME_DLL virtual ~TextDb();
 
-  RIME_API bool Open() override;
-  RIME_API bool OpenReadOnly() override;
-  RIME_API bool Close() override;
+  RIME_DLL bool Open() override;
+  RIME_DLL bool OpenReadOnly() override;
+  RIME_DLL bool Close() override;
 
-  RIME_API bool Backup(const path& snapshot_file) override;
-  RIME_API bool Restore(const path& snapshot_file) override;
+  RIME_DLL bool Backup(const path& snapshot_file) override;
+  RIME_DLL bool Restore(const path& snapshot_file) override;
 
-  RIME_API bool CreateMetadata() override;
-  RIME_API bool MetaFetch(const string& key, string* value) override;
-  RIME_API bool MetaUpdate(const string& key, const string& value) override;
+  RIME_DLL bool CreateMetadata() override;
+  RIME_DLL bool MetaFetch(const string& key, string* value) override;
+  RIME_DLL bool MetaUpdate(const string& key, const string& value) override;
 
-  RIME_API an<DbAccessor> QueryMetadata() override;
-  RIME_API an<DbAccessor> QueryAll() override;
-  RIME_API an<DbAccessor> Query(const string& key) override;
-  RIME_API bool Fetch(const string& key, string* value) override;
-  RIME_API bool Update(const string& key, const string& value) override;
-  RIME_API bool Erase(const string& key) override;
+  RIME_DLL an<DbAccessor> QueryMetadata() override;
+  RIME_DLL an<DbAccessor> QueryAll() override;
+  RIME_DLL an<DbAccessor> Query(const string& key) override;
+  RIME_DLL bool Fetch(const string& key, string* value) override;
+  RIME_DLL bool Update(const string& key, const string& value) override;
+  RIME_DLL bool Erase(const string& key) override;
 
  protected:
   void Clear();

--- a/src/rime/dict/user_db.cc
+++ b/src/rime/dict/user_db.cc
@@ -97,7 +97,7 @@ static TextFormat plain_userdb_format = {
 };
 
 template <>
-RIME_API UserDbWrapper<TextDb>::UserDbWrapper(const path& file_path,
+RIME_DLL UserDbWrapper<TextDb>::UserDbWrapper(const path& file_path,
                                               const string& db_name)
     : TextDb(file_path, db_name, "userdb", plain_userdb_format) {}
 

--- a/src/rime/dict/user_db.h
+++ b/src/rime/dict/user_db.h
@@ -61,10 +61,10 @@ class UserDbHelper {
   UserDbHelper(const the<Db>& db) : db_(db.get()) {}
   UserDbHelper(const an<Db>& db) : db_(db.get()) {}
 
-  RIME_API bool UpdateUserInfo();
-  RIME_API static bool IsUniformFormat(const path& file_path);
-  RIME_API bool UniformBackup(const path& snapshot_file);
-  RIME_API bool UniformRestore(const path& snapshot_file);
+  RIME_DLL bool UpdateUserInfo();
+  RIME_DLL static bool IsUniformFormat(const path& file_path);
+  RIME_DLL bool UniformBackup(const path& snapshot_file);
+  RIME_DLL bool UniformRestore(const path& snapshot_file);
 
   bool IsUserDb();
   string GetDbName();
@@ -79,7 +79,7 @@ class UserDbHelper {
 template <class BaseDb>
 class UserDbWrapper : public BaseDb {
  public:
-  RIME_API UserDbWrapper(const path& file_path, const string& db_name);
+  RIME_DLL UserDbWrapper(const path& file_path, const string& db_name);
 
   virtual bool CreateMetadata() {
     return BaseDb::CreateMetadata() && UserDbHelper(this).UpdateUserInfo();

--- a/src/rime/dict/vocabulary.h
+++ b/src/rime/dict/vocabulary.h
@@ -79,7 +79,7 @@ class DictEntryList : public vector<of<DictEntry>> {
 
 using DictEntryFilter = function<bool(an<DictEntry> entry)>;
 
-class RIME_API DictEntryFilterBinder {
+class RIME_DLL DictEntryFilterBinder {
  public:
   virtual ~DictEntryFilterBinder() = default;
   virtual void AddFilter(DictEntryFilter filter);

--- a/src/rime/engine.h
+++ b/src/rime/engine.h
@@ -34,7 +34,7 @@ class Engine : public Messenger {
   Engine* active_engine() { return active_engine_ ? active_engine_ : this; }
   void set_active_engine(Engine* engine = nullptr) { active_engine_ = engine; }
 
-  RIME_API static Engine* Create();
+  RIME_DLL static Engine* Create();
 
  protected:
   Engine();

--- a/src/rime/key_event.h
+++ b/src/rime/key_event.h
@@ -19,7 +19,7 @@ class KeyEvent {
   KeyEvent() = default;
   KeyEvent(int keycode, int modifier)
       : keycode_(keycode), modifier_(modifier) {}
-  RIME_API KeyEvent(const string& repr);
+  RIME_DLL KeyEvent(const string& repr);
 
   int keycode() const { return keycode_; }
   void keycode(int value) { keycode_ = value; }
@@ -35,10 +35,10 @@ class KeyEvent {
   // 按鍵表示為形如「狀態+鍵名」的文字
   // 若無鍵名，則以四位或六位十六进制数形式的文字來標識
   // 形如 "0x12ab", "0xfffffe"
-  RIME_API string repr() const;
+  RIME_DLL string repr() const;
 
   // 解析文字表示的按鍵
-  RIME_API bool Parse(const string& repr);
+  RIME_DLL bool Parse(const string& repr);
 
   bool operator==(const KeyEvent& other) const {
     return keycode_ == other.keycode_ && modifier_ == other.modifier_;
@@ -59,15 +59,15 @@ class KeyEvent {
 class KeySequence : public vector<KeyEvent> {
  public:
   KeySequence() = default;
-  RIME_API KeySequence(const string& repr);
+  RIME_DLL KeySequence(const string& repr);
 
   // 可表示為一串文字
   // 若其中包含不產生可打印字符的按鍵，以 {鍵名} 來標記
   // 組合鍵也用 {組合鍵狀態+鍵名} 來標記
-  RIME_API string repr() const;
+  RIME_DLL string repr() const;
 
   // 解析按鍵序列描述文字
-  RIME_API bool Parse(const string& repr);
+  RIME_DLL bool Parse(const string& repr);
 };
 
 inline std::ostream& operator<<(std::ostream& out, const KeyEvent& key_event) {

--- a/src/rime/key_table.cc
+++ b/src/rime/key_table.cc
@@ -2000,7 +2000,7 @@ static const key_entry keys_by_name[] = {
     {0x0000ff, 1270},  {0x0000a5, 468},   {0x00007a, 383},   {0x0001bf, 1456},
     {0x0001bc, 1430},  {0x0001be, 1449}};
 
-RIME_API int RimeGetModifierByName(const char* name) {
+RIME_DLL int RimeGetModifierByName(const char* name) {
   const int n = sizeof(modifier_name) / sizeof(const char*);
   if (!name)
     return 0;
@@ -2012,7 +2012,7 @@ RIME_API int RimeGetModifierByName(const char* name) {
   return 0;
 }
 
-RIME_API const char* RimeGetModifierName(int modifier) {
+RIME_DLL const char* RimeGetModifierName(int modifier) {
   const int n = sizeof(modifier_name) / sizeof(const char*);
   for (int i = 0; i < n && modifier != 0; ++i) {
     if ((modifier & 1) != 0) {
@@ -2023,7 +2023,7 @@ RIME_API const char* RimeGetModifierName(int modifier) {
   return NULL;
 }
 
-RIME_API int RimeGetKeycodeByName(const char* name) {
+RIME_DLL int RimeGetKeycodeByName(const char* name) {
   for (const key_entry* p = keys_by_keyval; p->keyval != XK_VoidSymbol; ++p) {
     if (!strcmp(name, key_names + p->offset)) {
       return p->keyval;
@@ -2032,7 +2032,7 @@ RIME_API int RimeGetKeycodeByName(const char* name) {
   return XK_VoidSymbol;
 }
 
-RIME_API const char* RimeGetKeyName(int keycode) {
+RIME_DLL const char* RimeGetKeyName(int keycode) {
   const int n = sizeof(keys_by_name) / sizeof(const key_entry);
   for (int i = 0; i < n; ++i) {
     if (keycode == keys_by_name[i].keyval) {

--- a/src/rime/key_table.h
+++ b/src/rime/key_table.h
@@ -48,19 +48,19 @@ typedef enum {
 // 给定modifier文字，返回马赛克值
 // 例如 RimeGetModifierByName("Alt") == (1 << 3)
 // 如果不认得所给的键名，返回 0
-RIME_API int RimeGetModifierByName(const char* name);
+RIME_DLL int RimeGetModifierByName(const char* name);
 
 // 给一个数值，取得最低的非0位所对应的modifier文字
 // 例如 RimeGetModifierName(12) == "Control"
 // 取不到则返回 NULL
-RIME_API const char* RimeGetModifierName(int modifier);
+RIME_DLL const char* RimeGetModifierName(int modifier);
 
 // 由键名取得键值
 // 查无此键则返回 XK_VoidSymbol
-RIME_API int RimeGetKeycodeByName(const char* name);
+RIME_DLL int RimeGetKeycodeByName(const char* name);
 
 // 由键值取得键名
 // 不认得此键，则返回 NULL
-RIME_API const char* RimeGetKeyName(int keycode);
+RIME_DLL const char* RimeGetKeyName(int keycode);
 
 #endif  // RIME_KEY_TABLE_H_

--- a/src/rime/lever/deployment_tasks.h
+++ b/src/rime/lever/deployment_tasks.h
@@ -25,14 +25,14 @@ class DetectModifications : public DeploymentTask {
 };
 
 // initialize/update installation.yaml
-class RIME_API InstallationUpdate : public DeploymentTask {
+class RIME_DLL InstallationUpdate : public DeploymentTask {
  public:
   InstallationUpdate(TaskInitializer arg = TaskInitializer()) {}
   bool Run(Deployer* deployer);
 };
 
 // update distributed config files and preset schemas
-class RIME_API WorkspaceUpdate : public DeploymentTask {
+class RIME_DLL WorkspaceUpdate : public DeploymentTask {
  public:
   WorkspaceUpdate(TaskInitializer arg = TaskInitializer()) {}
   bool Run(Deployer* deployer);
@@ -44,7 +44,7 @@ class RIME_API WorkspaceUpdate : public DeploymentTask {
 };
 
 // update a specific schema, build corresponding dictionary
-class RIME_API SchemaUpdate : public DeploymentTask {
+class RIME_DLL SchemaUpdate : public DeploymentTask {
  public:
   explicit SchemaUpdate(const path& source_path) : source_path_(source_path) {}
   SchemaUpdate(TaskInitializer arg);

--- a/src/rime/lever/levers_api_impl.h
+++ b/src/rime/lever/levers_api_impl.h
@@ -1,5 +1,7 @@
 // implementation of levers api
 
+#include <rime_levers_api.h>
+
 #include <rime/service.h>
 #include <rime/lever/custom_settings.h>
 #include <rime/lever/switcher_settings.h>

--- a/src/rime/lever/levers_module.cc
+++ b/src/rime/lever/levers_module.cc
@@ -32,7 +32,6 @@ static void rime_levers_initialize() {
 
 static void rime_levers_finalize() {}
 
-#include <rime_levers_api.h>
 // defines rime_levers_get_api()
 #include "levers_api_impl.h"
 

--- a/src/rime/lever/levers_stdbool.cc
+++ b/src/rime/lever/levers_stdbool.cc
@@ -1,5 +1,4 @@
 #include <rime_api_stdbool.h>
-#include <rime_levers_api.h>
 // defines rime_levers_get_api_stdbool()
 #include "levers_api_impl.h"
 

--- a/src/rime/lever/user_dict_manager.h
+++ b/src/rime/lever/user_dict_manager.h
@@ -16,7 +16,7 @@ class Deployer;
 
 using UserDictList = vector<string>;
 
-class RIME_API UserDictManager {
+class RIME_DLL UserDictManager {
  public:
   UserDictManager(Deployer* deployer);
 

--- a/src/rime/menu.h
+++ b/src/rime/menu.h
@@ -26,13 +26,13 @@ class Translation;
 
 class Menu {
  public:
-  RIME_API Menu();
+  RIME_DLL Menu();
 
-  RIME_API void AddTranslation(an<Translation> translation);
+  RIME_DLL void AddTranslation(an<Translation> translation);
   void AddFilter(Filter* filter);
 
-  RIME_API size_t Prepare(size_t candidate_count);
-  RIME_API Page* CreatePage(size_t page_size, size_t page_no);
+  RIME_DLL size_t Prepare(size_t candidate_count);
+  RIME_DLL Page* CreatePage(size_t page_size, size_t page_no);
   an<Candidate> GetCandidateAt(size_t index);
 
   // CAVEAT: returns the number of candidates currently obtained,

--- a/src/rime/registry.h
+++ b/src/rime/registry.h
@@ -18,12 +18,12 @@ class Registry {
  public:
   using ComponentMap = map<string, ComponentBase*>;
 
-  RIME_API ComponentBase* Find(const string& name);
-  RIME_API void Register(const string& name, ComponentBase* component);
-  RIME_API void Unregister(const string& name);
+  RIME_DLL ComponentBase* Find(const string& name);
+  RIME_DLL void Register(const string& name, ComponentBase* component);
+  RIME_DLL void Unregister(const string& name);
   void Clear();
 
-  RIME_API static Registry& instance();
+  RIME_DLL static Registry& instance();
 
  private:
   Registry() = default;

--- a/src/rime/resource.h
+++ b/src/rime/resource.h
@@ -19,7 +19,7 @@ struct ResourceType {
   string suffix;
 };
 
-class RIME_API ResourceResolver {
+class RIME_DLL ResourceResolver {
  public:
   explicit ResourceResolver(const ResourceType type) : type_(type) {}
   virtual ~ResourceResolver() {}
@@ -35,7 +35,7 @@ class RIME_API ResourceResolver {
 };
 
 // try fallback path if target file doesn't exist in root path
-class RIME_API FallbackResourceResolver : public ResourceResolver {
+class RIME_DLL FallbackResourceResolver : public ResourceResolver {
  public:
   explicit FallbackResourceResolver(const ResourceType& type)
       : ResourceResolver(type) {}

--- a/src/rime/segmentation.h
+++ b/src/rime/segmentation.h
@@ -57,7 +57,7 @@ struct Segment {
   an<Candidate> GetSelectedCandidate() const;
 };
 
-class RIME_API Segmentation : public vector<Segment> {
+class RIME_DLL Segmentation : public vector<Segment> {
  public:
   Segmentation();
   virtual ~Segmentation() {}

--- a/src/rime/service.h
+++ b/src/rime/service.h
@@ -56,7 +56,7 @@ class Session {
 class ResourceResolver;
 struct ResourceType;
 
-class RIME_API Service {
+class RIME_DLL Service {
  public:
   ~Service();
 

--- a/src/rime/setup.cc
+++ b/src/rime/setup.cc
@@ -22,15 +22,15 @@
 namespace rime {
 
 #define Q(x) #x
-RIME_API RIME_MODULE_LIST(kDefaultModules, "default" RIME_EXTRA_MODULES);
+RIME_DLL RIME_MODULE_LIST(kDefaultModules, "default" RIME_EXTRA_MODULES);
 #undef Q
-RIME_API RIME_MODULE_LIST(kDeployerModules, "deployer");
+RIME_DLL RIME_MODULE_LIST(kDeployerModules, "deployer");
 RIME_MODULE_LIST(kLegacyModules, "legacy");
 
 RIME_REGISTER_MODULE_GROUP(default, "core", "dict", "gears")
 RIME_REGISTER_MODULE_GROUP(deployer, "core", "dict", "levers")
 
-RIME_API void LoadModules(const char* module_names[]) {
+RIME_DLL void LoadModules(const char* module_names[]) {
   ModuleManager& mm(ModuleManager::instance());
   for (const char** m = module_names; *m; ++m) {
     if (RimeModule* module = mm.Find(*m)) {
@@ -39,7 +39,7 @@ RIME_API void LoadModules(const char* module_names[]) {
   }
 }
 
-RIME_API void SetupDeployer(RimeTraits* traits) {
+RIME_DLL void SetupDeployer(RimeTraits* traits) {
   if (!traits)
     return;
   Deployer& deployer(Service::instance().deployer());
@@ -65,7 +65,7 @@ RIME_API void SetupDeployer(RimeTraits* traits) {
     deployer.staging_dir = deployer.user_data_dir / "build";
 }
 
-RIME_API void SetupLogging(const char* app_name,
+RIME_DLL void SetupLogging(const char* app_name,
                            int min_log_level,
                            const char* log_dir) {
 #ifdef RIME_ENABLE_LOGGING
@@ -95,7 +95,7 @@ RIME_API void SetupLogging(const char* app_name,
 #endif  // RIME_ENABLE_LOGGING
 }
 
-RIME_API void SetupLogging(const char* app_name) {
+RIME_DLL void SetupLogging(const char* app_name) {
   SetupLogging(app_name, 0, NULL);
 }
 

--- a/src/rime/setup.h
+++ b/src/rime/setup.h
@@ -11,18 +11,18 @@
 
 namespace rime {
 
-RIME_API extern const char* kDefaultModules[];
-RIME_API extern const char* kDeployerModules[];
+RIME_DLL extern const char* kDefaultModules[];
+RIME_DLL extern const char* kDeployerModules[];
 extern const char* kLegacyModules[];
 
-RIME_API void LoadModules(const char* module_names[]);
+RIME_DLL void LoadModules(const char* module_names[]);
 
-RIME_API void SetupDeployer(RimeTraits* traits);
+RIME_DLL void SetupDeployer(RimeTraits* traits);
 
-RIME_API void SetupLogging(const char* app_name,
+RIME_DLL void SetupLogging(const char* app_name,
                            int min_log_level,
                            const char* log_dir);
-RIME_API void SetupLogging(const char* app_name);
+RIME_DLL void SetupLogging(const char* app_name);
 
 }  // namespace rime
 

--- a/src/rime/ticket.h
+++ b/src/rime/ticket.h
@@ -24,7 +24,7 @@ struct Ticket {
   Ticket(Schema* s, const string& ns);
   // prescription: in the form of "klass" or "klass@alias"
   // where alias, if given, will override default name space
-  RIME_API Ticket(Engine* e,
+  RIME_DLL Ticket(Engine* e,
                   const string& ns = "",
                   const string& prescription = "");
 };

--- a/src/rime/translation.h
+++ b/src/rime/translation.h
@@ -14,7 +14,7 @@
 
 namespace rime {
 
-class RIME_API Translation {
+class RIME_DLL Translation {
  public:
   Translation() = default;
   virtual ~Translation() = default;
@@ -51,7 +51,7 @@ class UniqueTranslation : public Translation {
   an<Candidate> candidate_;
 };
 
-class RIME_API FifoTranslation : public Translation {
+class RIME_DLL FifoTranslation : public Translation {
  public:
   FifoTranslation();
 

--- a/src/rime_api.cc
+++ b/src/rime_api.cc
@@ -4,13 +4,14 @@
 //
 // 2011-08-09 GONG Chen <chen.sst@gmail.com>
 //
+
+#include "rime_api_impl.h"
+
 #include <cstring>
 #include <sstream>
 #include <rime/common.h>
 #include <rime/module.h>
 #include <rime/setup.h>
-
-#include "rime_api_impl.h"
 
 using namespace rime;
 

--- a/src/rime_api.h
+++ b/src/rime_api.h
@@ -18,15 +18,19 @@ extern "C" {
 #if defined(_WIN32)
 #if defined(RIME_EXPORTS)
 /* DLL export */
-#define RIME_API __declspec(dllexport)
+#define RIME_DLL __declspec(dllexport)
+#define RIME_API extern "C" RIME_DLL
 #elif defined(RIME_IMPORTS)
 /* DLL import */
-#define RIME_API __declspec(dllimport)
+#define RIME_DLL __declspec(dllimport)
+#define RIME_API extern "C" RIME_DLL
 #else
 /* static library */
+#define RIME_DLL
 #define RIME_API
 #endif
 #else /* _WIN32 */
+#define RIME_DLL
 #define RIME_API
 #endif /* _WIN32 */
 

--- a/src/rime_api_impl.h
+++ b/src/rime_api_impl.h
@@ -1,6 +1,8 @@
 // intended to be included multiple times in c++ source files with different
 // RIME_FLAVORED macro definitions
 
+#include "rime_api.h"
+
 #include <rime/common.h>
 #include <rime/composition.h>
 #include <rime/config.h>
@@ -15,8 +17,6 @@
 #include <rime/setup.h>
 #include <rime/signature.h>
 #include <rime/switches.h>
-
-#include "rime_api.h"
 
 using namespace rime;
 


### PR DESCRIPTION
Fixes #964

`RIME_API` should include `extern "C"`;
 C++ symbols are now DLL-exported by the `RIME_DLL` macro instead.