### PR TITLE
feat(dict): supports recursive import_tables flattening

### DIFF
--- a/data/test/dictionary_cycle_b.dict.yaml
+++ b/data/test/dictionary_cycle_b.dict.yaml
@@ -1,0 +1,9 @@
+---
+name: dictionary_cycle_b
+version: "1.0"
+sort: by_weight
+import_tables:
+  - dictionary_cycle_c
+...
+
+cb	cb	100

--- a/data/test/dictionary_cycle_c.dict.yaml
+++ b/data/test/dictionary_cycle_c.dict.yaml
@@ -1,0 +1,9 @@
+---
+name: dictionary_cycle_c
+version: "1.0"
+sort: by_weight
+import_tables:
+  - dictionary_cycle_test
+...
+
+cc	cc	100

--- a/data/test/dictionary_cycle_test.dict.yaml
+++ b/data/test/dictionary_cycle_test.dict.yaml
@@ -1,0 +1,10 @@
+---
+name: dictionary_cycle_test
+version: "1.0"
+sort: by_weight
+import_tables_recursive: true
+import_tables:
+  - dictionary_cycle_b
+...
+
+ca	ca	100

--- a/data/test/dictionary_nonrecursive_b.dict.yaml
+++ b/data/test/dictionary_nonrecursive_b.dict.yaml
@@ -1,0 +1,9 @@
+---
+name: dictionary_nonrecursive_b
+version: "1.0"
+sort: by_weight
+import_tables:
+  - dictionary_nonrecursive_c
+...
+
+nb	nb	100

--- a/data/test/dictionary_nonrecursive_c.dict.yaml
+++ b/data/test/dictionary_nonrecursive_c.dict.yaml
@@ -1,0 +1,7 @@
+---
+name: dictionary_nonrecursive_c
+version: "1.0"
+sort: by_weight
+...
+
+nc	nc	100

--- a/data/test/dictionary_nonrecursive_test.dict.yaml
+++ b/data/test/dictionary_nonrecursive_test.dict.yaml
@@ -1,0 +1,9 @@
+---
+name: dictionary_nonrecursive_test
+version: "1.0"
+sort: by_weight
+import_tables:
+  - dictionary_nonrecursive_b
+...
+
+na	na	100

--- a/data/test/dictionary_recursive_b.dict.yaml
+++ b/data/test/dictionary_recursive_b.dict.yaml
@@ -1,0 +1,9 @@
+---
+name: dictionary_recursive_b
+version: "1.0"
+sort: by_weight
+import_tables:
+  - dictionary_recursive_c
+...
+
+b	b	100

--- a/data/test/dictionary_recursive_c.dict.yaml
+++ b/data/test/dictionary_recursive_c.dict.yaml
@@ -1,0 +1,7 @@
+---
+name: dictionary_recursive_c
+version: "1.0"
+sort: by_weight
+...
+
+c	c	100

--- a/data/test/dictionary_recursive_test.dict.yaml
+++ b/data/test/dictionary_recursive_test.dict.yaml
@@ -1,0 +1,10 @@
+---
+name: dictionary_recursive_test
+version: "1.0"
+sort: by_weight
+import_tables_recursive: true
+import_tables:
+  - dictionary_recursive_b
+...
+
+a	a	100

--- a/src/rime/dict/dict_compiler.cc
+++ b/src/rime/dict/dict_compiler.cc
@@ -8,6 +8,9 @@
 #include <cfloat>
 #include <cmath>
 #include <fstream>
+#include <algorithm>
+#include <vector>
+#include <unordered_set>
 #include <rime/algo/algebra.h>
 #include <rime/algo/utilities.h>
 #include <rime/dict/corrector.h>
@@ -36,6 +39,23 @@ DictCompiler::DictCompiler(Dictionary* dictionary)
 
 DictCompiler::~DictCompiler() {}
 
+static string format_cycle_path(const vector<string>& stack,
+                                const string& repeated) {
+  auto it = std::find(stack.begin(), stack.end(), repeated);
+  if (it == stack.end())
+    return repeated;
+
+  string s;
+  for (auto p = it; p != stack.end(); ++p) {
+    if (!s.empty())
+      s += " -> ";
+    s += *p;
+  }
+  s += " -> ";
+  s += repeated;
+  return s;
+}
+
 static bool load_dict_settings_from_file(DictSettings* settings,
                                          const path& dict_file) {
   std::ifstream fin(dict_file.c_str());
@@ -44,20 +64,142 @@ static bool load_dict_settings_from_file(DictSettings* settings,
   return success;
 }
 
+static bool dict_imports_recursive(DictSettings& settings) {
+  bool recursive = false;
+  settings.GetBool("import_tables_recursive", &recursive);
+  return recursive;
+}
+
+static bool collect_import_closure(const string& dict_name,
+                                   bool recursive,
+                                   vector<path>* dict_files,
+                                   std::unordered_set<string>* visited,
+                                   std::unordered_set<string>* visiting,
+                                   vector<string>* stack,
+                                   ResourceResolver* source_resolver) {
+  if (visited->count(dict_name))
+    return true;
+
+  if (visiting->count(dict_name)) {
+    const string& root = stack->empty() ? dict_name : stack->front();
+    LOG(ERROR) << "cyclic import_tables detected while compiling '"
+               << root << "': "
+               << format_cycle_path(*stack, dict_name);
+    return false;
+  }
+
+  visiting->insert(dict_name);
+  stack->push_back(dict_name);
+
+  auto dict_file = source_resolver->ResolvePath(dict_name + ".dict.yaml");
+  if (!std::filesystem::exists(dict_file)) {
+    LOG(ERROR) << "source file '" << dict_file << "' does not exist.";
+    stack->pop_back();
+    visiting->erase(dict_name);
+    return false;
+  }
+
+  DictSettings settings;
+  if (!load_dict_settings_from_file(&settings, dict_file)) {
+    LOG(ERROR) << "failed to load settings from '" << dict_file << "'.";
+    stack->pop_back();
+    visiting->erase(dict_name);
+    return false;
+  }
+
+  if (recursive) {
+    if (auto imports = settings.GetList("import_tables")) {
+      for (auto it = imports->begin(); it != imports->end(); ++it) {
+        if (!Is<ConfigValue>(*it))
+          continue;
+        string imported = As<ConfigValue>(*it)->str();
+        if (imported.empty())
+          continue;
+        if (imported == dict_name) {
+          LOG(WARNING) << "cannot import '" << imported << "' from itself.";
+          continue;
+        }
+        if (!collect_import_closure(imported, true, dict_files,
+                                    visited, visiting, stack,
+                                    source_resolver)) {
+          stack->pop_back();
+          visiting->erase(dict_name);
+          return false;
+        }
+      }
+    }
+  } else {
+    // Compatibility with old behavior: only expand one layer import_tables
+    if (auto tables = settings.GetTables()) {
+      bool skip_self = true;
+      for (auto it = tables->begin(); it != tables->end(); ++it) {
+        if (!Is<ConfigValue>(*it))
+          continue;
+        string table_name = As<ConfigValue>(*it)->str();
+        if (table_name.empty())
+          continue;
+        if (skip_self) {
+          skip_self = false;
+          continue;
+        }
+        if (table_name == dict_name) {
+          LOG(WARNING) << "cannot import '" << table_name << "' from itself.";
+          continue;
+        }
+        if (visited->count(table_name))
+          continue;
+        auto imported_file =
+            source_resolver->ResolvePath(table_name + ".dict.yaml");
+        if (!std::filesystem::exists(imported_file)) {
+          LOG(ERROR) << "source file '" << imported_file << "' does not exist.";
+          stack->pop_back();
+          visiting->erase(dict_name);
+          return false;
+        }
+        visited->insert(table_name);
+        dict_files->push_back(imported_file);
+      }
+    }
+  }
+
+  // Post-order: dependencies first, then the dictionary itself.
+  dict_files->push_back(dict_file);
+  stack->pop_back();
+  visiting->erase(dict_name);
+  visited->insert(dict_name);
+  return true;
+}
+
 static bool get_dict_files_from_settings(vector<path>* dict_files,
                                          DictSettings& settings,
                                          ResourceResolver* source_resolver) {
-  if (auto tables = settings.GetTables()) {
-    for (auto it = tables->begin(); it != tables->end(); ++it) {
-      string dict_name = As<ConfigValue>(*it)->str();
-      auto dict_file = source_resolver->ResolvePath(dict_name + ".dict.yaml");
-      if (!std::filesystem::exists(dict_file)) {
-        LOG(ERROR) << "source file '" << dict_file << "' does not exist.";
-        return false;
-      }
-      dict_files->push_back(dict_file);
-    }
+  dict_files->clear();
+
+  std::unordered_set<string> visited;
+  std::unordered_set<string> visiting;
+  vector<string> stack;
+
+  const bool recursive = dict_imports_recursive(settings);
+  const string root = settings.dict_name();
+
+  if (root.empty()) {
+    LOG(ERROR) << "missing dictionary name in settings.";
+    return false;
   }
+
+  const bool ok = collect_import_closure(root, recursive, dict_files,
+                                         &visited, &visiting, &stack,
+                                         source_resolver);
+  if (!ok)
+    return false;
+
+  LOG(INFO) << "resolved " << dict_files->size()
+            << " dict source file(s) for '" << root
+            << "', recursive=" << (recursive ? "true" : "false");
+  for (const auto& f : *dict_files) {
+    LOG(INFO) << "  dict source: " << f;
+  }
+
   return true;
 }
 
@@ -90,12 +232,15 @@ bool DictCompiler::Compile(const path& schema_file) {
     return false;
   }
   vector<path> dict_files;
-  if (!get_dict_files_from_settings(&dict_files, settings,
-                                    source_resolver_.get())) {
-    return false;
+  uint32_t dict_file_checksum = 0;
+  if (build_table_from_source) {
+    if (!get_dict_files_from_settings(&dict_files, settings,
+                                      source_resolver_.get())) {
+      return false;
+    }
+    dict_file_checksum =
+       compute_dict_file_checksum(0, dict_files, settings);
   }
-  uint32_t dict_file_checksum =
-      compute_dict_file_checksum(0, dict_files, settings);
   uint32_t schema_file_checksum =
       schema_file.empty() ? 0 : Checksum(schema_file);
   bool rebuild_table = false;

--- a/test/dictionary_recursive_test.cc
+++ b/test/dictionary_recursive_test.cc
@@ -1,0 +1,133 @@
+//
+// Copyright RIME Developers
+// Distributed under the BSD License
+//
+
+#include <gtest/gtest.h>
+#include <rime/common.h>
+#include <rime/dict/dict_compiler.h>
+#include <rime/dict/dictionary.h>
+
+namespace {
+
+rime::the<rime::Dictionary> BuildDictionaryOrNull(const std::string& name) {
+  rime::the<rime::Dictionary> dict(new rime::Dictionary(
+      name, {},
+      {rime::New<rime::Table>(rime::path{name + ".table.bin"})},
+      rime::New<rime::Prism>(rime::path{name + ".prism.bin"})));
+
+  dict->Remove();
+  rime::DictCompiler compiler(dict.get());
+  if (!compiler.Compile(rime::path())) {
+    return nullptr;
+  }
+  if (!dict->Load()) {
+    return nullptr;
+  }
+  return dict;
+}
+
+void ExpectLookupFound(rime::Dictionary* dict,
+                       const std::string& code,
+                       const std::string& text) {
+  ASSERT_TRUE(dict);
+  ASSERT_TRUE(dict->loaded());
+
+  rime::DictEntryIterator it;
+  dict->LookupWords(&it, code, false);
+  ASSERT_FALSE(it.exhausted()) << "expected code '" << code << "' to be found";
+  ASSERT_TRUE(bool(it.Peek()));
+  EXPECT_EQ(text, it.Peek()->text);
+}
+
+void ExpectLookupNotFound(rime::Dictionary* dict, const std::string& code) {
+  ASSERT_TRUE(dict);
+  ASSERT_TRUE(dict->loaded());
+
+  rime::DictEntryIterator it;
+  dict->LookupWords(&it, code, false);
+  EXPECT_TRUE(it.exhausted()) << "expected code '" << code << "' to be absent";
+}
+
+class RimeRecursiveImportDictionaryTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    if (!dict_) {
+      dict_ = BuildDictionaryOrNull("dictionary_recursive_test");
+    }
+  }
+
+  void TearDown() override { dict_.reset(); }
+
+ protected:
+  static rime::the<rime::Dictionary> dict_;
+};
+
+rime::the<rime::Dictionary> RimeRecursiveImportDictionaryTest::dict_;
+
+class RimeNonRecursiveImportDictionaryTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    if (!dict_) {
+      dict_ = BuildDictionaryOrNull("dictionary_nonrecursive_test");
+    }
+  }
+
+  void TearDown() override { dict_.reset(); }
+
+ protected:
+  static rime::the<rime::Dictionary> dict_;
+};
+
+rime::the<rime::Dictionary> RimeNonRecursiveImportDictionaryTest::dict_;
+
+TEST_F(RimeRecursiveImportDictionaryTest, Ready) {
+  ASSERT_TRUE(dict_);
+  EXPECT_TRUE(dict_->loaded());
+}
+
+TEST_F(RimeRecursiveImportDictionaryTest, RecursiveImportChainLookup) {
+  ASSERT_TRUE(dict_);
+  ASSERT_TRUE(dict_->loaded());
+
+  // root dictionary entry
+  ExpectLookupFound(dict_.get(), "a", "a");
+
+  // directly imported dictionary entry
+  ExpectLookupFound(dict_.get(), "b", "b");
+
+  // transitively imported dictionary entry
+  ExpectLookupFound(dict_.get(), "c", "c");
+}
+
+TEST_F(RimeNonRecursiveImportDictionaryTest, Ready) {
+  ASSERT_TRUE(dict_);
+  EXPECT_TRUE(dict_->loaded());
+}
+
+TEST_F(RimeNonRecursiveImportDictionaryTest, LegacyOneLevelImportOnly) {
+  ASSERT_TRUE(dict_);
+  ASSERT_TRUE(dict_->loaded());
+
+  // root dictionary entry
+  ExpectLookupFound(dict_.get(), "na", "na");
+
+  // directly imported dictionary entry
+  ExpectLookupFound(dict_.get(), "nb", "nb");
+
+  // transitively imported dictionary entry should NOT be visible
+  ExpectLookupNotFound(dict_.get(), "nc");
+}
+
+TEST(RimeDictCompilerRecursiveImportTest, RecursiveImportCycleFails) {
+  rime::the<rime::Dictionary> dict(new rime::Dictionary(
+      "dictionary_cycle_test", {},
+      {rime::New<rime::Table>(rime::path{"dictionary_cycle_test.table.bin"})},
+      rime::New<rime::Prism>(rime::path{"dictionary_cycle_test.prism.bin"})));
+
+  dict->Remove();
+  rime::DictCompiler compiler(dict.get());
+  EXPECT_FALSE(compiler.Compile(rime::path()));
+}
+
+}  // namespace


### PR DESCRIPTION
## Pull request

#### Issue tracker
~Fixes will automatically close the related issue~

~Fixes #~

#### Feature
This change adds optional recursive import_tables resolution at
dictionary compile time.

When `import_tables_recursive: true` is set on the root dictionary,
the compiler recursively resolves imported dictionaries, de-duplicates
them, detects cycles, and flattens the resulting closure through the
existing `BuildTable()` pipeline.

This change is intended to preserve the current build model:
- the root dictionary defines the overall build behavior;
- imported dictionaries are read only to parse their source entries;
- the recursive step only expands the transitive `import_tables` closure.

Default behavior is unchanged: without the flag, only one import level
is honored.

This makes layered dictionary customization easier to maintain, especially
when users build their own extension dictionaries on top of existing
schemas or shared dictionary sets.

#### Unit test
- [x] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
- Added gtests for:
  - recursive chain import success
  - legacy one-level import compatibility
  - cyclic import detection
- Verified with:
  - `cd build/test; ./rime_test --gtest_filter='*RecursiveImport*' --gtest_color=yes`
  - `ctest --test-dir build --output-on-failure`
