### PR TITLE
fix(userdb): create parent directories before writable open

### DIFF
--- a/src/rime/dict/user_db.cc
+++ b/src/rime/dict/user_db.cc
@@ -6,7 +6,9 @@
 //
 #include <algorithm>
 #include <cstdlib>
+#include <filesystem>
 #include <sstream>
+#include <system_error>
 #include <boost/algorithm/string.hpp>
 #include <rime/service.h>
 #include <rime/algo/dynamics.h>
@@ -101,6 +103,73 @@ template <>
 RIME_DLL UserDbWrapper<TextDb>::UserDbWrapper(const path& file_path,
                                               const string& db_name)
     : TextDb(file_path, db_name, "userdb", plain_userdb_format) {}
+
+static bool is_subpath(const path& file_path, const path& directory) {
+  auto file_iter = file_path.begin();
+  for (const auto& component : directory) {
+    if (file_iter == file_path.end() || *file_iter != component)
+      return false;
+    ++file_iter;
+  }
+  return file_iter != file_path.end();
+}
+
+bool UserDbHelper::IsUserDataPath(const path& file_path) {
+  std::error_code error;
+  const path user_data_dir = std::filesystem::weakly_canonical(
+      Service::instance().deployer().user_data_dir, error);
+  if (error) {
+    LOG(ERROR) << "failed to resolve user data directory: " << error.message();
+    return false;
+  }
+
+  error.clear();
+  const path resolved_file_path =
+      std::filesystem::weakly_canonical(file_path, error);
+  if (error) {
+    LOG(ERROR) << "failed to resolve userdb path '" << file_path
+               << "': " << error.message();
+    return false;
+  }
+
+  if (!is_subpath(resolved_file_path, user_data_dir)) {
+    LOG(ERROR) << "userdb path '" << resolved_file_path
+               << "' is outside user data directory '" << user_data_dir << "'.";
+    return false;
+  }
+  return true;
+}
+
+bool UserDbHelper::EnsureParentDirectory(const path& file_path) {
+  path parent_path(file_path.parent_path());
+  if (parent_path.empty())
+    return true;
+  std::error_code error;
+  if (std::filesystem::exists(parent_path, error)) {
+    if (std::filesystem::is_directory(parent_path, error))
+      return true;
+    if (error) {
+      LOG(ERROR) << "failed to inspect userdb directory '" << parent_path
+                 << "': " << error.message();
+    } else {
+      LOG(ERROR) << "userdb directory path '" << parent_path
+                 << "' is not a directory.";
+    }
+    return false;
+  }
+  if (error) {
+    LOG(ERROR) << "failed to inspect userdb directory '" << parent_path
+               << "': " << error.message();
+    return false;
+  }
+  std::filesystem::create_directories(parent_path, error);
+  if (error) {
+    LOG(ERROR) << "failed to create userdb directory '" << parent_path
+               << "': " << error.message();
+    return false;
+  }
+  return true;
+}
 
 bool UserDbHelper::UpdateUserInfo() {
   Deployer& deployer(Service::instance().deployer());

--- a/src/rime/dict/user_db.h
+++ b/src/rime/dict/user_db.h
@@ -6,7 +6,6 @@
 //
 #ifndef RIME_USER_DB_H_
 #define RIME_USER_DB_H_
-
 #include <stdint.h>
 #include <rime/component.h>
 #include <rime/dict/db.h>
@@ -28,7 +27,6 @@ struct UserDbValue {
   string Pack() const;
   bool Unpack(const string& value);
 };
-
 /**
  * A placeholder class for user db.
  *
@@ -45,7 +43,6 @@ class UserDb {
    public:
     virtual string extension() const = 0;
   };
-
   /// Requires a registered component for a user db class.
   static Component* Require(const string& name) {
     return dynamic_cast<Component*>(Db::Require(name));
@@ -60,8 +57,9 @@ class UserDbHelper {
   UserDbHelper(Db* db) : db_(db) {}
   UserDbHelper(const the<Db>& db) : db_(db.get()) {}
   UserDbHelper(const an<Db>& db) : db_(db.get()) {}
-
   RIME_DLL bool UpdateUserInfo();
+  RIME_DLL static bool IsUserDataPath(const path& file_path);
+  RIME_DLL static bool EnsureParentDirectory(const path& file_path);
   RIME_DLL static bool IsUniformFormat(const path& file_path);
   RIME_DLL bool UniformBackup(const path& snapshot_file);
   RIME_DLL bool UniformRestore(const path& snapshot_file);
@@ -74,13 +72,15 @@ class UserDbHelper {
  protected:
   Db* db_;
 };
-
 /// A template to define a user db class based on an implementation of rime::Db.
 template <class BaseDb>
 class UserDbWrapper : public BaseDb {
  public:
   RIME_DLL UserDbWrapper(const path& file_path, const string& db_name);
-
+  virtual bool Open() {
+    return UserDbHelper::EnsureParentDirectory(this->file_path()) &&
+           BaseDb::Open();
+  }
   virtual bool CreateMetadata() {
     return BaseDb::CreateMetadata() && UserDbHelper(this).UpdateUserInfo();
   }
@@ -95,14 +95,16 @@ class UserDbWrapper : public BaseDb {
                : BaseDb::Restore(snapshot_file);
   }
 };
-
 /// Implements a component that serves as a factory for a user db class.
 template <class BaseDb>
 class UserDbComponent : public UserDb::Component, protected DbComponentBase {
  public:
   using UserDbImpl = UserDbWrapper<BaseDb>;
   Db* Create(const string& name) override {
-    return new UserDbImpl(DbFilePath(name, extension()), name);
+    const path file_path = DbFilePath(name, extension());
+    if (!UserDbHelper::IsUserDataPath(file_path))
+      return nullptr;
+    return new UserDbImpl(file_path, name);
   }
 
   string extension() const override;
@@ -112,7 +114,6 @@ class UserDbMerger : public Sink {
  public:
   explicit UserDbMerger(Db* db);
   virtual ~UserDbMerger();
-
   virtual bool MetaPut(const string& key, const string& value);
   virtual bool Put(const string& key, const string& value);
 
@@ -136,7 +137,6 @@ class UserDbImporter : public Sink {
  protected:
   Db* db_;
 };
-
 }  // namespace rime
 
 #endif  // RIME_USER_DB_H_

--- a/test/user_db_test.cc
+++ b/test/user_db_test.cc
@@ -6,13 +6,14 @@
 //
 #include <gtest/gtest.h>
 #include <rime/algo/syllabifier.h>
+#include <filesystem>
+#include <rime/service.h>
 #include <rime/dict/text_db.h>
 #include <rime/dict/user_db.h>
 
 using namespace rime;
 
 using TestDb = UserDbWrapper<TextDb>;
-
 TEST(RimeUserDbTest, AccessRecordByKey) {
   TestDb db(path{"user_db_test.txt"}, "user_db_test");
   if (db.Exists())
@@ -39,7 +40,6 @@ TEST(RimeUserDbTest, AccessRecordByKey) {
   EXPECT_TRUE(db.Close());
   ASSERT_FALSE(db.loaded());
 }
-
 TEST(RimeUserDbTest, Query) {
   TestDb db(path{"user_db_test.txt"}, "user_db_test");
   if (db.Exists())
@@ -88,4 +88,45 @@ TEST(RimeUserDbTest, Query) {
     EXPECT_FALSE(accessor->GetNextRecord(&key, &value));
   }
   db.Close();
+}
+TEST(RimeUserDbTest, CreateParentDirectoriesForNestedPath) {
+  const path test_root{"user_db_nested_test"};
+  const path db_path = test_root / "data" / "tips.txt";
+
+  std::filesystem::remove_all(test_root);
+
+  TestDb db(db_path, "data/tips");
+
+  // Read-only access must not create missing directories.
+  EXPECT_FALSE(db.OpenReadOnly());
+  EXPECT_FALSE(std::filesystem::exists(db_path.parent_path()));
+  // Writable access creates the missing data directory.
+  ASSERT_TRUE(db.Open());
+  EXPECT_TRUE(std::filesystem::is_directory(db_path.parent_path()));
+
+  EXPECT_TRUE(db.Update("test", "value"));
+
+  string value;
+  EXPECT_TRUE(db.Fetch("test", &value));
+  EXPECT_EQ("value", value);
+
+  EXPECT_TRUE(db.Close());
+  EXPECT_TRUE(db.Exists());
+
+  std::filesystem::remove_all(test_root);
+}
+TEST(RimeUserDbTest, RejectPathsOutsideUserDataDirectory) {
+  UserDbComponent<TextDb> component;
+
+  the<Db> nested_path_db(component.Create("lua/data"));
+  EXPECT_TRUE(nested_path_db);
+
+  the<Db> parent_path_db(component.Create("lua/../../user_db_escape_test"));
+  EXPECT_FALSE(parent_path_db);
+
+  const path user_data_dir = std::filesystem::weakly_canonical(
+      Service::instance().deployer().user_data_dir);
+  const path outside_path = user_data_dir.parent_path() / "user_db_escape_test";
+  the<Db> absolute_path_db(component.Create(outside_path.u8string()));
+  EXPECT_FALSE(absolute_path_db);
 }


### PR DESCRIPTION
在打包Linux、安卓等app时候，内置lua脚本创建的带有路径的数据库，此时用户目录可能不存在该目录，打开前需创建路径