### PR TITLE
fix(script_translator): excluded words cause crashes

### DIFF
--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -569,6 +569,7 @@ inline static bool prefer_user_phrase(
 }
 
 bool ScriptTranslation::PrepareCandidate() {
+iter_incremented:
   if (exhausted()) {
     candidate_source_ = kUninitialized;
     candidate_ = nullptr;
@@ -628,6 +629,10 @@ bool ScriptTranslation::PrepareCandidate() {
     return true;
   } else if (phrase_code_length > 0) {
     DictEntryIterator& iter = phrase_iter_->second;
+    if (iter.exhausted()) {
+      ++phrase_iter_;
+      goto iter_incremented;
+    }
     const auto& entry = iter.Peek();
     DLOG(INFO) << "phrase '" << entry->text
                << "', code length: " << phrase_code_length;


### PR DESCRIPTION
fix #1149 

之前對於每個 phrase length，phrase dict iter 一定會有至少一個結果。但在引入 dict_filter 後，對於某個 phrase length，有可能所有結果均被刪掉，導致其結果爲空。

本 PR 將 PrepareCandidate 邏輯修改爲循環，使之在某 iter 爲空時再繼續嘗試下一個 phrase length。