### PR TITLE
docs(README): add Readline frontend [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Community:
   - [fcitx5-ui.nvim](https://github.com/black-desk/fcitx5-ui.nvim): Fcitx5 frontend for Vim
   - [tmux-rime](https://github.com/Freed-Wu/tmux-rime): frontend for Tmux
   - [rl_custom_rime](https://github.com/Freed-Wu/rl_custom_rime): frontend for Readline
+  - [ARIF](https://www.nongnu.org/arif/): frontend for Readline
   - [zsh-rime](https://github.com/Freed-Wu/zsh-rime): frontend for Zsh
   - [pyrime](https://github.com/Freed-Wu/pyrime): frontend for Ptpython
   - [fcitx-rime](https://github.com/fcitx/fcitx-rime): Fcitx frontend for Linux


### PR DESCRIPTION
ARIF 是一个轻量的输入法框架，目前支持 Readline 作为前端，Rime 作为引擎。
该项目最初是为了满足个人需求而开发，使用过程中逐渐完善，现已基本稳定。

希望能够给更多有类似需求的用户带来方便，故申请收录。