### PR TITLE
chore: log warning on trash config

### DIFF
--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -437,8 +437,8 @@ bool ConfigFileUpdate::Run(Deployer* deployer) {
   path trash = user_data_path / "trash";
   if (TrashDeprecatedUserCopy(source_config_path, dest_config_path,
                               version_key_, trash)) {
-    LOG(INFO) << "deprecated user copy of '" << file_name_ << "' is moved to "
-              << trash;
+    LOG(WARNING) << "deprecated user copy of '" << file_name_
+                 << "' is moved to " << trash;
   }
   // build the config file if needs update
   the<Config> config(Config::Require("config")->Create(file_name_));


### PR DESCRIPTION
## Pull request

#### Feature
User config is automatically moved and needs manual intervention, so it shouldn't be INFO. It doesn't necessarily fail deployment so shouldn't be ERROR. WARNING is best.

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
