### PR TITLE
fix: custom setting of default failed caused by default.custom.yaml nonexistence

### DIFF
--- a/src/rime/lever/custom_settings.cc
+++ b/src/rime/lever/custom_settings.cc
@@ -37,10 +37,12 @@ bool CustomSettings::Load() {
   }
   path custom_config_path =
       deployer_->user_data_dir / custom_config_file(config_id_);
+  modified_ = false;
   if (!custom_config_.LoadFromFile(custom_config_path)) {
+    LOG(WARNING) << "cannot find '" << config_id_ << ".custom.yaml'"
+                 << " in " << custom_config_path;
     return false;
   }
-  modified_ = false;
   return true;
 }
 

--- a/src/rime/lever/switcher_settings.cc
+++ b/src/rime/lever/switcher_settings.cc
@@ -19,7 +19,7 @@ SwitcherSettings::SwitcherSettings(Deployer* deployer)
     : CustomSettings(deployer, "default", "Rime::SwitcherSettings") {}
 
 bool SwitcherSettings::Load() {
-  CustomSettings::Load();
+  auto ret = CustomSettings::Load();
   available_.clear();
   selection_.clear();
   hotkeys_.clear();
@@ -27,7 +27,7 @@ bool SwitcherSettings::Load() {
   GetAvailableSchemasFromDirectory(deployer_->user_data_dir);
   GetSelectedSchemasFromConfig();
   GetHotkeysFromConfig();
-  return true;
+  return ret;
 }
 
 bool SwitcherSettings::Select(Selection selection) {

--- a/src/rime/lever/switcher_settings.cc
+++ b/src/rime/lever/switcher_settings.cc
@@ -19,8 +19,7 @@ SwitcherSettings::SwitcherSettings(Deployer* deployer)
     : CustomSettings(deployer, "default", "Rime::SwitcherSettings") {}
 
 bool SwitcherSettings::Load() {
-  if (!CustomSettings::Load())
-    return false;
+  CustomSettings::Load();
   available_.clear();
   selection_.clear();
   hotkeys_.clear();


### PR DESCRIPTION

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #
fix: custom setting of default failed caused by default.custom.yaml nonexistence

#### Feature
Describe feature of pull request

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
