### PR TITLE
feat: 修改max_homophones默认值以提升多整句输出时的top3正确率

### DIFF
--- a/src/rime/gear/script_translator.h
+++ b/src/rime/gear/script_translator.h
@@ -54,7 +54,7 @@ class ScriptTranslator : public Translator,
   int core_word_length() const;
 
  protected:
-  int max_homophones_ = 1;
+  int max_homophones_ = 8;
   int spelling_hints_ = 0;
   int max_word_length_ = 0;
   int core_word_length_ = 0;


### PR DESCRIPTION
在 https://github.com/rime/librime/pull/1164 这个pr中，我提到：
> 在此之前我在我的分支上也做了一个top3多整句，根据我的评测结果，似乎有点不一样，我会寻找下差异点
> 当前librime官方版本明月拼音top3正确率55% 我的版本明月拼音top3正确率63%

现在我已找到差异。是max_homophones默认值问题。
max_homophones默认 1 时，每个起止位置只拿第 1 个词条进 WordGraph。（这样会导致潜在的正确句子过早被丢弃）

改成 8 后，每个起止位置最多拿前 8 个词条进 WordGraph。它不直接影响普通候选列表的枚举。
影响是：
对有整码精确词的短词，基本无影响。
对长句整句生成，更多候选路径会进入 beam search，正确句子更不容易在造句前就被丢掉。

对比报告：

评测范围：

- 方案：`mingyuepinyin` (`luna_pinyin_simp`)
- 语料：`data/corpus/*.txt` 下全部语料
- 句子数：246
- 评测口径：Top 3 精确匹配
- 用户词库：通过评测 patch 禁用
- 同义词归一化：`其它→其他`、`他/她/它→他`、`的/地/得→的`

总体结果：

| DLL | Top 3 完全匹配 | Top 3 句子正确率 | 文字正确率 |
| --- | ---: | ---: | ---: |
| `rime-24986039806.dll` | 136 / 246 | 55.28% | 89.83% |
| `rime-default8.dll` | 159 / 246 | 64.63% | 89.83% |

提升：

- Top 3 完全匹配：+23 句
- Top 3 句子正确率：+9.35 个百分点
- 文字正确率：保持 89.83% 不变

结论：
默认同音候选宽度为 1 时，整句词图召回过窄，正确路径可能在 beam search 排序之前就被移除。将默认值提高到 8 后，在不修改整句排序算法本身的情况下，`mingyuepinyin` 全量语料 Top 3 句子正确率从 55.28% 提升到 64.63%。






附：
# 默认值8正确、默认值1不正确的句子

- 方案：`mingyuepinyin` (`luna_pinyin_simp`)
- 评测口径：Top 3 精确匹配，使用同义词归一化
- 对照 DLL：`rime-24986039806.dll` （默认值1）
- 新 DLL：`rime-default8.dll`（默认值8）
- 总评测句数：246
- 提升句数：30
- 回退句数：7
- 净提升：23

## 1. `news` #24

- Gold：发展信心更足
- 输入：`fazhanxinxingengzu`
- `rime-24986039806.dll` Top3：发展信心梗阻 | 发展 | 罚站
- `rime-default8.dll` Top3：发展信心梗阻 | 发展信心更足 | 发展信心更卒

## 2. `news` #33

- Gold：发展预期持续向好
- 输入：`fazhanyuqichixuxianghao`
- `rime-24986039806.dll` Top3：发展预期持续想好 | 发展 | 罚站
- `rime-default8.dll` Top3：发展预期持续想好 | 发展与其持续想好 | 发展预期持续向好

## 3. `news` #42

- Gold：消费活力持续释放
- 输入：`xiaofeihuolichixushifang`
- `rime-24986039806.dll` Top3：消费获利持续释放 | 消费火里赤叙事放 | 消费火里赤需释放
- `rime-default8.dll` Top3：消费获利持续释放 | 消费活力持续释放 | 消费火力持续释放

## 4. `news` #50

- Gold：近八成商品类别零售额实现增长
- 输入：`jinbachengshangpinleibielingshoueshixianzengzhang`
- `rime-24986039806.dll` Top3：进八成商品类别零售额实现增长 | 紧巴成商品类别零售额实现增长 | 紧巴乘上品类别零售额实现增长
- `rime-default8.dll` Top3：进八成商品类别零售额实现增长 | 金八成商品类别零售额实现增长 | 近八成商品类别零售额实现增长

## 5. `news` #53

- Gold：消费新业态新模式也在不断茁壮成长
- 输入：`xiaofeixinyetaixinmoshiyezaibuduanzhuozhuangchengzhang`
- `rime-24986039806.dll` Top3：消费新也太新模式也在不断茁壮成长 | 消费心也太新模式也在不断茁壮成长 | 消费心也台新模式也在不断茁壮成长
- `rime-default8.dll` Top3：消费新也太新模式也在不断茁壮成长 | 消费新液态新模式也在不断茁壮成长 | 消费新业态新模式也在不断茁壮成长

## 6. `news` #54

- Gold：线上线下融合发展势头向好
- 输入：`xianshangxianxiaronghefazhanshitouxianghao`
- `rime-24986039806.dll` Top3：线上线下融合发展势头想好 | 线上线下融合发展石头想好 | 线上
- `rime-default8.dll` Top3：线上线下融合发展势头想好 | 线上线下融合发展势头向好 | 线上线下融合发展势头相好

## 7. `news` #58

- Gold：实现供需高效对接
- 输入：`shixiangongxugaoxiaoduijie`
- `rime-24986039806.dll` Top3：实现供需高校对接 | 实现 | 视线
- `rime-default8.dll` Top3：实现供需高校对接 | 实现工序高校对接 | 实现供需高效对接

## 8. `novel` #6

- Gold：仆人把白雪公主带走了
- 输入：`purenbabaixuegongzhudaizoule`
- `rime-24986039806.dll` Top3：仆人吧白雪公主带走了 | 普人吧白雪公主带走了 | 仆人
- `rime-default8.dll` Top3：仆人吧白雪公主带走了 | 仆人把白雪公主带走了 | 仆人八白雪公主带走了

## 9. `novel` #27

- Gold：但却没有一个去伤害她
- 输入：`danquemeiyouyigequshanghaita`
- `rime-24986039806.dll` Top3：但却没有一个去上海他 | 但却没有一个去上海獭 | 但却
- `rime-default8.dll` Top3：但却没有一个去上海他 | 但却没有一个去上海她 | 但却没有一个去伤害他

## 10. `novel` #36

- Gold：一张桌子上铺着白布
- 输入：`yizhangzhuozishangpuzhebaibu`
- `rime-24986039806.dll` Top3：一张桌子上铺着摆布 | 一张 | 一章
- `rime-default8.dll` Top3：一张桌子上铺着摆布 | 一张桌子上铺着白布 | 一张桌子上铺着百步

## 11. `novel` #49

- Gold：于是来到那些床前
- 输入：`yushilaidaonaxiechuangqian`
- `rime-24986039806.dll` Top3：于是来到那些窗前 | 于是 | 浴室
- `rime-default8.dll` Top3：于是来到那些窗前 | 于是来到那些床前 | 于是

## 12. `novel` #52

- Gold：就是那一张太短
- 输入：`jiushinayizhangtaiduan`
- `rime-24986039806.dll` Top3：就是那一章太短 | 就是 | 救市
- `rime-default8.dll` Top3：就是那一章太短 | 就是哪一张太短 | 就是那一张太短

## 13. `novel` #96

- Gold：吓了一大跳
- 输入：`xialeyidatiao`
- `rime-24986039806.dll` Top3：下了一大跳 | 下了 | 吓了
- `rime-default8.dll` Top3：下了一大跳 | 吓了一大跳 | 瞎了一大跳

## 14. `novel` #101

- Gold：我叫白雪公主
- 输入：`wojiaobaixuegongzhu`
- `rime-24986039806.dll` Top3：我校白雪公主 | 我校 | 我叫
- `rime-default8.dll` Top3：我校白雪公主 | 我叫白雪公主 | 我觉白雪公主

## 15. `novel` #110

- Gold：白雪公主很乐意地说
- 输入：`baixuegongzhuhenleyidishuo`
- `rime-24986039806.dll` Top3：白雪公主很了一地说 | 白雪公主恨了一地说 | 白雪公主恨了异地说
- `rime-default8.dll` Top3：白雪公主很了一地说 | 白雪公主很乐意地说 | 白雪公主恨了一地说

## 16. `novel` #114

- Gold：七个小矮人每天到山里寻找金子和银子
- 输入：`qigexiaoairenmeitiandaoshanlixunzhaojinziheyinzi`
- `rime-24986039806.dll` Top3：七个小矮人每天到山里寻找金子和因子 | 七个小矮人每天刀山里寻找金子和因子 | 七个小矮人没天道山里寻找金子和因子
- `rime-default8.dll` Top3：七个小矮人每天到山里寻找金子和因子 | 七个小矮人每天到山梨寻找金子和因子 | 七个小矮人每天到山里寻找金子和银子

## 17. `novel` #116

- Gold：他们告诫她说
- 输入：`tamengaojietashuo`
- `rime-24986039806.dll` Top3：他们高阶他说 | 他们搞 | 他们
- `rime-default8.dll` Top3：他们高阶他说 | 他们告诫他说 | 他们高阶她说

## 18. `novel` #118

- Gold：你千万不要让任何人进屋来
- 输入：`niqianwanbuyaorangrenherenjinwulai`
- `rime-24986039806.dll` Top3：你千万不要让任何人劲舞来 | 你千万不要让人和人劲舞来 | 你千万不要让任何人进无赖
- `rime-default8.dll` Top3：你千万不要让任何人劲舞来 | 你千万不要让任何人进屋来 | 你千万不要让任何人金屋来

## 19. `novel` #119

- Gold：那个仆人回来复命后
- 输入：`nagepurenhuilaifuminghou`
- `rime-24986039806.dll` Top3：那个仆人回来复明后 | 那个仆人回来副明后 | 那个仆人会来福明后
- `rime-default8.dll` Top3：那个仆人回来复明后 | 那个仆人回来复命后 | 那个仆人回来浮名后

## 20. `novel` #120

- Gold：王后以为白雪公主已经死了
- 输入：`wanghouyiweibaixuegongzhuyijingsile`
- `rime-24986039806.dll` Top3：往后以为白雪公主已经死了 | 往后 | 王后
- `rime-default8.dll` Top3：往后以为白雪公主已经死了 | 往后一位白雪公主已经死了 | 王后以为白雪公主已经死了

## 21. `novel` #134

- Gold：在那绿色的树荫下
- 输入：`zainalvsedeshuyinxia`
- `rime-24986039806.dll` Top3：在哪绿色的树荫下 | 在哪 | 在那
- `rime-default8.dll` Top3：在哪绿色的树荫下 | 在那绿色的树荫下 | 再拿绿色的树荫下

## 22. `novel` #136

- Gold：白雪公主就躲藏在那里
- 输入：`baixuegongzhujiuduocangzainali`
- `rime-24986039806.dll` Top3：白雪公主就躲藏在哪里 | 白雪公主就多藏在哪里 | 白雪公主就多仓在哪里
- `rime-default8.dll` Top3：白雪公主就躲藏在哪里 | 白雪公主就躲藏在那里 | 白雪公主就多藏在哪里

## 23. `novel` #140

- Gold：王后听了大吃一惊
- 输入：`wanghoutingledachiyijing`
- `rime-24986039806.dll` Top3：往后听了大吃一惊 | 往后 | 王后
- `rime-default8.dll` Top3：往后听了大吃一惊 | 王后听了大吃一惊 | 往后停了大吃一惊

## 24. `novel` #164

- Gold：老太婆进来后说道
- 输入：`laotaipojinlaihoushuodao`
- `rime-24986039806.dll` Top3：老太婆进来后说到 | 老太泼进来后说到 | 老太婆
- `rime-default8.dll` Top3：老太婆进来后说到 | 老太婆进来后说道 | 老太婆近来后说到

## 25. `novel` #185

- Gold：他们的心马上缩紧了
- 输入：`tamendexinmashangsuojinle`
- `rime-24986039806.dll` Top3：他们的心马上缩进了 | 他们的心马上所进了 | 他们的新马上锁进了
- `rime-default8.dll` Top3：他们的心马上缩进了 | 他们的心马上锁紧了 | 他们的心马上缩紧了

## 26. `novel` #193

- Gold：那个老太婆就是王后
- 输入：`nagelaotaipojiushiwanghou`
- `rime-24986039806.dll` Top3：那个老太婆就是往后 | 那个 | 哪个
- `rime-default8.dll` Top3：那个老太婆就是往后 | 哪个老太婆就是往后 | 那个老太婆就是王后

## 27. `prose` #10

- Gold：记不清都是在它的哪些角落里了
- 输入：`jibuqingdoushizaitadenaxiejiaoluolile`
- `rime-24986039806.dll` Top3：记不清都是在他的那些角落里了 | 记不清都是在他的那些角落离了 | 记不清
- `rime-default8.dll` Top3：记不清都是在他的那些角落里了 | 记不清都是在他的哪些角落里了 | 记不清都是在她的那些角落里了

## 28. `prose` #27

- Gold：因为独特的地域优势
- 输入：`yinweidutedediyuyoushi`
- `rime-24986039806.dll` Top3：因为独特的低于优势 | 因为 | 淫威
- `rime-default8.dll` Top3：因为独特的低于优势 | 因为独特的低于又是 | 因为独特的地域优势

## 29. `prose` #42

- Gold：冰灯成了人们生活中不可缺少的帮手
- 输入：`bingdengchenglerenmenshenghuozhongbukequeshaodebangshou`
- `rime-24986039806.dll` Top3：冰灯成了人们生活中不可缺少的榜首 | 冰灯成了人们生活中不可缺少德邦收 | 并等成了人们生活中不可缺少的榜首
- `rime-default8.dll` Top3：冰灯成了人们生活中不可缺少的榜首 | 冰灯成了人们生活中不可缺少的帮手 | 丙等成了人们生活中不可缺少的榜首

## 30. `tech` #17

- Gold：区块链最初因其作为比特币背后技术的而引起人们的关注
- 输入：`qukuailianzuichuyinqizuoweibitebibeihoujishudeeryinqirenmendeguanzhu`
- `rime-24986039806.dll` Top3：区块链最初引起作为比特币背后技术的而引起人们的关注 | 区块链最初引起作为比特币背后技术德尔引起人们的关注 | 区块链最初引起作为比特币背后及书的而引起人们的关注
- `rime-default8.dll` Top3：区块链最初引起作为比特币背后技术的而引起人们的关注 | 区块链最初因其作为比特币背后技术的而引起人们的关注 | 区块链最初阴气作为比特币背后技术的而引起人们的关注

