### PR TITLE
feat(script_translator): learn new phrases automatically from segmentations

### DIFF
--- a/src/rime/gear/memory.h
+++ b/src/rime/gear/memory.h
@@ -30,6 +30,7 @@ struct CommitEntry : DictEntry {
   void Clear();
   void AppendPhrase(const an<Phrase>& phrase);
   bool Save() const;
+  int Length() const;
 };
 
 class Memory {
@@ -38,7 +39,8 @@ class Memory {
   virtual ~Memory();
 
   virtual bool Memorize(const CommitEntry& commit_entry) = 0;
-
+  virtual bool ProcessSegmentOnCommit(CommitEntry& commit_entry,
+                                      const Segment& seg);
   bool StartSession();
   bool FinishSession();
   bool DiscardSession();

--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -229,6 +229,7 @@ bool ScriptTranslator::ProcessSegmentOnCommit(CommitEntry& commit_entry,
   bool recognized = Language::intelligible(phrase, this);
   if (recognized) {
     if (commit_entry.Length() > max_word_length_) {
+      UpdateElements(commit_entry);
       commit_entry.Clear();
     }
 
@@ -243,6 +244,8 @@ bool ScriptTranslator::ProcessSegmentOnCommit(CommitEntry& commit_entry,
   if (!recognized || seg.status >= Segment::kConfirmed) {
     if (commit_entry.Length() <= max_word_length_) {
       commit_entry.Save();
+    } else {
+      UpdateElements(commit_entry);
     }
     commit_entry.Clear();
   }
@@ -272,7 +275,7 @@ string ScriptTranslator::GetPrecedingText(size_t start) const {
                      : engine_->context()->commit_history().latest_text();
 }
 
-bool ScriptTranslator::Memorize(const CommitEntry& commit_entry) {
+bool ScriptTranslator::UpdateElements(const CommitEntry& commit_entry) {
   bool update_elements = false;
   // avoid updating single character entries within a phrase which is
   // composed with single characters only
@@ -289,6 +292,11 @@ bool ScriptTranslator::Memorize(const CommitEntry& commit_entry) {
       user_dict_->UpdateEntry(*e, 0);
     }
   }
+  return true;
+}
+
+bool ScriptTranslator::Memorize(const CommitEntry& commit_entry) {
+  UpdateElements(commit_entry);
   user_dict_->UpdateEntry(commit_entry, 1);
   return true;
 }

--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -248,7 +248,7 @@ bool ScriptTranslator::ProcessSegmentOnCommit(CommitEntry& commit_entry,
     }
 
     if (exceed_upperlimit(commit_entry.Length() + phrase->code().size(),
-                            core_word_length())) {
+                          core_word_length())) {
       commit_entry.Save();
       commit_entry.Clear();
     }

--- a/src/rime/gear/script_translator.h
+++ b/src/rime/gear/script_translator.h
@@ -41,6 +41,10 @@ class ScriptTranslator : public Translator,
   string GetPrecedingText(size_t start) const;
   bool UpdateElements(const CommitEntry& commit_entry);
 
+  bool ConcatenatePhrases(CommitEntry& commit_entry,
+                          const vector<an<Phrase>>& phrases);
+  bool SaveCommitEntry(CommitEntry& commit_entry);
+
   // options
   int max_homophones() const { return max_homophones_; }
   int spelling_hints() const { return spelling_hints_; }
@@ -59,6 +63,7 @@ class ScriptTranslator : public Translator,
   bool enable_word_completion_ = false;
   the<Corrector> corrector_;
   the<Poet> poet_;
+  vector<an<Phrase>> queue_;
 };
 
 }  // namespace rime

--- a/src/rime/gear/script_translator.h
+++ b/src/rime/gear/script_translator.h
@@ -46,12 +46,14 @@ class ScriptTranslator : public Translator,
   int spelling_hints() const { return spelling_hints_; }
   bool always_show_comments() const { return always_show_comments_; }
   bool enable_word_completion() const { return enable_word_completion_; }
+  int max_word_length() const { return max_word_length_; }
+  int core_word_length() const;
 
  protected:
   int max_homophones_ = 1;
   int spelling_hints_ = 0;
-  int max_word_length_ = 7;
-  int core_word_length_ = 4;
+  int max_word_length_ = 0;
+  int core_word_length_ = 0;
   bool always_show_comments_ = false;
   bool enable_correction_ = false;
   bool enable_word_completion_ = false;

--- a/src/rime/gear/script_translator.h
+++ b/src/rime/gear/script_translator.h
@@ -39,6 +39,7 @@ class ScriptTranslator : public Translator,
   string FormatPreedit(const string& preedit);
   string Spell(const Code& code);
   string GetPrecedingText(size_t start) const;
+  bool UpdateElements(const CommitEntry& commit_entry);
 
   // options
   int max_homophones() const { return max_homophones_; }

--- a/src/rime/gear/script_translator.h
+++ b/src/rime/gear/script_translator.h
@@ -30,8 +30,11 @@ class ScriptTranslator : public Translator,
  public:
   ScriptTranslator(const Ticket& ticket);
 
-  virtual an<Translation> Query(const string& input, const Segment& segment);
-  virtual bool Memorize(const CommitEntry& commit_entry);
+  virtual an<Translation> Query(const string& input,
+                                const Segment& segment) override;
+  virtual bool Memorize(const CommitEntry& commit_entry) override;
+  virtual bool ProcessSegmentOnCommit(CommitEntry& commit_entry,
+                                      const Segment& seg) override;
 
   string FormatPreedit(const string& preedit);
   string Spell(const Code& code);
@@ -46,6 +49,8 @@ class ScriptTranslator : public Translator,
  protected:
   int max_homophones_ = 1;
   int spelling_hints_ = 0;
+  int max_word_length_ = 7;
+  int core_word_length_ = 4;
   bool always_show_comments_ = false;
   bool enable_correction_ = false;
   bool enable_word_completion_ = false;


### PR DESCRIPTION
#### Feature

feat(script_translator): learn new phrases automatically from segmentations

* separate new phrases by segmentations rather than using the sentence
  as a whole, while committing into user\_dictionary

* join adjacent segments if the result is no longer than core\_word\_length

* ignore the phrases which are longer than max\_word\_length

##### Examples

在整句輸入時，通過斷句（由光標或選詞等產生）學習新詞，而不是學習整句作為新詞，然後寫入用戶詞典。
例如： 在下表中，句子中的符號‘|’，表示斷句的位置；且參數<code>max_word_length</code>和<code>core_word_length</code>，分別配置為7和4. 

| 學習的新詞 | 整句輸入時的斷句| 記錄的詞數  |
| ----- | -----------------------|------------ |
| 去畫    | 一旦嘗試\|去\|畫\|示意圖     |    3  |
| 和式    | 總是比把除數寫成\|和式\|要更方便些 |  2 （忽略 1）  |
| 它     | 它\|是我的一個東西          |   2   |
| 它     | 要做的就是簡化\|它          |   2   |
| 有歧義   | 這是\|有歧義\| 的一句話 |  3  |
| 他們是   | 我知道\|他們\|是\|可愛的人    |  3    |

**說明**：

1. 斷句產生的多個相鄰片段（segment），如果合併後長度不超過 <code>core_word_length</code>，將會合併成一個詞；其餘每個片段（segment）生成一個詞。
2. 產生的詞，如果長度不超過 <code>max_word_length</code> ，則記錄到用戶詞典中，尤其是作為學到的新詞；否則，只更新其構成元素（elements）的權重。
3. 產生的詞彙，通過音節或codes數，計算詞長。
4. 參數<code>core_word_length</code>生效的取值，不超過參數<code>max_word_length</code>的取值。 
5. 該功能默認關閉。若配置參數<code>core_word_length</code>為大於0的值時，從斷句片段學習新詞的功能開啟，否則維持原來行為方式；若配置<code>max_word_length</code> 為大於0 的值時，將按長度過濾新生成的用戶詞彙，否則維持原來行為方式。

#### Unit test

* [x] Done

#### Manual test

* [x] Done

#### Code Review

1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
7. Can be merged clean without conflicts
8. PR will be merged by rebase upstream base

#### Additional Info