### PR TITLE
ci: fix wrong filter on push event

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -3,9 +3,9 @@ name: Commit CI
 on:
   push:
     branches:
-      - '!master'
-    tags:
-      - '![0-9]+.*'
+      - '**'
+    tags-ignore:
+      - '**'
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

The forked repo non main branch won't trigger workflow, is hard for
preparing pull request on non main branch in forked repo.

First of all, we should trigger push event on any branch, the current
filter is wrong, which won't trigger workflow on **forked repo** push event.

The grammar is wrong by the document: https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#example-including-and-excluding-branches

> If you define a branch with the ! character, you must also define at least one branch without the ! character. If you only want to exclude branches, use branches-ignore instead.

Secondly, the main branch should trigger commit build in case of merge or rebase
with pull requests.

#### Feature
Describe feature of pull request

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
