### PR TITLE
feat(translator_commons): add `dictionary_exclude` to exclude words

### DIFF
--- a/src/rime/dict/dictionary.cc
+++ b/src/rime/dict/dictionary.cc
@@ -137,6 +137,7 @@ void DictEntryIterator::AddFilter(DictEntryFilter filter) {
   // the introduced filter could invalidate the current or even all the
   // remaining entries
   while (!exhausted() && !filter_(Peek())) {
+    entry_.reset();
     FindNextEntry();
   }
 }

--- a/src/rime/dict/dictionary.h
+++ b/src/rime/dict/dictionary.h
@@ -71,17 +71,20 @@ class Dictionary : public Class<Dictionary, const Ticket&> {
   RIME_DLL bool Remove();
   RIME_DLL bool Load();
 
-  RIME_DLL an<DictEntryCollector> Lookup(const SyllableGraph& syllable_graph,
-                                         size_t start_pos,
-                                         bool predict_word = false,
-                                         double initial_credibility = 0.0);
+  RIME_DLL an<DictEntryCollector> Lookup(
+      const SyllableGraph& syllable_graph,
+      size_t start_pos,
+      const hash_set<string>* blacklist = nullptr,
+      bool predict_word = false,
+      double initial_credibility = 0.0);
   // if predictive is true, do an expand search with limit,
   // otherwise do an exact match.
   // return num of matching keys.
   RIME_DLL size_t LookupWords(DictEntryIterator* result,
                               const string& str_code,
                               bool predictive,
-                              size_t limit = 0);
+                              size_t limit = 0,
+                              const hash_set<string>* blacklist = nullptr);
   // translate syllable id sequence to string code
   RIME_DLL bool Decode(const Code& code, vector<string>* result);
 

--- a/src/rime/gear/reverse_lookup_translator.cc
+++ b/src/rime/gear/reverse_lookup_translator.cc
@@ -172,7 +172,7 @@ an<Translation> ReverseLookupTranslator::Query(const string& input,
   bool quality = false;
   if (start < input.length()) {
     if (options_ && options_->enable_completion()) {
-      dict_->LookupWords(&iter, code, true, 100);
+      dict_->LookupWords(&iter, code, true, 100, nullptr);
       quality = !iter.exhausted() && (iter.Peek()->remaining_code_length == 0);
     } else {
       // 2012-04-08 gongchen: fetch multi-syllable words from rev-lookup table

--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -6,11 +6,11 @@
 //
 // 2011-07-10 GONG Chen <chen.sst@gmail.com>
 //
-#include <algorithm>
 #include <stack>
 #include <cmath>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/reversed.hpp>
+#include <rime/common.h>
 #include <rime/composition.h>
 #include <rime/candidate.h>
 #include <rime/config.h>
@@ -368,7 +368,8 @@ bool ScriptTranslation::Evaluate(Dictionary* dict, UserDictionary* user_dict) {
   bool predict_word = translator_->enable_word_completion() &&
                       start_ + consumed == end_of_input_;
 
-  phrase_ = dict->Lookup(syllable_graph, 0, predict_word);
+  phrase_ =
+      dict->Lookup(syllable_graph, 0, &translator_->blacklist(), predict_word);
   if (user_dict) {
     const size_t kUnlimitedDepth = 0;
     const size_t kNumSyllablesToPredictWord = 4;
@@ -578,7 +579,8 @@ an<Sentence> ScriptTranslation::MakeSentence(Dictionary* dict,
                                       kMaxSyllablesForUserPhraseQuery));
     }
     // merge lookup results
-    EnrollEntries(same_start_pos, dict->Lookup(syllable_graph, x.first));
+    EnrollEntries(same_start_pos, dict->Lookup(syllable_graph, x.first,
+                                               &translator_->blacklist()));
   }
   if (auto sentence =
           poet_->MakeSentence(graph, syllable_graph.interpreted_length,

--- a/src/rime/gear/table_translator.cc
+++ b/src/rime/gear/table_translator.cc
@@ -131,6 +131,7 @@ class LazyTableTranslation : public TableTranslation {
 
  private:
   Dictionary* dict_;
+  const hash_set<string>* blacklist_;
   UserDictionary* user_dict_;
   size_t limit_;
   size_t user_dict_limit_;
@@ -150,6 +151,7 @@ LazyTableTranslation::LazyTableTranslation(TableTranslator* translator,
                        end,
                        preedit),
       dict_(translator->dict()),
+      blacklist_(&translator->blacklist()),
       user_dict_(enable_user_dict ? translator->user_dict() : NULL),
       limit_(kInitialSearchLimit),
       user_dict_limit_(kInitialSearchLimit) {
@@ -191,7 +193,7 @@ bool LazyTableTranslation::FetchMoreTableEntries() {
   DLOG(INFO) << "fetching more table entries: limit = " << limit_
              << ", count = " << previous_entry_count;
   DictEntryIterator more;
-  if (dict_->LookupWords(&more, input_, true, limit_) < limit_) {
+  if (dict_->LookupWords(&more, input_, true, limit_, blacklist_) < limit_) {
     DLOG(INFO) << "all table entries obtained.";
     limit_ = 0;  // no more try
   } else {
@@ -263,7 +265,7 @@ an<Translation> TableTranslator::Query(const string& input,
   } else {
     DictEntryIterator iter;
     if (dict_ && dict_->loaded()) {
-      dict_->LookupWords(&iter, code, false);
+      dict_->LookupWords(&iter, code, false, 0, &blacklist());
     }
     UserDictEntryIterator uter;
     if (enable_user_dict) {
@@ -645,7 +647,8 @@ an<Translation> TableTranslator::MakeSentence(const string& input,
         if (homographs.size() >= max_homographs_)
           continue;
         DictEntryIterator iter;
-        dict_->LookupWords(&iter, active_input.substr(0, m.length), false);
+        dict_->LookupWords(&iter, active_input.substr(0, m.length), false, 0,
+                           &blacklist());
         if (filter_by_charset) {
           iter.AddFilter(CharsetFilter::FilterDictEntry);
         }

--- a/src/rime/gear/translator_commons.cc
+++ b/src/rime/gear/translator_commons.cc
@@ -145,6 +145,16 @@ TranslatorOptions::TranslatorOptions(const Ticket& ticket) {
           tags_.push_back(value->str());
     if (tags_.empty())
       tags_.push_back("abc");
+
+    // blacklist
+    if (auto blacklist =
+            config->GetList(ticket.name_space + "/dictionary_exclude")) {
+      for (auto it = blacklist->begin(); it != blacklist->end(); ++it) {
+        if (auto blackword = As<ConfigValue>(*it)) {
+          blacklist_.insert(blackword->str());
+        }
+      }
+    }
   }
   if (delimiters_.empty()) {
     delimiters_ = " ";

--- a/src/rime/gear/translator_commons.h
+++ b/src/rime/gear/translator_commons.h
@@ -167,6 +167,7 @@ class TranslatorOptions {
   void set_initial_quality(double quality) { initial_quality_ = quality; }
   Projection& preedit_formatter() { return preedit_formatter_; }
   Projection& comment_formatter() { return comment_formatter_; }
+  const hash_set<string>& blacklist() { return blacklist_; }
 
  protected:
   string delimiters_;
@@ -178,6 +179,7 @@ class TranslatorOptions {
   Projection preedit_formatter_;
   Projection comment_formatter_;
   Patterns user_dict_disabling_patterns_;
+  hash_set<string> blacklist_;
 };
 
 }  // namespace rime


### PR DESCRIPTION
closes #883 

该 PR 新增 `translator/dictionary_exclude`

```
translator:
  dictionary: luna_pinyin
  dictionary_exclude: 
    - 零零
```

其语义严格等价于从 .dict.yaml 中删除对应词条，但不影响组句和用户词库，即用户依然可以选字打出对应词。在上面的例子中， luna_pinyin 在用户词库为空时，将无法输出「零零」，但用户可以依次选取2次「零」造词，之后又可以直接输出「零零」。

未解决问题：
- 是否应该使用外部 .txt 或 .dict.yaml 文件、而非 schema.yaml 来指定黑名单？
