### PR TITLE
倉頡候選項預設只該顯示單字，不該顯示詞組

### DIFF
--- a/data/minimal/cangjie5.dict.yaml
+++ b/data/minimal/cangjie5.dict.yaml
@@ -20,7 +20,7 @@
 name: "cangjie5"
 version: "0.17"
 sort: by_weight
-use_preset_vocabulary: true
+use_preset_vocabulary: false #想輸入詞組的用者請自行改成true
 max_phrase_length: 7
 min_phrase_weight: 100
 columns:

--- a/data/minimal/cangjie5.schema.yaml
+++ b/data/minimal/cangjie5.schema.yaml
@@ -64,7 +64,7 @@ translator:
   dictionary: cangjie5
   enable_charset_filter: true
   enable_sentence: true
-  enable_encoder: true
+  enable_encoder: false #想輸入詞組的用者請自行改成true
   encode_commit_history: true
   max_phrase_length: 5
   preedit_format:


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes rime/home#2073

#### Feature
我也有rime/home#88 的問題
倉頡輸入法本來就是爲減少單字重碼而設計，候選項根本就應該預設只列出單字，改造出輸入詞組的功能只可以算「模組」（mod），不可以視爲原味（vanilla），允許詞組作候選項不就有違初衷、適得其反了嗎？還是改回去吧！

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
