### PR TITLE
feat(punctuator): option to commit digit separator

### DIFF
--- a/src/rime/gear/punctuator.cc
+++ b/src/rime/gear/punctuator.cc
@@ -40,6 +40,12 @@ void PunctConfig::LoadConfig(Engine* engine, bool load_symbols) {
       digit_separators_ = configured;
     }
   }
+  {
+    string configured;
+    if (config->GetString("punctuator/digit_separator_action", &configured)) {
+      digit_separator_commit_ = (configured == "commit");
+    }
+  }
 }
 
 an<ConfigItem> PunctConfig::GetPunctDefinition(const string key) {
@@ -133,7 +139,8 @@ bool Punctuator::ConvertDigitSeparator(char ch) {
   if (ctx->composition().empty() && is_after_number(ctx)) {
     DLOG(INFO) << "convert punct in number: " << ch;
     ctx->PushInput(ch) && punctuation_is_translated(ctx, "punct_number") &&
-        ctx->composition().Forward();
+        (config_.digit_separator_commit() ? ctx->Commit()
+                                          : ctx->composition().Forward());
     return true;
   }
   return false;

--- a/src/rime/gear/punctuator.h
+++ b/src/rime/gear/punctuator.h
@@ -28,6 +28,7 @@ class PunctConfig {
   bool is_digit_separator(char ch) const {
     return digit_separators_.find(ch) != string::npos;
   }
+  bool digit_separator_commit() const { return digit_separator_commit_; }
 
  protected:
   string shape_;
@@ -35,6 +36,7 @@ class PunctConfig {
   an<ConfigMap> symbols_;
 
   string digit_separators_ = ",.:'";
+  bool digit_separator_commit_ = false;
 };
 
 class Punctuator : public Processor {


### PR DESCRIPTION
instead of converting it to a `punct_number` segment in the input buffer.
this reproduces the behaviour before commit e02d6b3.

opt in the option with `punctuator/digit_separator_action: commit`
