### PR TITLE
fix(vocabulary): Homophones sorting should be stable.

### DIFF
--- a/src/rime/dict/vocabulary.cc
+++ b/src/rime/dict/vocabulary.cc
@@ -80,8 +80,8 @@ inline bool dereference_less(const T& a, const T& b) {
 
 template <typename C>
 inline void sort(C& container) {
-  std::sort(std::begin(container), std::end(container),
-            dereference_less<typename C::value_type>);
+  std::stable_sort(std::begin(container), std::end(container),
+                   dereference_less<typename C::value_type>);
 }
 
 template <typename C>
@@ -90,7 +90,7 @@ inline void sort_range(C& container, size_t start, size_t count) {
     return;
   auto i(std::begin(container) + start);
   auto j(start + count >= container.size() ? std::end(container) : i + count);
-  std::sort(i, j, dereference_less<typename C::value_type>);
+  std::stable_sort(i, j, dereference_less<typename C::value_type>);
 }
 
 void ShortDictEntryList::Sort() {


### PR DESCRIPTION
在编译 table 时，有时可以观察到 `sort: by_weight` 的词典中，重码候选顺序会因为排序不稳定而乱掉，改为稳定排序即可修复。