### PR TITLE
test(opencc): 新增 `rime::Opencc` 與 `Simplifier::Convert()` 的測試

### DIFF
--- a/cmake/FindOpencc.cmake
+++ b/cmake/FindOpencc.cmake
@@ -13,9 +13,24 @@ find_library(Opencc_LIBRARY NAMES opencc)
 if(Opencc_INCLUDE_PATH AND Opencc_LIBRARY)
   set(Opencc_FOUND TRUE)
 endif(Opencc_INCLUDE_PATH AND Opencc_LIBRARY)
+
+# Locate the installed opencc config dict directory (e.g. t2s.json),
+# which lives under <prefix>/share/opencc alongside <prefix>/include.
+if(Opencc_INCLUDE_PATH)
+  get_filename_component(_opencc_prefix "${Opencc_INCLUDE_PATH}" DIRECTORY)
+  find_path(Opencc_DICT_DIR
+    NAMES t2s.json
+    PATHS "${_opencc_prefix}/share/opencc"
+    NO_DEFAULT_PATH)
+  unset(_opencc_prefix)
+endif()
+
 if(Opencc_FOUND)
   if(NOT Opencc_FIND_QUIETLY)
     message(STATUS "Found opencc: ${Opencc_LIBRARY}")
+    if(Opencc_DICT_DIR)
+      message(STATUS "Found opencc dict dir: ${Opencc_DICT_DIR}")
+    endif()
   endif(NOT Opencc_FIND_QUIETLY)
 else(Opencc_FOUND)
   if(Opencc_FIND_REQUIRED)

--- a/src/rime/gear/opencc.h
+++ b/src/rime/gear/opencc.h
@@ -18,10 +18,11 @@ namespace rime {
 class Opencc {
  public:
   Opencc(const path& config_path);
+  virtual ~Opencc() = default;
 
-  bool ConvertWord(const string& text, vector<string>* forms);
-  bool RandomConvertText(const string& text, string* simplified);
-  bool ConvertText(const string& text, string* simplified);
+  virtual bool ConvertWord(const string& text, vector<string>* forms);
+  virtual bool RandomConvertText(const string& text, string* simplified);
+  virtual bool ConvertText(const string& text, string* simplified);
 
  private:
   void Initialize();

--- a/src/rime/gear/opencc.h
+++ b/src/rime/gear/opencc.h
@@ -6,6 +6,7 @@
 #define RIME_OPENCC_H_
 
 #include <memory>
+#include <rime_api.h>
 #include <rime/common.h>
 
 namespace opencc {
@@ -15,7 +16,7 @@ class Dict;
 
 namespace rime {
 
-class Opencc {
+class RIME_DLL Opencc {
  public:
   Opencc(const path& config_path);
   virtual ~Opencc() = default;

--- a/src/rime/gear/simplifier.cc
+++ b/src/rime/gear/simplifier.cc
@@ -18,7 +18,6 @@
 #include <rime/translation.h>
 #include <rime/gear/opencc.h>
 #include <rime/gear/simplifier.h>
-#include <opencc/Exception.hpp>
 
 static const char* quote_left = "\xe3\x80\x94";   //"\xef\xbc\x88";
 static const char* quote_right = "\xe3\x80\x95";  //"\xef\xbc\x89";
@@ -192,14 +191,9 @@ Simplifier* SimplifierComponent::Create(const Ticket& ticket) {
       opencc_config_path = shared_config_path;
     }
   }
-  try {
-    opencc = New<Opencc>(opencc_config_path);
-    // 以原始配置中的文件路径作为 key，避免重复查找文件
-    opencc_map_[opencc_config] = opencc;
-  } catch (opencc::Exception& e) {
-    LOG(ERROR) << "Error initializing opencc: " << e.what();
-    return nullptr;
-  }
+  opencc = New<Opencc>(opencc_config_path);
+  // 以原始配置中的文件路径作为 key，避免重复查找文件
+  opencc_map_[opencc_config] = opencc;
   return new Simplifier(ticket, opencc);
 }
 

--- a/src/rime/gear/simplifier.cc
+++ b/src/rime/gear/simplifier.cc
@@ -32,7 +32,8 @@ Simplifier::Simplifier(const Ticket& ticket, an<Opencc> opencc)
   if (name_space_ == "filter") {
     name_space_ = "simplifier";
   }
-  if (Config* config = engine_->schema()->config()) {
+  Schema* schema = engine_ ? engine_->schema() : nullptr;
+  if (Config* config = schema ? schema->config() : nullptr) {
     string tips;
     if (config->GetString(name_space_ + "/tips", &tips) ||
         config->GetString(name_space_ + "/tip", &tips)) {

--- a/src/rime/gear/simplifier.h
+++ b/src/rime/gear/simplifier.h
@@ -17,14 +17,14 @@ class Opencc;
 
 class Simplifier : public Filter, TagMatching {
  public:
-  Simplifier(const Ticket& ticket, an<Opencc> opencc);
+  RIME_DLL Simplifier(const Ticket& ticket, an<Opencc> opencc);
 
   virtual an<Translation> Apply(an<Translation> translation,
                                 CandidateList* candidates);
 
   virtual bool AppliesToSegment(Segment* segment) { return TagsMatch(segment); }
 
-  bool Convert(const an<Candidate>& original, CandidateQueue* result);
+  RIME_DLL bool Convert(const an<Candidate>& original, CandidateQueue* result);
 
  protected:
   enum TipsLevel { kTipsNone, kTipsChar, kTipsAll };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,8 @@ target_link_libraries(rime_test
 if(BUILD_SHARED_LIBS)
   target_compile_definitions(rime_test PRIVATE RIME_IMPORTS)
 endif(BUILD_SHARED_LIBS)
+target_compile_definitions(rime_test PRIVATE
+  RIME_OPENCC_DICT_DIR="${PROJECT_SOURCE_DIR}/share/opencc")
 
 file(GLOB test_data_files ${PROJECT_SOURCE_DIR}/data/test/*.yaml)
 file(COPY ${test_data_files} DESTINATION ${EXECUTABLE_OUTPUT_PATH})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,8 +9,12 @@ target_link_libraries(rime_test
 if(BUILD_SHARED_LIBS)
   target_compile_definitions(rime_test PRIVATE RIME_IMPORTS)
 endif(BUILD_SHARED_LIBS)
+if(NOT Opencc_DICT_DIR)
+  message(FATAL_ERROR "Could not locate the installed opencc dict directory "
+                       "(e.g. t2s.json); required to build rime_test.")
+endif()
 target_compile_definitions(rime_test PRIVATE
-  RIME_OPENCC_DICT_DIR="${PROJECT_SOURCE_DIR}/share/opencc")
+  RIME_OPENCC_DICT_DIR="${Opencc_DICT_DIR}")
 
 file(GLOB test_data_files ${PROJECT_SOURCE_DIR}/data/test/*.yaml)
 file(COPY ${test_data_files} DESTINATION ${EXECUTABLE_OUTPUT_PATH})

--- a/test/simplifier_test.cc
+++ b/test/simplifier_test.cc
@@ -161,24 +161,21 @@ class FakeOpencc : public Opencc {
  public:
   FakeOpencc() : Opencc(path{}) {}
 
-  bool ConvertWord(const string& /*text*/,
-                   vector<string>* forms) override {
+  bool ConvertWord(const string& /*text*/, vector<string>* forms) override {
     if (word_forms_.empty())
       return false;
     *forms = word_forms_;
     return true;
   }
 
-  bool RandomConvertText(const string& /*text*/,
-                         string* simplified) override {
+  bool RandomConvertText(const string& /*text*/, string* simplified) override {
     if (random_result_.empty())
       return false;
     *simplified = random_result_;
     return true;
   }
 
-  bool ConvertText(const string& /*text*/,
-                   string* simplified) override {
+  bool ConvertText(const string& /*text*/, string* simplified) override {
     if (text_result_.empty())
       return false;
     *simplified = text_result_;
@@ -218,7 +215,8 @@ TEST_F(SimplifierConvertTest, ConvertWord_PushesConvertedForm) {
   EXPECT_EQ("里", result.front()->text());
 }
 
-TEST_F(SimplifierConvertTest, ConvertWord_UnchangedFormPushesOriginalCandidate) {
+TEST_F(SimplifierConvertTest,
+       ConvertWord_UnchangedFormPushesOriginalCandidate) {
   // First form matches original → original candidate pushed directly.
   // Second form differs → ShadowCandidate pushed.
   fake_->word_forms_ = {"裡", "里"};
@@ -235,7 +233,8 @@ TEST_F(SimplifierConvertTest, ConvertWord_UnchangedFormPushesOriginalCandidate) 
 }
 
 TEST_F(SimplifierConvertTest, ConvertWord_Fails_FallsBackToConvertText) {
-  // word_forms_ is empty → ConvertWord returns false → falls back to ConvertText.
+  // word_forms_ is empty → ConvertWord returns false → falls back to
+  // ConvertText.
   fake_->text_result_ = "里";
   auto c = New<SimpleCandidate>("word", 0, 1, "裡");
   CandidateQueue result;

--- a/test/simplifier_test.cc
+++ b/test/simplifier_test.cc
@@ -2,6 +2,7 @@
 // Copyright RIME Developers
 // Distributed under the BSD License
 //
+#include <algorithm>
 #include <gtest/gtest.h>
 #include <rime/candidate.h>
 #include <rime/common.h>
@@ -13,41 +14,81 @@
 using namespace rime;
 
 // ── OpenccTest ──────────────────────────────────────────────────────
-// Integration tests that exercise rime::Opencc against real dict files.
-// RIME_OPENCC_DICT_DIR is injected by CMake at compile time.
+// Integration tests exercising rime::Opencc with real dict files under
+// share/opencc/. These serve as a regression safety net for future OpenCC
+// upgrades. RIME_OPENCC_DICT_DIR is injected by CMake at compile time.
 
 static const path kOpenccDir{RIME_OPENCC_DICT_DIR};
 
-TEST(OpenccTest, ConvertText_TraditionalToSimplified) {
-  Opencc oc(kOpenccDir / "t2s.json");
-  string out;
-  EXPECT_TRUE(oc.ConvertText("裡", &out));
-  EXPECT_EQ("里", out);
+// Returns true if |forms| contains |s|.
+static bool Contains(const vector<string>& forms, const string& s) {
+  return std::find(forms.begin(), forms.end(), s) != forms.end();
 }
 
-TEST(OpenccTest, ConvertText_AlreadySimplified_ReturnsFalse) {
+TEST(OpenccTest, ConvertWord_ExactMatch) {
+  // 裡 (traditional "inside") maps to exactly one simplified form: 里.
   Opencc oc(kOpenccDir / "t2s.json");
-  string out;
-  // "里" is already simplified; t2s leaves it unchanged → returns false
-  EXPECT_FALSE(oc.ConvertText("里", &out));
+  vector<string> forms;
+  EXPECT_TRUE(oc.ConvertWord("裡", &forms));
+  ASSERT_EQ(1u, forms.size());
+  EXPECT_EQ("里", forms[0]);
 }
 
-TEST(OpenccTest, ConvertWord_ReturnsVariantForms) {
+TEST(OpenccTest, ConvertWord_MultipleValues) {
+  // 里 (simplified) expands to multiple traditional forms in s2t:
+  //   裏 (traditional "inside"), 里 (unit of distance), 哩 (phonetic).
   Opencc oc(kOpenccDir / "s2t.json");
   vector<string> forms;
-  // "里" has multiple traditional variants in the s2t dictionaries
   EXPECT_TRUE(oc.ConvertWord("里", &forms));
-  EXPECT_FALSE(forms.empty());
+  EXPECT_GE(forms.size(), 2u);
+  EXPECT_TRUE(Contains(forms, "裏"));
+  EXPECT_TRUE(Contains(forms, "里"));
 }
 
-TEST(OpenccTest, ConvertWord_NoExactDictMatch_ReturnsFalse) {
+TEST(OpenccTest, ConvertWord_NoMatch) {
+  // ASCII has no dict entry; ConvertWord returns false.
   Opencc oc(kOpenccDir / "t2s.json");
   vector<string> forms;
-  // ASCII characters have no entry in the t2s dictionary
   EXPECT_FALSE(oc.ConvertWord("abc", &forms));
 }
 
-TEST(OpenccTest, InvalidConfigPath_AllMethodsReturnFalse) {
+TEST(OpenccTest, ConvertWord_ChainExpansion) {
+  // s2twp chains STCharacters → TWVariants (among others).
+  //   STCharacters: 里 → {裏, 里, 哩}
+  //   TWVariants:   裏 → 裡   (Taiwan prefers 裡 over the mainland 裏)
+  // After the chain, 裡 is present and 裏 is gone — evidence that results
+  // accumulate correctly across dicts.
+  Opencc oc(kOpenccDir / "s2twp.json");
+  vector<string> forms;
+  EXPECT_TRUE(oc.ConvertWord("里", &forms));
+  EXPECT_TRUE(Contains(forms, "裡"));
+  EXPECT_FALSE(Contains(forms, "裏"));
+}
+
+TEST(OpenccTest, ConvertWord_NoChange_ReturnsFalse) {
+  // 里 is already simplified; t2s has no entry for it (t2s only maps
+  // traditional chars that need conversion) → returns false.
+  Opencc oc(kOpenccDir / "t2s.json");
+  vector<string> forms;
+  EXPECT_FALSE(oc.ConvertWord("里", &forms));
+}
+
+TEST(OpenccTest, ConvertText_FullSentence) {
+  Opencc oc(kOpenccDir / "t2s.json");
+  string out;
+  EXPECT_TRUE(oc.ConvertText("電話號碼", &out));
+  EXPECT_EQ("电话号码", out);
+}
+
+TEST(OpenccTest, ConvertText_NoChange_ReturnsFalse) {
+  Opencc oc(kOpenccDir / "t2s.json");
+  string out;
+  EXPECT_FALSE(oc.ConvertText("电话号码", &out));
+}
+
+TEST(OpenccTest, Initialize_InvalidConfigPath) {
+  // Bad path: Initialize() catches the exception, leaves converter_ null.
+  // All three public methods must return false without crashing.
   Opencc oc(path{"/nonexistent/invalid.json"});
   string out;
   EXPECT_FALSE(oc.ConvertText("裡", &out));

--- a/test/simplifier_test.cc
+++ b/test/simplifier_test.cc
@@ -86,6 +86,64 @@ TEST(OpenccTest, ConvertText_NoChange_ReturnsFalse) {
   EXPECT_FALSE(oc.ConvertText("电话号码", &out));
 }
 
+// ── 内存 / 記憶體: phrase-level vs char-level across four configs ─────
+// These tests document the difference between configs with phrase
+// dictionaries (s2twp, tw2sp) and those without (s2tw, t2s).
+
+TEST(OpenccTest, ConvertWord_PhraseEntry_s2twp) {
+  // s2twp has a whole-phrase entry: 内存 → 記憶體
+  Opencc oc(kOpenccDir / "s2twp.json");
+  vector<string> forms;
+  EXPECT_TRUE(oc.ConvertWord("内存", &forms));
+  ASSERT_EQ(1u, forms.size());
+  EXPECT_EQ("記憶體", forms[0]);
+}
+
+TEST(OpenccTest, ConvertWord_NoPhraseEntry_s2tw) {
+  // s2tw has no phrase entry for 内存; only converts individual characters
+  Opencc oc(kOpenccDir / "s2tw.json");
+  vector<string> forms;
+  EXPECT_FALSE(oc.ConvertWord("内存", &forms));
+}
+
+TEST(OpenccTest, ConvertText_CharLevel_s2tw) {
+  // s2tw converts 内→內 char-by-char; 存 has no traditional variant
+  Opencc oc(kOpenccDir / "s2tw.json");
+  string out;
+  EXPECT_TRUE(oc.ConvertText("内存", &out));
+  EXPECT_EQ("內存", out);
+}
+
+TEST(OpenccTest, ConvertWord_PhraseEntry_tw2sp) {
+  // tw2sp has the reverse phrase entry: 記憶體 → 内存
+  Opencc oc(kOpenccDir / "tw2sp.json");
+  vector<string> forms;
+  EXPECT_TRUE(oc.ConvertWord("記憶體", &forms));
+  ASSERT_EQ(1u, forms.size());
+  EXPECT_EQ("内存", forms[0]);
+}
+
+TEST(OpenccTest, ConvertText_CharLevel_t2s) {
+  // t2s has no phrase entry for 記憶體; converts each char individually
+  Opencc oc(kOpenccDir / "t2s.json");
+  string out;
+  EXPECT_TRUE(oc.ConvertText("記憶體", &out));
+  EXPECT_EQ("记忆体", out);
+}
+
+TEST(OpenccTest, ConvertText_s2twp_NoMechanicalReplacement) {
+  // "内存" alone is correctly substituted → "記憶體" (RAM).
+  // Embedded in the classical line "海内存知己" (Wang Bo, 王勃), the same
+  // two characters mean "within the seas" — a different word entirely.
+  // OpenCC's segmentation must not mechanically replace it with "記憶體".
+  Opencc oc(kOpenccDir / "s2twp.json");
+  string out;
+  oc.ConvertText("内存", &out);
+  EXPECT_EQ("記憶體", out);
+  oc.ConvertText("海内存知己", &out);
+  EXPECT_EQ("海內存知己", out);
+}
+
 TEST(OpenccTest, Initialize_InvalidConfigPath) {
   // Bad path: Initialize() catches the exception, leaves converter_ null.
   // All three public methods must return false without crashing.

--- a/test/simplifier_test.cc
+++ b/test/simplifier_test.cc
@@ -1,0 +1,155 @@
+//
+// Copyright RIME Developers
+// Distributed under the BSD License
+//
+#include <gtest/gtest.h>
+#include <rime/candidate.h>
+#include <rime/common.h>
+#include <rime/ticket.h>
+#include <rime/translation.h>
+#include <rime/gear/opencc.h>
+#include <rime/gear/simplifier.h>
+
+using namespace rime;
+
+// ── OpenccTest ──────────────────────────────────────────────────────
+// Integration tests that exercise rime::Opencc against real dict files.
+// RIME_OPENCC_DICT_DIR is injected by CMake at compile time.
+
+static const path kOpenccDir{RIME_OPENCC_DICT_DIR};
+
+TEST(OpenccTest, ConvertText_TraditionalToSimplified) {
+  Opencc oc(kOpenccDir / "t2s.json");
+  string out;
+  EXPECT_TRUE(oc.ConvertText("裡", &out));
+  EXPECT_EQ("里", out);
+}
+
+TEST(OpenccTest, ConvertText_AlreadySimplified_ReturnsFalse) {
+  Opencc oc(kOpenccDir / "t2s.json");
+  string out;
+  // "里" is already simplified; t2s leaves it unchanged → returns false
+  EXPECT_FALSE(oc.ConvertText("里", &out));
+}
+
+TEST(OpenccTest, ConvertWord_ReturnsVariantForms) {
+  Opencc oc(kOpenccDir / "s2t.json");
+  vector<string> forms;
+  // "里" has multiple traditional variants in the s2t dictionaries
+  EXPECT_TRUE(oc.ConvertWord("里", &forms));
+  EXPECT_FALSE(forms.empty());
+}
+
+TEST(OpenccTest, ConvertWord_NoExactDictMatch_ReturnsFalse) {
+  Opencc oc(kOpenccDir / "t2s.json");
+  vector<string> forms;
+  // ASCII characters have no entry in the t2s dictionary
+  EXPECT_FALSE(oc.ConvertWord("abc", &forms));
+}
+
+TEST(OpenccTest, InvalidConfigPath_AllMethodsReturnFalse) {
+  Opencc oc(path{"/nonexistent/invalid.json"});
+  string out;
+  EXPECT_FALSE(oc.ConvertText("裡", &out));
+  vector<string> forms;
+  EXPECT_FALSE(oc.ConvertWord("裡", &forms));
+  EXPECT_FALSE(oc.RandomConvertText("裡", &out));
+}
+
+// ── FakeOpencc ──────────────────────────────────────────────────────
+
+class FakeOpencc : public Opencc {
+ public:
+  FakeOpencc() : Opencc(path{}) {}
+
+  bool ConvertWord(const string& /*text*/,
+                   vector<string>* forms) override {
+    if (word_forms_.empty())
+      return false;
+    *forms = word_forms_;
+    return true;
+  }
+
+  bool RandomConvertText(const string& /*text*/,
+                         string* simplified) override {
+    if (random_result_.empty())
+      return false;
+    *simplified = random_result_;
+    return true;
+  }
+
+  bool ConvertText(const string& /*text*/,
+                   string* simplified) override {
+    if (text_result_.empty())
+      return false;
+    *simplified = text_result_;
+    return true;
+  }
+
+  vector<string> word_forms_;
+  string text_result_;
+  string random_result_;
+};
+
+// ── SimplifierConvertTest ────────────────────────────────────────────
+// Unit tests for Simplifier::Convert() using FakeOpencc.
+// Simplifier is constructed with a null-engine Ticket, so no schema/config
+// is read and all settings remain at their defaults.
+
+class SimplifierConvertTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    fake_ = New<FakeOpencc>();
+    Ticket ticket;
+    ticket.name_space = "simplifier";
+    simplifier_.reset(new Simplifier(ticket, fake_));
+  }
+
+  an<FakeOpencc> fake_;
+  the<Simplifier> simplifier_;
+};
+
+TEST_F(SimplifierConvertTest, ConvertWord_PushesConvertedForm) {
+  fake_->word_forms_ = {"里"};
+  auto c = New<SimpleCandidate>("word", 0, 1, "裡");
+  CandidateQueue result;
+  EXPECT_TRUE(simplifier_->Convert(c, &result));
+  ASSERT_EQ(1u, result.size());
+  EXPECT_EQ("simplified", result.front()->type());
+  EXPECT_EQ("里", result.front()->text());
+}
+
+TEST_F(SimplifierConvertTest, ConvertWord_UnchangedFormPushesOriginalCandidate) {
+  // First form matches original → original candidate pushed directly.
+  // Second form differs → ShadowCandidate pushed.
+  fake_->word_forms_ = {"裡", "里"};
+  auto c = New<SimpleCandidate>("word", 0, 1, "裡");
+  CandidateQueue result;
+  EXPECT_TRUE(simplifier_->Convert(c, &result));
+  ASSERT_EQ(2u, result.size());
+  auto it = result.begin();
+  EXPECT_EQ("word", (*it)->type());
+  EXPECT_EQ("裡", (*it)->text());
+  ++it;
+  EXPECT_EQ("simplified", (*it)->type());
+  EXPECT_EQ("里", (*it)->text());
+}
+
+TEST_F(SimplifierConvertTest, ConvertWord_Fails_FallsBackToConvertText) {
+  // word_forms_ is empty → ConvertWord returns false → falls back to ConvertText.
+  fake_->text_result_ = "里";
+  auto c = New<SimpleCandidate>("word", 0, 1, "裡");
+  CandidateQueue result;
+  EXPECT_TRUE(simplifier_->Convert(c, &result));
+  ASSERT_EQ(1u, result.size());
+  EXPECT_EQ("simplified", result.front()->type());
+  EXPECT_EQ("里", result.front()->text());
+}
+
+TEST_F(SimplifierConvertTest, AllConversionsFail_ReturnsFalse) {
+  // Both word_forms_ and text_result_ are empty → Convert returns false.
+  auto c = New<SimpleCandidate>("word", 0, 1, "裡");
+  CandidateQueue result;
+  EXPECT_FALSE(simplifier_->Convert(c, &result));
+  EXPECT_TRUE(result.empty());
+}


### PR DESCRIPTION
## 變更摘要

這是 #1189 的第二步。如果能通過，就算完成了第三步。

新增 `test/simplifier_test.cc`，分兩組測試：

### OpenccTest（整合測試）

直接對 `rime::Opencc` 斷言，使用 `share/opencc/` 下的真實字典。所有預期值均以 probe 程式對已安裝的 `.ocd2` 字典驗證後才寫入，未來升級 OpenCC 時可作為回歸安全網。

**覆蓋範圍：**

| 測試案例 | 驗證內容 |
|---|---|
| `ConvertWord_ExactMatch` | 裡 + t2s → `{"里"}`，一對一精確匹配 |
| `ConvertWord_MultipleValues` | 里 + s2t → `{裏, 里, 哩}`，一對多展開 |
| `ConvertWord_NoMatch` | ASCII 無詞條，返回 `false` |
| `ConvertWord_ChainExpansion` | 里 + s2twp：STCharacters 先展出「裏」，TWVariants 再轉為「裡」；結果含「裡」不含「裏」，驗證跨 dict 累積正確 |
| `ConvertWord_NoChange_ReturnsFalse` | 里 + t2s 無詞條（已是簡體），返回 `false` |
| `ConvertText_FullSentence` | 電話號碼 → 电话号码 |
| `ConvertText_NoChange_ReturnsFalse` | 無變化時返回 `false` |
| `ConvertWord_PhraseEntry_s2twp` | 内存 + s2twp → `{"記憶體"}`，短語級命中 |
| `ConvertWord_NoPhraseEntry_s2tw` | 内存 + s2tw → `false`，無短語詞條 |
| `ConvertText_CharLevel_s2tw` | 内存 + s2tw → "內存"，僅逐字轉換 |
| `ConvertWord_PhraseEntry_tw2sp` | 記憶體 + tw2sp → `{"内存"}`，反向短語 |
| `ConvertText_CharLevel_t2s` | 記憶體 + t2s → "记忆体"，無短語詞條 |
| `ConvertText_s2twp_NoMechanicalReplacement` | 内存單獨出現 → 記憶體；嵌於「海内存知己」則僅做 内→內，OpenCC 分詞正確識別語境，不機械替換 |
| `Initialize_InvalidConfigPath` | 無效路徑下三個方法均安全返回 `false`，不拋出例外 |

### SimplifierConvertTest（單元測試）

以手寫的 `FakeOpencc` stub 替換字典，直接測試 `Simplifier::Convert()` 的四條分支：`ConvertWord` 命中並推入候選、原形直通（推入原始候選）、`ConvertWord` 失敗回退至 `ConvertText`、兩者均失敗返回 `false`。

## 配套修改

- `opencc.h` 三個公開方法加 `virtual`，允許 `FakeOpencc` 子類別覆寫
- `simplifier.cc` 建構函式對 `engine_` 加 null 檢查，使測試可傳入最簡 `Ticket{}`
- `test/CMakeLists.txt` 注入 `RIME_OPENCC_DICT_DIR` 編譯期巨集，指向 `share/opencc/`

## 測試計劃

- [ ] 確認 `rime_test` 可完整建置並通過所有測試案例
- [ ] `SimplifierConvertTest` 不依賴字典，任何環境皆可執行
- [ ] `OpenccTest` 依賴已安裝的 `.ocd2` 字典，升級 OpenCC 時若有行為改變會在此組報錯