### PR TITLE
fix: add schema hidden flag

### DIFF
--- a/src/rime/schema.cc
+++ b/src/rime/schema.cc
@@ -35,6 +35,9 @@ void Schema::FetchUsefulConfigItems() {
   }
   config_->GetString("menu/alternative_select_keys", &select_keys_);
   config_->GetBool("menu/page_down_cycle", &page_down_cycle_);
+  if (!config_->GetBool("schema/hidden", &hidden_)) {
+    hidden_ = false;
+  }
 }
 
 Config* SchemaComponent::Create(const string& schema_id) {

--- a/src/rime/schema.h
+++ b/src/rime/schema.h
@@ -39,6 +39,7 @@ class Schema {
   // frequently used config items
   int page_size_ = 5;
   bool page_down_cycle_ = false;
+  bool hidden_ = false;
   string select_keys_;
 };
 


### PR DESCRIPTION
#### Feature
Introduces a `hidden` boolean property to the `Schema` class, parsing the `schema/hidden` configuration from `schema.yaml`. This establishes a standardized parameter for frontend applications to query.

#### Additional Info
Currently, it is a common practice for users to create "pseudo-schemas name" (伪方案) simply to mount dictionaries or serve as base dependencies for other schemas. Because frontends typically read and display all available schemas, these dependency-only schemas unnecessarily clutter the user's selection menu.

By introducing a `schema/hidden: true` flag, we provide an elegant, official convention for frontend developers to filter out these non-interactive schemas, eliminating the need for traditional, hacky workarounds.