### PR TITLE
fix(cmake): replace include() with find_package() to avoid calling find_package_handle_standard_args() twice with different arguments

### DIFF
--- a/cmake/RimeConfig.cmake
+++ b/cmake/RimeConfig.cmake
@@ -18,7 +18,7 @@ if(Rime_INCLUDE_DIR AND Rime_LIBRARIES)
     set(Rime_FIND_QUIETLY TRUE)
 endif(Rime_INCLUDE_DIR AND Rime_LIBRARIES)
 
-include(FindPkgConfig)
+find_package(PkgConfig)
 PKG_CHECK_MODULES(PC_Rime rime)
 
 find_path(Rime_INCLUDE_DIR


### PR DESCRIPTION
## Pull request

#### Issue tracker

This pull request is to fix a cmake warning while building [ibus-rime](https://github.com/rime/ibus-rime). Please check out [CMake Warning - The package name passed to find_package_handle_standard_args (PkgConfig) does not match the name of the calling package (Rime)](https://github.com/rime/ibus-rime/issues/199) for more details.
