### PR TITLE
fix(navigator): notifier connection should be disconnected

### DIFF
--- a/src/rime/gear/navigator.cc
+++ b/src/rime/gear/navigator.cc
@@ -61,8 +61,12 @@ Navigator::Navigator(const Ticket& ticket)
   LoadConfig(config, "navigator", Horizontal);
   LoadConfig(config, "navigator/vertical", Vertical);
 
-  engine_->context()->select_notifier().connect(
+  select_connection_ = engine_->context()->select_notifier().connect(
       [this](Context* ctx) { OnSelect(ctx); });
+}
+
+Navigator::~Navigator() {
+  select_connection_.disconnect();
 }
 
 ProcessResult Navigator::ProcessKeyEvent(const KeyEvent& key_event) {

--- a/src/rime/gear/navigator.h
+++ b/src/rime/gear/navigator.h
@@ -23,6 +23,7 @@ class Navigator : public Processor, public KeyBindingProcessor<Navigator, 2> {
   };
 
   explicit Navigator(const Ticket& ticket);
+  virtual ~Navigator();
 
   ProcessResult ProcessKeyEvent(const KeyEvent& key_event) override;
 
@@ -46,6 +47,8 @@ class Navigator : public Processor, public KeyBindingProcessor<Navigator, 2> {
 
   string input_;
   Spans spans_;
+
+  connection select_connection_;
 };
 
 }  // namespace rime


### PR DESCRIPTION
Apparently #952 is flawed. This PR corrects some crashes reported by fcitx and squirrel users.