### PR TITLE
fix(ascii_composer): Fix good old caps lock behavior

### DIFF
--- a/src/rime/gear/ascii_composer.cc
+++ b/src/rime/gear/ascii_composer.cc
@@ -143,7 +143,9 @@ ProcessResult AsciiComposer::ProcessCapsLock(const KeyEvent& key_event) {
       // Caps Lock modifier has been set before we process VK_CAPITAL.
       // here we assume IBus' behavior and invert caps with ! operation.
       SwitchAsciiMode(!key_event.caps(), caps_lock_switch_style_);
-      return kAccepted;
+      // When good_old_caps_lock is enabled, allow the key event to pass
+      // through the input method to toggle the Caps Lock state.
+      return good_old_caps_lock_ ? kRejected : kAccepted;
     } else {
       return kRejected;
     }


### PR DESCRIPTION
## Pull request

#### Issue tracker

Fixes rime/ibus-rime#171

#### Feature

Recent version of GNOME inspect how input methods handle the Caps Lock key. If the key event is consumed by the input method, the desktop environment no longer toggles the Caps Lock state, which can lead to unexpected behavior.

This patch allows the Caps Lock key event to pass through the input method when `good_old_caps_lock` is enabled, restoring the expected toggle behavior.

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
