### PR TITLE
feat(deployer): allow disabling backup_config_files

### DIFF
--- a/src/rime/deployer.cc
+++ b/src/rime/deployer.cc
@@ -18,7 +18,8 @@ Deployer::Deployer()
       prebuilt_data_dir("build"),
       staging_dir("build"),
       sync_dir("sync"),
-      user_id("unknown") {}
+      user_id("unknown"),
+      backup_config_files(false) {}
 
 Deployer::~Deployer() {
   JoinWorkThread();

--- a/src/rime/deployer.cc
+++ b/src/rime/deployer.cc
@@ -19,7 +19,7 @@ Deployer::Deployer()
       staging_dir("build"),
       sync_dir("sync"),
       user_id("unknown"),
-      backup_config_files(false) {}
+      backup_config_files(true) {}
 
 Deployer::~Deployer() {
   JoinWorkThread();

--- a/src/rime/deployer.h
+++ b/src/rime/deployer.h
@@ -42,6 +42,7 @@ class Deployer : public Messenger {
   string distribution_code_name;
   string distribution_version;
   string app_name;
+  bool backup_config_files;
   // }
 
   RIME_DLL Deployer();

--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -110,6 +110,10 @@ bool InstallationUpdate::Run(Deployer* deployer) {
       deployer->sync_dir = user_data_path / "sync";
     }
     LOG(INFO) << "sync dir: " << deployer->sync_dir;
+    bool backup_config_files;
+    if (config.GetBool("backup_config_files", &backup_config_files)) {
+      deployer->backup_config_files = backup_config_files;
+    }
     if (config.GetString("distribution_code_name", &last_distro_code_name)) {
       LOG(INFO) << "previous distribution: " << last_distro_code_name;
     }
@@ -535,6 +539,10 @@ static bool IsCustomizedCopy(const path& file_path) {
 }
 
 bool BackupConfigFiles::Run(Deployer* deployer) {
+  if (!deployer->backup_config_files) {
+    LOG(INFO) << "skip backing up config files because it's disabled.";
+    return true;
+  }
   LOG(INFO) << "backing up config files.";
   const path user_data_path(deployer->user_data_dir);
   if (!fs::exists(user_data_path))


### PR DESCRIPTION
虽然可以理解 `backup_config_files` 最初的目的，但目前的生态下，该功能已经没有什么作用了。

1. 它并不备份 lua 和 opencc 配置，所以备份得到的配置可能是不能用的
2. 它会直接覆盖掉之前的配置，不能避免误操作，所以还是无法给人放心的感觉
3. 拖慢「同步」速度

大部分讲究的用户会用 Plum/Git 等管理配置，再单独「同步」用户词库。这样 `backup_config_files` 就完全没有用了。而不讲究的用户可能本来就不知道这里有备份。

本 PR 在 installation.yaml 中增加一笔 `backup_config_files` 选项，置为 false 后则不再执行备份操作。 ~~默认值也直接改为 false。至于应否设为 true，还待商榷。~~ reverted, 默认保持原行为不变。