### PR TITLE
fix(build): plugins shouldn't statically link rime deps

### DIFF
--- a/deps.mk
+++ b/deps.mk
@@ -33,6 +33,7 @@ clean-src:
 
 glog:
 	cd $(src_dir)/glog; \
+	sed -i.bak '/set.*VISIBILITY/d' CMakeLists.txt; \
 	cmake . -B$(build) \
 	-DBUILD_SHARED_LIBS:BOOL=OFF \
 	-DBUILD_TESTING:BOOL=OFF \

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -39,6 +39,18 @@ else()
   endforeach(file)
 endif()
 
+function(remove_static_libs target)
+  get_target_property(libs ${target} LINK_LIBRARIES)
+  if(libs)
+    foreach(lib ${libs})
+      if(lib MATCHES ".*\.(a|lib)$")
+        list(REMOVE_ITEM libs ${lib})
+      endif()
+    endforeach()
+    set_target_properties(${target} PROPERTIES LINK_LIBRARIES "${libs}")
+  endif()
+endfunction()
+
 foreach(plugin ${plugins})
   unset(plugin_name)
   unset(plugin_objs)
@@ -54,6 +66,7 @@ foreach(plugin ${plugins})
     message(STATUS "Plugin ${plugin_name} provides modules: ${plugin_modules}")
     add_library(${plugin_name} ${rime_plugin_boilerplate_src} ${plugin_objs})
     target_link_libraries(${plugin_name} ${plugin_deps})
+    remove_static_libs(${plugin_name})  # HACK: prevent static libs from being linked
     set_target_properties(${plugin_name}
       PROPERTIES
       LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib/${RIME_PLUGINS_DIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,7 +82,7 @@ endif()
 
 if(BUILD_SHARED_LIBS)
   add_library(rime ${rime_src})
-  target_link_libraries(rime ${rime_deps})
+  target_link_libraries(rime PUBLIC ${rime_deps})
   set_target_properties(rime PROPERTIES
     DEFINE_SYMBOL "RIME_EXPORTS"
     VERSION ${rime_version}
@@ -165,7 +165,7 @@ if(BUILD_SHARED_LIBS)
   endif()
 else()
   add_library(rime-static STATIC ${rime_src})
-  target_link_libraries(rime-static ${rime_deps})
+  target_link_libraries(rime-static PUBLIC ${rime_deps})
   set_target_properties(rime-static PROPERTIES
     OUTPUT_NAME "rime" PREFIX "lib"
     ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)


### PR DESCRIPTION
This will, e.g., cause glog to be included in multiple binaries.

fixes #983
