### PR TITLE
fix(composition): skip phony segments in GetScriptText

### DIFF
--- a/src/rime/composition.cc
+++ b/src/rime/composition.cc
@@ -132,7 +132,7 @@ string Composition::GetScriptText(bool keep_selection) const {
       result += cand->text();
     else if (cand && !cand->preedit().empty())
       result += boost::erase_first_copy(cand->preedit(), "\t");
-    else
+    else if (!seg.HasTag("phony"))
       result += input_.substr(start, end - start);
   }
   if (input_.length() > end) {


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
问题：在 editor 配置了 commit_script_text 后，触发该操作时 phony segment 的 input 会被一起输出出来
我发现在 GetPreedit 和 GetCommitText 中都对 phony 进行了过滤，也许在 GetScriptText 里也应该这样做？

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
