### PR TITLE
perf(deployer): release memory to OS after batch dictionary compilation on glibc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ add_definitions(-DRIME_VERSION="${rime_version}")
 # generate compile_commands.json
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+include(CheckSymbolExists)
 include(GNUInstallDirs)
 
 option(BUILD_SHARED_LIBS "Build Rime as shared library" ON)
@@ -180,6 +181,8 @@ endif()
 if(UNIX)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 endif()
+
+check_symbol_exists(__GLIBC__ "features.h" IS_GLIBC)
 
 if (NOT CMAKE_BUILD_PARALLEL_LEVEL)
   include(ProcessorCount)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ set(rime_optional_deps "")
 if(Gflags_FOUND)
   set(rime_optional_deps ${rime_optional_deps} ${Gflags_LIBRARY})
 endif()
-if(ENABLE_EXTERNAL_PLUGINS)
+if(ENABLE_EXTERNAL_PLUGINS OR IS_GLIBC)
   set(rime_optional_deps ${rime_optional_deps} dl)
 endif()
 

--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -29,6 +29,8 @@
 #include <windows.h>
 #endif
 #ifdef __GLIBC__
+#include <cstdlib>
+#include <dlfcn.h>
 #include <malloc.h>
 #endif
 
@@ -248,8 +250,20 @@ bool WorkspaceUpdate::Run(Deployer* deployer) {
     }
   }
 #ifdef __GLIBC__
-  // ask glibc to release memory used by DictCompiler during SchemaUpdate to OS
-  malloc_trim(0);
+  // ask glibc to release memory used by DictCompiler during SchemaUpdate to OS.
+  // skip if allocator is replaced (e.g. via LD_PRELOAD): detected by
+  // `malloc` and `malloc_trim` coming from the same file, excluding
+  // cases where library functions share it, to avoid rare false positives.
+  static const bool is_glibc = []() {
+    Dl_info info_alloc, info_trim, info_rime;
+    return dladdr((const void*)malloc, &info_alloc) &&
+           dladdr((const void*)malloc_trim, &info_trim) &&
+           dladdr((const void*)rime_get_api, &info_rime) &&
+           info_alloc.dli_fbase == info_trim.dli_fbase &&
+           info_alloc.dli_fbase != info_rime.dli_fbase;
+  }();
+  if (is_glibc)
+    malloc_trim(0);
 #endif
   LOG(INFO) << "finished updating schemas: " << success << " success, "
             << failure << " failure.";

--- a/src/rime/lever/deployment_tasks.cc
+++ b/src/rime/lever/deployment_tasks.cc
@@ -28,6 +28,9 @@
 #ifdef _WIN32
 #include <windows.h>
 #endif
+#ifdef __GLIBC__
+#include <malloc.h>
+#endif
 
 namespace fs = std::filesystem;
 
@@ -244,6 +247,10 @@ bool WorkspaceUpdate::Run(Deployer* deployer) {
       }
     }
   }
+#ifdef __GLIBC__
+  // ask glibc to release memory used by DictCompiler during SchemaUpdate to OS
+  malloc_trim(0);
+#endif
   LOG(INFO) << "finished updating schemas: " << success << " success, "
             << failure << " failure.";
 


### PR DESCRIPTION
## Pull request

#### Issue tracker

- 在 glibc 平台上 (通常的 linux 平台)，修复 https://github.com/rime/librime/issues/440
  - 这个问题看 https://github.com/rime/squirrel/issues/134 在 macOS 上也有，但似乎没有类似的接口能用。squirrel 发布的好像是可执行程序，不想费力的话可以直接换个 mimalloc 之类的。

#### Manual test
- [x] Done
