### PR TITLE
fix(simplifier): handle OpenCC converters without conversion chains

### DIFF
--- a/src/rime/gear/simplifier.cc
+++ b/src/rime/gear/simplifier.cc
@@ -43,8 +43,9 @@ class Opencc {
       // opencc accepts file path encoded in UTF-8.
       converter_ = config.NewFromFile(config_path_.u8string());
 
-      const list<opencc::ConversionPtr> conversions =
-          converter_->GetConversionChain()->GetConversions();
+      const list<opencc::ConversionPtr> conversions = GetConversions();
+      if (conversions.empty())
+        return;
       dict_ = conversions.front()->GetDict();
     } catch (...) {
       LOG(ERROR) << "opencc config not found: " << config_path_;
@@ -56,8 +57,9 @@ class Opencc {
     if (converter_ == nullptr) {
       return false;
     }
-    const list<opencc::ConversionPtr> conversions =
-        converter_->GetConversionChain()->GetConversions();
+    const list<opencc::ConversionPtr> conversions = GetConversions();
+    if (conversions.empty())
+      return false;
     vector<string> original_words{text};
     bool matched = false;
     for (auto conversion : conversions) {
@@ -120,8 +122,9 @@ class Opencc {
     Initialize();
     if (dict_ == nullptr)
       return false;
-    const list<opencc::ConversionPtr> conversions =
-        converter_->GetConversionChain()->GetConversions();
+    const list<opencc::ConversionPtr> conversions = GetConversions();
+    if (conversions.empty())
+      return false;
     const char* phrase = text.c_str();
     for (auto conversion : conversions) {
       opencc::DictPtr dict = conversion->GetDict();
@@ -158,6 +161,16 @@ class Opencc {
   }
 
  private:
+  list<opencc::ConversionPtr> GetConversions() const {
+    if (converter_ == nullptr)
+      return {};
+    opencc::ConversionChainPtr conversion_chain =
+        converter_->GetConversionChain();
+    if (conversion_chain == nullptr)
+      return {};
+    return conversion_chain->GetConversions();
+  }
+
   bool initialized_;
   path config_path_;
   opencc::ConverterPtr converter_;


### PR DESCRIPTION
## 問題

[#1185](https://github.com/rime/librime/issues/1185)

OpenCC 1.3.2 的 `t2s.json` 包含 normalization，因此`Config::NewFromFile()` 會建立 `PipelineConverter`。

`PipelineConverter::GetConversionChain()` 按設計返回 `nullptr`，但 simplifier 會直接解引用其結果，導致啟用簡體轉換時發生 SIGSEGV。

## 修改

- 集中處理 `GetConversionChain()` 返回 `nullptr` 的情況。
- 正確處理空 conversion list。
- PipelineConverter 的 `ConvertWord()` 返回 `false`，讓`Simplifier::Convert()` 回退至 `ConvertText()`。
- `ConvertText()` 繼續透過 `converter_->Convert()` 完成轉換。