### PR TITLE
enhance(punctuator): commit on space after digit separators

### DIFF
--- a/src/rime/gear/punctuator.cc
+++ b/src/rime/gear/punctuator.cc
@@ -96,8 +96,7 @@ ProcessResult Punctuator::ProcessKeyEvent(const KeyEvent& key_event) {
   if (ctx->get_option("ascii_punct")) {
     return kNoop;
   }
-  if ((isdigit(ch) || (!use_space_ && ch == XK_space)) &&
-      is_after_digit_separator(ctx)) {
+  if ((isdigit(ch) || ch == XK_space) && is_after_digit_separator(ctx)) {
     ctx->PushInput(ch) && ctx->Commit();
     return kAccepted;
   }

--- a/src/rime/gear/punctuator.cc
+++ b/src/rime/gear/punctuator.cc
@@ -96,12 +96,13 @@ ProcessResult Punctuator::ProcessKeyEvent(const KeyEvent& key_event) {
   if (ctx->get_option("ascii_punct")) {
     return kNoop;
   }
-  if (!use_space_ && ch == XK_space && ctx->IsComposing()) {
-    return kNoop;
-  }
-  if (isdigit(ch) && is_after_digit_separator(ctx)) {
+  if ((isdigit(ch) || (!use_space_ && ch == XK_space)) &&
+      is_after_digit_separator(ctx)) {
     ctx->PushInput(ch) && ctx->Commit();
     return kAccepted;
+  }
+  if (!use_space_ && ch == XK_space && ctx->IsComposing()) {
+    return kNoop;
   }
   if (ConvertDigitSeparator(ch)) {
     return kAccepted;


### PR DESCRIPTION
Follow-up #973 
Fix #972 (comment)

在数字分隔符后按空格，直接输出半角符号 **和一个空格** ，从而保持旧版行为。