### PR TITLE
fix(build): avoid a `-j` parse error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ prefix ?= $(DESTDIR)/usr
 endif
 
 ifndef NOPARALLEL
-export MAKEFLAGS+=" -j$$(( $$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || echo 8) + 1)) "
+  MAKEFLAGS += -j$(shell expr $$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || echo 8) + 1)
 endif
 
 debug install-debug uninstall-debug test-debug: build ?= debug

--- a/deps.mk
+++ b/deps.mk
@@ -4,7 +4,7 @@ rime_root = $(CURDIR)
 src_dir = $(rime_root)/deps
 
 ifndef NOPARALLEL
-export MAKEFLAGS+=" -j$$(( $$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || echo 8) + 1)) "
+  MAKEFLAGS += -j$(shell expr $$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || echo 8) + 1)
 endif
 
 build ?= build


### PR DESCRIPTION
Specifically for `MAKEFLAGS`, GNU make wants an evaluated value instead of a deferred expansion, which is not evaluated by any shell, causing the following error.

```
make: the '-j' option requires a positive integer argument
```

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
