### PR TITLE
hide candidate in librime

### DIFF
--- a/src/rime_api_impl.h
+++ b/src/rime_api_impl.h
@@ -249,6 +249,10 @@ RIME_DEPRECATED Bool RimeGetContext(RimeSessionId session_id,
       context->menu.highlighted_candidate_index = selected_index % page_size;
       int i = 0;
       context->menu.num_candidates = page->candidates.size();
+      if (ctx->get_option("_hide_candidate")) {
+        context->menu.num_candidates = 0;
+        return True;
+      }
       context->menu.candidates = new RimeCandidate[page->candidates.size()];
       for (const an<Candidate>& cand : page->candidates) {
         RimeCandidate* dest = &context->menu.candidates[i++];


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #1112

#### Feature
This pull request introduces the ability to control whether the candidate list is displayed through a Rime option (_hide_candidate).

When the option `_hide_candidate ` is enabled, Rime sets `num_candidates` to 0. once the frontends like squirrel and weasel detect that `num_candidates` is 0, they will skip populating and showing the candidate list, allowing users or schemas to dynamically hide candidates without relying on theme configuration.
#### Unit test
- [ ] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
