### PR TITLE
ci: use clang-format from apt llvm

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -11,33 +11,15 @@ on:
 
 jobs:
   lint:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout last commit
         uses: actions/checkout@v4
-      - name: Install clang-format@18
-        shell: pwsh
+
+      - name: Install clang-format-18
         run: |
-          $version = ""
-          if (Get-Command "clang-format" -ErrorAction SilentlyContinue){
-            $version = clang-format --version
-            $pat = ".*\s+(\d+\.\d+\.\d+)"
-            if ($version -match $pat) {
-              $version = $matches[1]
-            }
-          }
-          if ($version -ne "") {
-            Write-Host "clang-format version：$version"
-            if ([version]$version -eq [version]"18.1.8") {
-              Write-Host "clang-format OK"
-            } else {
-              Write-Host "clang-format version does not meet"
-              choco install llvm --version=18.1.8 --force
-            }
-          } else {
-            Write-Host "clang-format not installed"
-            choco install llvm --version=18.1.8
-          }
+          ./action-install-clang-format.sh 18
+
       - name: Code style lint
         run: make clang-format-lint
 

--- a/action-install-clang-format.sh
+++ b/action-install-clang-format.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# https://apt.llvm.org/
+sudo apt install -y wget
+wget https://apt.llvm.org/llvm.sh
+chmod +x llvm.sh
+sudo ./llvm.sh $1
+sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-$1 100


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Most of C++ developers prefer Unix box, so we should use the Unix for style check.
1. The lint time decrease from 1m 47s to 28s which is an improvement of 73.83%.
2. Upgrade clang-format is easier with one parameter.
3. llvm apt support Debian and Ubuntu distribution.
4. Improve CI waiting time for developer.

#### Feature
Describe feature of pull request

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
