### PR TITLE
支持多句子候選輸出

### DIFF
--- a/src/rime/common.h
+++ b/src/rime/common.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <deque>
 #define BOOST_BIND_NO_PLACEHOLDERS
 #include <boost/signals2/connection.hpp>
 #include <boost/signals2/signal.hpp>
@@ -37,6 +38,7 @@
 
 namespace rime {
 
+using std::deque;
 using std::function;
 using std::list;
 using std::make_pair;

--- a/src/rime/gear/poet.cc
+++ b/src/rime/gear/poet.cc
@@ -26,6 +26,7 @@ struct Line {
   const DictEntry* entry;
   size_t end_pos;
   double weight;
+  size_t text_hash;  // for dedup
 
   static const Line kEmpty;
 
@@ -68,7 +69,7 @@ struct Line {
   }
 };
 
-const Line Line::kEmpty{nullptr, nullptr, 0, 0.0};
+const Line Line::kEmpty{nullptr, nullptr, 0, 0.0, 0};
 
 inline static Grammar* create_grammar(Config* config) {
   if (auto* grammar = Grammar::Require("grammar")) {
@@ -249,6 +250,98 @@ an<Sentence> Poet::MakeSentence(const WordGraph& graph,
                                                          preceding_text)
                   : MakeSentenceWithStrategy<DynamicProgramming>(
                         graph, total_length, preceding_text);
+}
+
+// Make `max_sentences` sentences using beam search and dp on word graph.
+//
+// There is no strategy because it unconditionally use grammar.
+deque<an<Sentence>> Poet::MakeSentences(const WordGraph& graph,
+                                        size_t total_length,
+                                        const string& preceding_text,
+                                        size_t max_sentences) {
+  size_t beam_width =
+      max_sentences * 3;  // allow more possibilities during search
+  using State = std::list<Line>;
+  map<int, State> states;
+  states[0].push_back(Line::kEmpty);
+  for (const auto& sv : graph) {
+    size_t start_pos = sv.first;
+    if (states.find(start_pos) == states.end())
+      continue;
+
+    const auto& source_state = states[start_pos];
+    for (const auto& ev : sv.second) {
+      size_t end_pos = ev.first;
+      if (start_pos == 0 && end_pos == total_length)
+        continue;
+      const DictEntryList& entries = ev.second;
+      bool is_rear = end_pos == total_length;
+      auto& target_state = states[end_pos];
+
+      for (const auto& source_line : source_state) {
+        for (const auto& entry : entries) {
+          const string& context =
+              source_line.empty() ? preceding_text : source_line.context();
+          double weight = source_line.weight +
+                          Grammar::Evaluate(context, entry->text, entry->weight,
+                                            is_rear, grammar_.get());
+          size_t new_hash = source_line.text_hash;
+          for (char c : entry->text) {
+            new_hash = new_hash * 31 + c;
+          }
+          Line new_line{&source_line, entry.get(), end_pos, weight, new_hash};
+
+          // dedup by text hash
+          auto dup = std::find_if(
+              target_state.begin(), target_state.end(),
+              [&](const Line& l) { return l.text_hash == new_line.text_hash; });
+          if (dup != target_state.end()) {
+            if (new_line.weight > dup->weight) {
+              target_state.erase(dup);
+            } else {
+              continue;
+            }
+          }
+
+          // insert in descending order of weight
+          auto it = std::find_if(
+              target_state.begin(), target_state.end(),
+              [&](const Line& l) { return l.weight < new_line.weight; });
+          target_state.insert(it, new_line);
+          if (target_state.size() > beam_width)
+            target_state.pop_back();
+        }
+      }
+    }
+  }
+
+  auto found = states.find(total_length);
+  if (found == states.end() || found->second.empty())
+    return {};
+
+  deque<an<Sentence>> results;
+  size_t i = 0;
+  double last_weight = found->second.front().weight;
+  for (const auto& candidate : found->second) {
+    i++;
+    if (i > max_sentences)
+      break;
+    double cur_weight = candidate.weight;
+    // idea: if the current sentence is, on average, not too rare when
+    // compared to last sentence, we should consider it too
+    if (fabs(cur_weight - last_weight) / fabs(last_weight) > 0.05) {
+      break;
+    }
+    last_weight = cur_weight;
+    auto sentence = New<Sentence>(language_);
+    for (const auto* c : candidate.components()) {
+      if (!c->entry)
+        continue;
+      sentence->Extend(*c->entry, c->end_pos, c->weight);
+    }
+    results.emplace_back(sentence);
+  }
+  return results;
 }
 
 }  // namespace rime

--- a/src/rime/gear/poet.cc
+++ b/src/rime/gear/poet.cc
@@ -258,7 +258,8 @@ an<Sentence> Poet::MakeSentence(const WordGraph& graph,
 deque<an<Sentence>> Poet::MakeSentences(const WordGraph& graph,
                                         size_t total_length,
                                         const string& preceding_text,
-                                        size_t max_sentences) {
+                                        size_t max_sentences,
+                                        double cutoff_threshold) {
   size_t beam_width =
       max_sentences * 3;  // allow more possibilities during search
   using State = std::list<Line>;
@@ -320,17 +321,24 @@ deque<an<Sentence>> Poet::MakeSentences(const WordGraph& graph,
     return {};
 
   deque<an<Sentence>> results;
-  size_t i = 0;
-  double last_weight = found->second.front().weight;
-  for (const auto& candidate : found->second) {
-    i++;
-    if (i > max_sentences)
-      break;
+  double last_weight;
+  double acceleration = 1.0 - 1.0 / (double)max_sentences;
+  auto iter = found->second.begin();
+  for (size_t i = 0; iter != found->second.end() && i < max_sentences;
+       ++i, ++iter) {
+    const auto& candidate = *iter;
     double cur_weight = candidate.weight;
-    // idea: if the current sentence is, on average, not too rare when
-    // compared to last sentence, we should consider it too
-    if (fabs(cur_weight - last_weight) / fabs(last_weight) > 0.05) {
-      break;
+    if (i > 0) {
+      // idea: if the current sentence is, on average, not too rare when
+      // compared to last sentence, we should consider it too
+      if (fabs(cur_weight - last_weight) / fabs(last_weight) >
+          cutoff_threshold) {
+        break;
+      }
+      // but don't deviate too far from the first weight by accelerating
+      // the cutoff threshold. cutoff_threshold becomes
+      // ~0.36*cutoff_threshold after N candidates are added.
+      cutoff_threshold *= acceleration;
     }
     last_weight = cur_weight;
     auto sentence = New<Sentence>(language_);

--- a/src/rime/gear/poet.h
+++ b/src/rime/gear/poet.h
@@ -42,7 +42,8 @@ class Poet {
   deque<an<Sentence>> MakeSentences(const WordGraph& graph,
                                     size_t total_length,
                                     const string& preceding_text,
-                                    size_t count);
+                                    size_t count,
+                                    double cutoff_threshold);
 
   template <class TranslatorT>
   an<Translation> ContextualWeighted(an<Translation> translation,

--- a/src/rime/gear/poet.h
+++ b/src/rime/gear/poet.h
@@ -39,6 +39,10 @@ class Poet {
   an<Sentence> MakeSentence(const WordGraph& graph,
                             size_t total_length,
                             const string& preceding_text);
+  deque<an<Sentence>> MakeSentences(const WordGraph& graph,
+                                    size_t total_length,
+                                    const string& preceding_text,
+                                    size_t count);
 
   template <class TranslatorT>
   an<Translation> ContextualWeighted(an<Translation> translation,

--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -115,14 +115,18 @@ class ScriptTranslation : public Translation {
                     Poet* poet,
                     const string& input,
                     size_t start,
-                    size_t end_of_input)
+                    size_t end_of_input,
+                    int max_sentences,
+                    double sentence_cutoff_threshold)
       : translator_(translator),
         poet_(poet),
         start_(start),
         end_of_input_(end_of_input),
         syllabifier_(
             New<ScriptSyllabifier>(translator, corrector, input, start)),
-        enable_correction_(corrector) {
+        enable_correction_(corrector),
+        max_sentences_(max_sentences),
+        sentence_cutoff_threshold_(sentence_cutoff_threshold) {
     set_exhausted(true);
   }
   bool Evaluate(Dictionary* dict, UserDictionary* user_dict);
@@ -136,7 +140,11 @@ class ScriptTranslation : public Translation {
   template <class QueryResult>
   void EnrollEntries(map<int, DictEntryList>& entries_by_end_pos,
                      const an<QueryResult>& query_result);
+  WordGraph PrepareForMakingSentence(Dictionary* dict,
+                                     UserDictionary* user_dict);
   an<Sentence> MakeSentence(Dictionary* dict, UserDictionary* user_dict);
+  deque<an<Sentence>> MakeSentences(Dictionary* dict,
+                                    UserDictionary* user_dict);
 
   ScriptTranslator* translator_;
   Poet* poet_;
@@ -146,7 +154,7 @@ class ScriptTranslation : public Translation {
 
   an<DictEntryCollector> phrase_;
   an<UserDictEntryCollector> user_phrase_;
-  an<Sentence> sentence_;
+  deque<an<Sentence>> sentences_;
 
   an<Phrase> candidate_ = nullptr;
   size_t candidate_index_ = 0;
@@ -163,6 +171,8 @@ class ScriptTranslation : public Translation {
 
   const size_t max_corrections_ = 4;
   size_t correction_count_ = 0;
+  int max_sentences_ = 1;
+  double sentence_cutoff_threshold_ = 0.1;
 
   bool enable_correction_;
 };
@@ -210,8 +220,9 @@ an<Translation> ScriptTranslator::Query(const string& input,
 
   size_t end_of_input = engine_->context()->input().length();
   // the translator should survive translations it creates
-  auto result = New<ScriptTranslation>(this, corrector_.get(), poet_.get(),
-                                       input, segment.start, end_of_input);
+  auto result = New<ScriptTranslation>(
+      this, corrector_.get(), poet_.get(), input, segment.start, end_of_input,
+      max_sentences_, sentence_cutoff_threshold_);
   if (!result || !result->Evaluate(
                      dict_.get(), enable_user_dict ? user_dict_.get() : NULL)) {
     return nullptr;
@@ -484,7 +495,15 @@ bool ScriptTranslation::Evaluate(Dictionary* dict, UserDictionary* user_dict) {
   // make sentences when there is no exact-matching phrase candidate
   if (has_at_least_two_syllables && !has_reliable_phrase &&
       !has_reliable_user_phrase) {
-    sentence_ = MakeSentence(dict, user_dict);
+    if (max_sentences_ > 1)
+      sentences_ = MakeSentences(dict, user_dict);
+    else if (max_sentences_) {
+      auto sentence = MakeSentence(dict, user_dict);
+      if (sentence)
+        sentences_ = {sentence};
+      else
+        sentences_.clear();
+    }
   }
 
   return !CheckEmpty();
@@ -501,7 +520,8 @@ bool ScriptTranslation::Next() {
       case kUninitialized:
         break;
       case kSentence:
-        sentence_.reset();
+        if (!sentences_.empty())
+          sentences_.pop_front();
         break;
       case kUserPhrase: {
         UserDictEntryIterator& uter(user_phrase_iter_->second);
@@ -575,9 +595,9 @@ iter_incremented:
     candidate_ = nullptr;
     return false;
   }
-  if (sentence_) {
+  if (!sentences_.empty()) {
     candidate_source_ = kSentence;
-    candidate_ = sentence_;
+    candidate_ = sentences_[0];
     return true;
   }
   const size_t full_code_length = end_of_input_ - start_;
@@ -675,8 +695,9 @@ void ScriptTranslation::EnrollEntries(
   }
 }
 
-an<Sentence> ScriptTranslation::MakeSentence(Dictionary* dict,
-                                             UserDictionary* user_dict) {
+WordGraph ScriptTranslation::PrepareForMakingSentence(
+    Dictionary* dict,
+    UserDictionary* user_dict) {
   const int kMaxSyllablesForUserPhraseQuery = 5;
   const auto& syllable_graph = syllabifier_->syllable_graph();
   WordGraph graph;
@@ -691,6 +712,29 @@ an<Sentence> ScriptTranslation::MakeSentence(Dictionary* dict,
     EnrollEntries(same_start_pos, dict->Lookup(syllable_graph, x.first,
                                                &translator_->blacklist()));
   }
+  return graph;
+}
+
+deque<an<Sentence>> ScriptTranslation::MakeSentences(
+    Dictionary* dict,
+    UserDictionary* user_dict) {
+  const auto& syllable_graph = syllabifier_->syllable_graph();
+  WordGraph graph = PrepareForMakingSentence(dict, user_dict);
+  auto sentences =
+      poet_->MakeSentences(graph, syllable_graph.interpreted_length,
+                           translator_->GetPrecedingText(start_),
+                           max_sentences_, sentence_cutoff_threshold_);
+  for (auto& sentence : sentences) {
+    sentence->Offset(start_);
+    sentence->set_syllabifier(syllabifier_);
+  }
+  return sentences;
+}
+
+an<Sentence> ScriptTranslation::MakeSentence(Dictionary* dict,
+                                             UserDictionary* user_dict) {
+  const auto& syllable_graph = syllabifier_->syllable_graph();
+  WordGraph graph = PrepareForMakingSentence(dict, user_dict);
   if (auto sentence =
           poet_->MakeSentence(graph, syllable_graph.interpreted_length,
                               translator_->GetPrecedingText(start_))) {

--- a/src/rime/gear/translator_commons.cc
+++ b/src/rime/gear/translator_commons.cc
@@ -125,12 +125,18 @@ TranslatorOptions::TranslatorOptions(const Ticket& ticket) {
     config->GetBool(ticket.name_space + "/strict_spelling", &strict_spelling_);
     config->GetDouble(ticket.name_space + "/initial_quality",
                       &initial_quality_);
+    config->GetInt(ticket.name_space + "/max_sentences", &max_sentences_);
+    max_sentences_ = std::min(std::max(1, max_sentences_), 100);
+    config->GetDouble(ticket.name_space + "/sentence_cutoff_threshold",
+                      &sentence_cutoff_threshold_);
+
     preedit_formatter_.Load(
         config->GetList(ticket.name_space + "/preedit_format"));
     comment_formatter_.Load(
         config->GetList(ticket.name_space + "/comment_format"));
     user_dict_disabling_patterns_.Load(
         config->GetList(ticket.name_space + "/disable_user_dict_for_patterns"));
+
     string tag;
     if (config->GetString(ticket.name_space + "/tag", &tag)) {
       // replace the first tag, and understand /tags as extra tags

--- a/src/rime/gear/translator_commons.h
+++ b/src/rime/gear/translator_commons.h
@@ -176,6 +176,8 @@ class TranslatorOptions {
   bool enable_completion_ = true;
   bool strict_spelling_ = false;
   double initial_quality_ = 0.;
+  int max_sentences_ = 1;
+  double sentence_cutoff_threshold_ = 0.1;
   Projection preedit_formatter_;
   Projection comment_formatter_;
   Patterns user_dict_disabling_patterns_;


### PR DESCRIPTION
## 變更

- 爲 poet 增加 `MakeSentences`，原理是在 word graph 上 dp 時做一個比較寬的 beam search ，最後輸出指定個數的句子。由於這個算法可能性能比原來的稍差一點，所以保留了原本的 MakeSentence。

- 整句輸出由 `max_sentences` 和 `cutoff_threshold` 控制，weight 與上一個 weight 相對差距超過 cutoff_threshold 時即停止。爲了保證不偏離首選 weight 太多，在每個迭代時會將 cutoff_threshold 縮小到上一次的 1-1/max_sentences，這樣在 max_sentences 過後，cutoff_threshold 縮小爲原來的 1/e 倍。

- 給 translator_commons 增加 `max_sentences` 參數（默認 1）。和 `sentence_cutoff_threshold` 參數（默認 0.1）用於微調算法。

- script_translator 在 max_sentences 大於 1 時調用 MakeSentences 並輸出

目前沒有支持 table_translator，未來可以增加。

注意：要發揮最佳功效還需要設定 `max_homophones` 爲大於 1 的值。see #1165 

## 效果

給朙月拼音增加：

```
translator:
  max_sentences: 10
```

並開啓八股文模型。

可以得到：

```
[kai shi ni ding tan pan cheng xu he tiao kuan]|
page: 1  (of size 10)
1. [開始擬定談判程序和條款]
2.  開始你定談判程序和條款 
3.  開是擬定談判程序和條款 
4.  開始你定碳盤程序和條款 
5.  開始你定碳盤成許和條款 
6.  開是你定談判程序和條款 
7.  開始擬定談盤程序和條款 
8.  開始擬定談判成許和條款 
9.  開是你定碳盤程序和條款 
10.  開始你定談盤程序和條款 
```

設爲小於等於 1 的數時，或不設置 max_sentences 時，仍使用原邏輯產生單個句子。

```
[kai shi ni ding tan pan cheng xu he tiao kuan]|
page: 1  (of size 10)
1. [開始擬定談判程序和條款]
2.  開始 
3.  開市 
4.  開示 
5.  開釋 
6.  揩拭 
7.  開駛 
8.  愒時 
9.  楷式 
10.  開士 
```

默認選項下，可能由於 cutoff 機制，輸出的句子數不足 max_sentences （此處設爲 10，但在下面的場景中分別只輸出了 1 句和 2 句）

```
[ta hen bu li jie]|
page: 1  (of size 10)
1. [他很不理解]
2.  他 
3.  她 
4.  它 
5.  塔 
6.  牠 
7.  踏 
8.  塌 
9.  嗒 
10.  榻 

[wo ye bu dong]|
page: 1  (of size 10)
1. [我也不懂]
2.  我也不動 
3.  我也不 
4.  我也 
5.  沃野 
6.  我 
7.  喔 
8.  窩 
9.  握 
10.  臥 

```
