### PR TITLE
Fix non-void function does not return a value

### DIFF
--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -266,6 +266,8 @@ bool ScriptTranslator::ConcatenatePhrases(CommitEntry& commit_entry,
   }
   SaveCommitEntry(commit_entry);
   commit_entry.Clear();
+
+  return true;
 }
 
 bool ScriptTranslator::ProcessSegmentOnCommit(CommitEntry& commit_entry,


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fix build error with Trime.

```
.../github/trime/app/src/main/jni/librime/src/rime/gear/script_translator.cc:269:1: error: non-void function does not return a value [-Werror,-Wreturn-type]
    269 | }
        | ^
  1 error generated.
```

#### Feature
Describe feature of pull request

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
