### PR TITLE
fix(script_translator): max word length should use word length

### DIFF
--- a/src/rime/gear/memory.cc
+++ b/src/rime/gear/memory.cc
@@ -16,6 +16,7 @@
 #include <rime/dict/user_dictionary.h>
 #include <rime/gear/memory.h>
 #include <rime/gear/translator_commons.h>
+#include <utf8.h>
 
 namespace rime {
 

--- a/src/rime/gear/memory.cc
+++ b/src/rime/gear/memory.cc
@@ -45,11 +45,16 @@ bool CommitEntry::Save() const {
   return false;
 }
 
-int CommitEntry::Length() const {
+int CommitEntry::TextLength() const {
   int length = 0;
   for (const DictEntry* e : elements) {
     if (e) {
-      length += e->code.size();
+      const char* it = e->text.c_str();
+      const char* end = e->text.c_str() + e->text.length();
+      while (it < end) {
+        length++;
+        utf8::unchecked::next(it);
+      }
     }
   }
   return length;

--- a/src/rime/gear/memory.h
+++ b/src/rime/gear/memory.h
@@ -30,7 +30,7 @@ struct CommitEntry : DictEntry {
   void Clear();
   void AppendPhrase(const an<Phrase>& phrase);
   bool Save() const;
-  int Length() const;
+  int TextLength() const;
 };
 
 class Memory {

--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -235,7 +235,7 @@ static bool exceed_upperlimit(int length, int upper_limit) {
 }
 
 bool ScriptTranslator::SaveCommitEntry(CommitEntry& commit_entry) {
-  if (exceed_upperlimit(commit_entry.Length(), max_word_length())) {
+  if (exceed_upperlimit(commit_entry.TextLength(), max_word_length())) {
     UpdateElements(commit_entry);
   } else {
     commit_entry.Save();


### PR DESCRIPTION
Prior to this change, max_word_length is only compared to total code length.