### PR TITLE
feat: clear composition with a abortcomposition notification

### DIFF
--- a/src/rime/context.cc
+++ b/src/rime/context.cc
@@ -110,6 +110,11 @@ void Context::Clear() {
   update_notifier_(this);
 }
 
+void Context::AbortComposition() {
+  Clear();
+  abort_notifier_(this);
+}
+
 bool Context::Select(size_t index) {
   if (composition_.empty())
     return false;

--- a/src/rime/context.h
+++ b/src/rime/context.h
@@ -41,6 +41,8 @@ class RIME_DLL Context {
   bool PopInput(size_t len = 1);
   bool DeleteInput(size_t len = 1);
   void Clear();
+  // Clear and notify abort
+  void AbortComposition();
 
   // return false if there is no candidate at index
   bool Select(size_t index);
@@ -79,7 +81,6 @@ class RIME_DLL Context {
   // options and properties starting with '_' are local to schema;
   // others are session scoped.
   void ClearTransientOptions();
-  void AbortCompositionNotification() { abort_notifier_(this); }
 
   Notifier& commit_notifier() { return commit_notifier_; }
   Notifier& select_notifier() { return select_notifier_; }

--- a/src/rime/context.h
+++ b/src/rime/context.h
@@ -79,11 +79,13 @@ class RIME_DLL Context {
   // options and properties starting with '_' are local to schema;
   // others are session scoped.
   void ClearTransientOptions();
+  void AbortCompositionNotification() { abort_notifier_(this); }
 
   Notifier& commit_notifier() { return commit_notifier_; }
   Notifier& select_notifier() { return select_notifier_; }
   Notifier& update_notifier() { return update_notifier_; }
   Notifier& delete_notifier() { return delete_notifier_; }
+  Notifier& abort_notifier() { return abort_notifier_; }
   OptionUpdateNotifier& option_update_notifier() {
     return option_update_notifier_;
   }
@@ -106,6 +108,7 @@ class RIME_DLL Context {
   Notifier select_notifier_;
   Notifier update_notifier_;
   Notifier delete_notifier_;
+  Notifier abort_notifier_;
   OptionUpdateNotifier option_update_notifier_;
   PropertyUpdateNotifier property_update_notifier_;
   KeyEventNotifier unhandled_key_notifier_;

--- a/src/rime/service.cc
+++ b/src/rime/service.cc
@@ -45,8 +45,7 @@ bool Session::CommitComposition() {
 void Session::ClearComposition() {
   if (!engine_)
     return;
-  engine_->context()->Clear();
-  engine_->context()->AbortCompositionNotification();
+  engine_->context()->AbortComposition();
 }
 
 void Session::ApplySchema(Schema* schema) {

--- a/src/rime/service.cc
+++ b/src/rime/service.cc
@@ -46,6 +46,7 @@ void Session::ClearComposition() {
   if (!engine_)
     return;
   engine_->context()->Clear();
+  engine_->context()->AbortCompositionNotification();
 }
 
 void Session::ApplySchema(Schema* schema) {


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

add a notifier `abort_notifier_` for Context, call it in`rime_api->clear_composition()` after Context::Clear(). esp for notifying session is clear by external API. 

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info

