### PR TITLE
feat: Add limit to the enable_completion

### DIFF
--- a/src/rime/gear/reverse_lookup_translator.cc
+++ b/src/rime/gear/reverse_lookup_translator.cc
@@ -171,7 +171,7 @@ an<Translation> ReverseLookupTranslator::Query(const string& input,
   DictEntryIterator iter;
   bool quality = false;
   if (start < input.length()) {
-    if (options_ && options_->enable_completion()) {
+    if (options_ && options_->is_completion_enabled(code.length())) {
       dict_->LookupWords(&iter, code, true, 100, nullptr);
       quality = !iter.exhausted() && (iter.Peek()->remaining_code_length == 0);
     } else {

--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -85,7 +85,7 @@ class ScriptSyllabifier : public PhraseSyllabifier {
         input_(input),
         start_(start),
         syllabifier_(translator->delimiters(),
-                     translator->enable_completion(),
+                     translator->is_completion_enabled(input.length()),
                      translator->strict_spelling()) {
     if (corrector) {
       syllabifier_.EnableCorrection(corrector);
@@ -453,8 +453,10 @@ static bool has_exact_match_phrase(Ptr ptr, Iter iter, size_t consumed) {
 bool ScriptTranslation::Evaluate(Dictionary* dict, UserDictionary* user_dict) {
   size_t consumed = syllabifier_->BuildSyllableGraph(*dict->prism());
   const auto& syllable_graph = syllabifier_->syllable_graph();
-  bool predict_word = translator_->enable_word_completion() &&
-                      start_ + consumed == end_of_input_;
+  bool predict_word =
+      translator_->enable_word_completion() &&
+      start_ + consumed == end_of_input_ &&
+      consumed >= static_cast<size_t>(translator_->completion_min_length());
 
   phrase_ =
       dict->Lookup(syllable_graph, 0, &translator_->blacklist(), predict_word);

--- a/src/rime/gear/table_translator.cc
+++ b/src/rime/gear/table_translator.cc
@@ -258,7 +258,7 @@ an<Translation> TableTranslator::Query(const string& input,
   boost::trim_right_if(code, boost::is_any_of(delimiters_));
 
   an<Translation> translation;
-  if (enable_completion_) {
+  if (is_completion_enabled(code.length())) {
     translation = Cached<LazyTableTranslation>(this, code, segment.start,
                                                segment.start + input.length(),
                                                preedit, enable_user_dict);

--- a/src/rime/gear/translator_commons.cc
+++ b/src/rime/gear/translator_commons.cc
@@ -122,6 +122,9 @@ TranslatorOptions::TranslatorOptions(const Ticket& ticket) {
                     &contextual_suggestions_);
     config->GetBool(ticket.name_space + "/enable_completion",
                     &enable_completion_);
+    config->GetInt(ticket.name_space + "/completion_min_length",
+                   &completion_min_length_);
+    completion_min_length_ = std::max(0, completion_min_length_);
     config->GetBool(ticket.name_space + "/strict_spelling", &strict_spelling_);
     config->GetDouble(ticket.name_space + "/initial_quality",
                       &initial_quality_);

--- a/src/rime/gear/translator_commons.h
+++ b/src/rime/gear/translator_commons.h
@@ -161,6 +161,15 @@ class TranslatorOptions {
   }
   bool enable_completion() const { return enable_completion_; }
   void set_enable_completion(bool enabled) { enable_completion_ = enabled; }
+  int completion_min_length() const { return completion_min_length_; }
+  void set_completion_min_length(int length) {
+    completion_min_length_ = length;
+  }
+  // completion is enabled only when the input code is long enough
+  bool is_completion_enabled(size_t input_length) const {
+    return enable_completion_ &&
+           input_length >= static_cast<size_t>(completion_min_length_);
+  }
   bool strict_spelling() const { return strict_spelling_; }
   void set_strict_spelling(bool is_strict) { strict_spelling_ = is_strict; }
   double initial_quality() const { return initial_quality_; }
@@ -174,6 +183,7 @@ class TranslatorOptions {
   vector<string> tags_{"abc"};  // invariant: non-empty
   bool contextual_suggestions_ = false;
   bool enable_completion_ = true;
+  int completion_min_length_ = 0;
   bool strict_spelling_ = false;
   double initial_quality_ = 0.;
   int max_sentences_ = 1;


### PR DESCRIPTION
## Pull request

#### Feature

如 #1193 描述，对 enable_completion 添加限制。

```yaml
translator:
  enable_completion: true
  completion_min_length: 3   # 输入码长度 >= 3 时才出逐码提示
```

#### Manual test

- [x] Done

