### PR TITLE
ci: update runner windows-2019 to windows-latest

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - name: Checkout last commit
         uses: actions/checkout@v4


### PR DESCRIPTION
Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
