### PR TITLE
chore: upgrade boost to 1.88.0

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -23,8 +23,8 @@ jobs:
             create-distributable: true
             build_variant: universal
     env:
-      boost_version: 1.84.0
-      BOOST_ROOT: ${{ github.workspace }}/deps/boost-1.84.0
+      boost_version: 1.88.0
+      BOOST_ROOT: ${{ github.workspace }}/deps/boost-1.88.0
       RIME_PLUGINS: ${{ inputs.rime_plugins }}
     steps:
       - name: Checkout last commit

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -23,8 +23,8 @@ jobs:
           - { compiler: clang, cc: clang, cxx: clang++ }
           - { compiler: msvc, arch: x86, cross_arch: x64_x86 }
     env:
-      boost_version: 1.84.0
-      BOOST_ROOT: ${{ github.workspace }}\deps\boost-1.84.0
+      boost_version: 1.88.0
+      BOOST_ROOT: ${{ github.workspace }}\deps\boost-1.88.0
       RIME_PLUGINS: ${{ inputs.rime_plugins }}
 
     steps:

--- a/README-mac.md
+++ b/README-mac.md
@@ -47,7 +47,7 @@ Set shell variable `BOOST_ROOT` to the path to `boost-<version>` directory prior
 to building librime.
 
 ``` sh
-export BOOST_ROOT="$(pwd)/deps/boost-1.84.0"
+export BOOST_ROOT="$(pwd)/deps/boost-1.88.0"
 ```
 
 **Option 2:** Install Boost libraries from Homebrew.

--- a/env.bat.template
+++ b/env.bat.template
@@ -3,7 +3,7 @@ rem Customize your build environment and save the modified copy to env.bat
 set RIME_ROOT=%CD%
 
 rem REQUIRED: path to Boost source directory
-if not defined BOOST_ROOT set BOOST_ROOT=%RIME_ROOT%\deps\boost-1.84.0
+if not defined BOOST_ROOT set BOOST_ROOT=%RIME_ROOT%\deps\boost-1.88.0
 
 rem architecture, Visual Studio version and platform toolset
 set ARCH=Win32

--- a/env.vs2019.bat
+++ b/env.vs2019.bat
@@ -3,7 +3,7 @@ rem Customize your build environment and save the modified copy to env.bat
 set RIME_ROOT=%CD%
 
 rem REQUIRED: path to Boost source directory
-if not defined BOOST_ROOT set BOOST_ROOT=%RIME_ROOT%\deps\boost-1.84.0
+if not defined BOOST_ROOT set BOOST_ROOT=%RIME_ROOT%\deps\boost-1.88.0
 
 rem architecture, Visual Studio version and platform toolset
 set ARCH=Win32

--- a/env.vs2022.bat
+++ b/env.vs2022.bat
@@ -3,7 +3,7 @@ rem Customize your build environment and save the modified copy to env.bat
 set RIME_ROOT=%CD%
 
 rem REQUIRED: path to Boost source directory
-if not defined BOOST_ROOT set BOOST_ROOT=%RIME_ROOT%\deps\boost-1.84.0
+if not defined BOOST_ROOT set BOOST_ROOT=%RIME_ROOT%\deps\boost-1.88.0
 
 rem architecture, Visual Studio version and platform toolset
 set ARCH=Win32

--- a/install-boost.bat
+++ b/install-boost.bat
@@ -2,16 +2,19 @@ setlocal
 
 if not defined RIME_ROOT set RIME_ROOT=%CD%
 
-if not defined boost_version set boost_version=1.84.0
+if not defined boost_version set boost_version=1.88.0
+
+if not defined boost_tarball set boost_tarball=boost_%boost_version:.=_%
 
 if not defined BOOST_ROOT set BOOST_ROOT=%RIME_ROOT%\deps\boost-%boost_version%
 
 if exist "%BOOST_ROOT%\libs" goto boost_found
 for %%I in ("%BOOST_ROOT%\.") do set src_dir=%%~dpI
 rem download boost source
-aria2c https://github.com/boostorg/boost/releases/download/boost-%boost_version%/boost-%boost_version%.7z -d %src_dir%
+aria2c https://archives.boost.io/release/%boost_version%/source/%boost_tarball%.7z -d %src_dir%
 pushd %src_dir%
-7z x boost-%boost_version%.7z
+7z x %boost_tarball%.7z
+ren %boost_tarball% boost-%boost_version%
 cd boost-%boost_version%
 call .\bootstrap.bat
 .\b2 headers

--- a/install-boost.sh
+++ b/install-boost.sh
@@ -3,13 +3,13 @@ set -ex
 
 RIME_ROOT="$(cd "$(dirname "$0")"; pwd)"
 
-boost_version="${boost_version=1.84.0}"
+boost_version="${boost_version=1.88.0}"
 
 BOOST_ROOT="${BOOST_ROOT=${RIME_ROOT}/deps/boost-${boost_version}}"
 
-boost_tarball="boost-${boost_version}.tar.xz"
-download_url="https://github.com/boostorg/boost/releases/download/boost-${boost_version}/${boost_tarball}"
-boost_tarball_sha256sum="2e64e5d79a738d0fa6fb546c6e5c2bd28f88d268a2a080546f74e5ff98f29d0e  ${boost_tarball}"
+boost_tarball="boost_${boost_version//./_}.tar.gz"
+download_url="https://archives.boost.io/release/${boost_version}/source/${boost_tarball}"
+boost_tarball_sha256sum="3621533e820dcab1e8012afd583c0c73cf0f77694952b81352bf38c1488f9cb4  ${boost_tarball}"
 
 download_boost_source() {
     cd "${RIME_ROOT}/deps"
@@ -17,7 +17,8 @@ download_boost_source() {
         curl -LO "${download_url}"
     fi
     echo "${boost_tarball_sha256sum}" | shasum -a 256 -c
-    tar -xJf "${boost_tarball}"
+    tar -xzf "${boost_tarball}"
+    mv "boost_${boost_version//./_}" "boost-${boost_version}"
     [[ -f "${BOOST_ROOT}/bootstrap.sh" ]]
 }
 


### PR DESCRIPTION

## Pull request

This verison is verified in Trime(https://github.com/osfans/trime/pull/1646) about three months ago, no issue found.

Due to boost release in GitHub was split to *.cmake and *.b2, so we use the
boost official release in https://www.boost.org/releases/latest/

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
