### PR TITLE
ci: fix lint, always lint with clang-format 18.1.8

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -7,15 +7,37 @@ on:
     tags:
       - '![0-9]+.*'
   pull_request:
+  workflow_dispatch:
 
 jobs:
   lint:
-    runs-on: macos-14
+    runs-on: windows-2019
     steps:
       - name: Checkout last commit
         uses: actions/checkout@v4
-      - name: Install latest lang-format
-        run: brew update && brew install clang-format
+      - name: Install clang-format@18
+        shell: pwsh
+        run: |
+          $version = ""
+          if (Get-Command "clang-format" -ErrorAction SilentlyContinue){
+            $version = clang-format --version
+            $pat = ".*\s+(\d+\.\d+\.\d+)"
+            if ($version -match $pat) {
+              $version = $matches[1]
+            }
+          }
+          if ($version -ne "") {
+            Write-Host "clang-format version：$version"
+            if ([version]$version -eq [version]"18.1.8") {
+              Write-Host "clang-format OK"
+            } else {
+              Write-Host "clang-format version does not meet"
+              choco install llvm --version=18.1.8 --force
+            }
+          } else {
+            Write-Host "clang-format not installed"
+            choco install llvm --version=18.1.8
+          }
       - name: Code style lint
         run: make clang-format-lint
 


### PR DESCRIPTION
ci: add workflow_dispatch for commit-ci

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

lint job might failed if the clang-format version of ci host changed.

#### Feature
Describe feature of pull request

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
