### PR TITLE
ci: use the macos-15 runner image

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -15,11 +15,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [macos-13, macos-14]
+        runs-on: [macos-13, macos-15]
         include:
           - runs-on: macos-13
             create-distributable: false
-          - runs-on: macos-14
+          - runs-on: macos-15
             create-distributable: true
             build_variant: universal
     env:


### PR DESCRIPTION

## Pull request

#### Issue tracker
Fixes will automatically close the related issue
Use the macos-15 runner image

https://github.blog/changelog/2025-04-10-github-actions-macos-15-and-windows-2025-images-are-now-generally-available/

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
