### PR TITLE
ci: use macos-15-intel for retired macos-13

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [macos-13, macos-15]
+        runs-on: [macos-15-intel, macos-15]
         include:
-          - runs-on: macos-13
+          - runs-on: macos-15-intel
             create-distributable: false
           - runs-on: macos-15
             create-distributable: true


### PR DESCRIPTION

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
