### PR TITLE
ci(macos-13): use system llvm

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -35,9 +35,8 @@ jobs:
 
       - name: Configure build environment
         run: |
-          brew install llvm ninja
+          brew install ninja
           echo "CMAKE_GENERATOR=Ninja"  >> $GITHUB_ENV
-          echo "/usr/local/opt/llvm/bin" >> $GITHUB_PATH
           echo git_ref_name="$(git describe --always)" >> $GITHUB_ENV
 
       - name: Configure build variant


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #
llvm/clang installed by homebrew  may be not abi compatable with system's stdc++ lib. it would cause `./install-boost.sh ` to fail.

#### Feature
Describe feature of pull request

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
