### PR TITLE
perf(prism): reduce temporary key copies during search

### DIFF
--- a/src/rime/algo/syllabifier.cc
+++ b/src/rime/algo/syllabifier.cc
@@ -7,6 +7,7 @@
 //
 #include <algorithm>
 #include <queue>
+#include <string_view>
 #include <boost/range/adaptor/reversed.hpp>
 #include <rime/algo/syllabifier.h>
 #include <rime/dict/corrector.h>
@@ -65,14 +66,16 @@ int Syllabifier::BuildSyllableGraph(const string& input,
     // see where we can go by advancing a syllable
     vector<Prism::Match> matches;
     set<SyllableId> exact_match_syllables;
-    auto current_input = input.substr(begin_pos);
+    std::string_view current_input(input.data() + begin_pos,
+                                   input.length() - begin_pos);
     prism.CommonPrefixSearch(current_input, &matches);
     if (corrector_) {
       for (auto& m : matches) {
         exact_match_syllables.insert(m.value);
       }
       Corrections corrections;
-      corrector_->ToleranceSearch(prism, current_input, &corrections, 5);
+      corrector_->ToleranceSearch(prism, string{current_input}, &corrections,
+                                  5);
       for (const auto& m : corrections) {
         for (auto accessor = prism.QuerySpelling(m.first);
              !accessor.exhausted(); accessor.Next()) {

--- a/src/rime/dict/prism.cc
+++ b/src/rime/dict/prism.cc
@@ -16,8 +16,11 @@ namespace rime {
 namespace {
 
 struct node_t {
-  string key;
+  node_t(size_t node_pos, size_t key_length)
+      : node_pos(node_pos), key_length(key_length) {}
+
   size_t node_pos;
+  size_t key_length;
 };
 
 // 在 SpellingDescriptor::type 的高位記錄 is_correction, 避開符號位
@@ -269,17 +272,16 @@ bool Prism::GetValue(const string& key, int* value) const {
 
 // Given a key, search all the keys in the tree that share
 // a common prefix with that key.
-void Prism::CommonPrefixSearch(const string& key, vector<Match>* result) {
+void Prism::CommonPrefixSearch(std::string_view key, vector<Match>* result) {
   if (!result || key.empty())
     return;
-  size_t len = key.length();
-  result->resize(len);
-  size_t num_results =
-      trie_->commonPrefixSearch(key.c_str(), &result->front(), len, len);
+  result->resize(key.length());
+  size_t num_results = trie_->commonPrefixSearch(key.data(), &result->front(),
+                                                 key.length(), key.length());
   result->resize(num_results);
 }
 
-void Prism::ExpandSearch(const string& key,
+void Prism::ExpandSearch(std::string_view key,
                          vector<Match>* result,
                          size_t limit) {
   if (!result)
@@ -288,7 +290,8 @@ void Prism::ExpandSearch(const string& key,
   size_t count = 0;
   size_t node_pos = 0;
   size_t key_pos = 0;
-  int ret = trie_->traverse(key.c_str(), node_pos, key_pos);
+  const char* search_key = key.empty() ? "" : key.data();
+  int ret = trie_->traverse(search_key, node_pos, key_pos, key.length());
   // key is not a valid path
   if (ret == -2)
     return;
@@ -297,25 +300,23 @@ void Prism::ExpandSearch(const string& key,
     if (limit && ++count >= limit)
       return;
   }
+  const char* alphabet =
+      (format_ > 1.0 - DBL_EPSILON) ? metadata_->alphabet : kDefaultAlphabet;
   std::queue<node_t> q;
-  q.push({key, node_pos});
+  q.emplace(node_pos, key_pos);
   while (!q.empty()) {
-    node_t node = q.front();
+    const node_t node = q.front();
     q.pop();
-    const char* c =
-        (format_ > 1.0 - DBL_EPSILON) ? metadata_->alphabet : kDefaultAlphabet;
-    for (; *c; ++c) {
-      string k = node.key + *c;
-      size_t k_pos = node.key.length();
-      size_t n_pos = node.node_pos;
-      ret = trie_->traverse(k.c_str(), n_pos, k_pos);
-      if (ret <= -2) {
-        // ignore
-      } else if (ret == -1) {
-        q.push({k, n_pos});
-      } else {
-        q.push({k, n_pos});
-        result->push_back(Match{ret, k_pos});
+    for (const char* c = alphabet; *c; ++c) {
+      size_t next_node_pos = node.node_pos;
+      size_t next_key_pos = 0;
+      ret = trie_->traverse(c, next_node_pos, next_key_pos, 1);
+      if (ret <= -2)
+        continue;
+      const size_t matched_length = node.key_length + next_key_pos;
+      q.emplace(next_node_pos, matched_length);
+      if (ret >= 0) {
+        result->push_back(Match{ret, matched_length});
         if (limit && ++count >= limit)
           return;
       }

--- a/src/rime/dict/prism.h
+++ b/src/rime/dict/prism.h
@@ -9,6 +9,7 @@
 #ifndef RIME_PRISM_H_
 #define RIME_PRISM_H_
 
+#include <string_view>
 #include <darts.h>
 #include <rime/common.h>
 #include <rime/algo/spelling.h>
@@ -79,8 +80,8 @@ class Prism : public MappedFile {
 
   RIME_DLL bool HasKey(const string& key);
   RIME_DLL bool GetValue(const string& key, int* value) const;
-  RIME_DLL void CommonPrefixSearch(const string& key, vector<Match>* result);
-  RIME_DLL void ExpandSearch(const string& key,
+  RIME_DLL void CommonPrefixSearch(std::string_view key, vector<Match>* result);
+  RIME_DLL void ExpandSearch(std::string_view key,
                              vector<Match>* result,
                              size_t limit);
   SpellingAccessor QuerySpelling(SyllableId spelling_id);

--- a/test/prism_test.cc
+++ b/test/prism_test.cc
@@ -5,6 +5,7 @@
 // 2011-05-17 Zou xu <zouivex@gmail.com>
 //
 #include <algorithm>
+#include <string_view>
 #include <gtest/gtest.h>
 #include <rime/dict/prism.h>
 
@@ -17,7 +18,6 @@ class RimePrismTest : public ::testing::Test {
   virtual void SetUp() {
     prism_.reset(new Prism(path{"prism_test.bin"}));
     prism_->Remove();
-
     set<string> keyset;
     keyset.insert("google");   // 4
     keyset.insert("good");     // 2
@@ -38,7 +38,6 @@ class RimePrismTest : public ::testing::Test {
 
 TEST_F(RimePrismTest, SaveAndLoad) {
   EXPECT_TRUE(prism_->Save());
-
   Prism test(prism_->file_path());
   EXPECT_TRUE(test.Load());
 
@@ -57,7 +56,6 @@ TEST_F(RimePrismTest, GetValue) {
   int value = -1;
   EXPECT_TRUE(prism_->GetValue("adobe", &value));
   EXPECT_EQ(value, 0);
-
   value = -1;
   EXPECT_TRUE(prism_->GetValue("baidu", &value));
   EXPECT_EQ(value, 1);
@@ -74,7 +72,6 @@ TEST_F(RimePrismTest, CommonPrefixMatch) {
   EXPECT_EQ(result[1].value, 3);   // goodbye
   EXPECT_EQ(result[1].length, 7);  // goodbye
 }
-
 TEST_F(RimePrismTest, ExpandSearch) {
   vector<Prism::Match> result;
 
@@ -87,4 +84,40 @@ TEST_F(RimePrismTest, ExpandSearch) {
   EXPECT_EQ(result[1].length, 6);  // google
   EXPECT_EQ(result[2].value, 3);   // goodbye
   EXPECT_EQ(result[2].length, 7);  // goodbye
+}
+TEST_F(RimePrismTest, ExpandSearchLimit) {
+  vector<Prism::Match> result;
+  prism_->ExpandSearch("goo", &result, 2);
+  // result is good and google.
+
+  ASSERT_EQ(result.size(), 2);
+  EXPECT_EQ(result[0].value, 2);
+  EXPECT_EQ(result[0].length, 4);
+  EXPECT_EQ(result[1].value, 4);
+  EXPECT_EQ(result[1].length, 6);
+}
+
+TEST_F(RimePrismTest, CommonPrefixSearchWithLength) {
+  const string input("xxgoodbye");
+  vector<Prism::Match> result;
+
+  prism_->CommonPrefixSearch(std::string_view(input).substr(2, 4), &result);
+  ASSERT_EQ(result.size(), 1);
+  EXPECT_EQ(result[0].value, 2);
+  EXPECT_EQ(result[0].length, 4);
+}
+
+TEST_F(RimePrismTest, ExpandSearchWithLength) {
+  const string input("xxgoodbye");
+  vector<Prism::Match> result;
+
+  prism_->ExpandSearch(std::string_view(input).substr(2, 3), &result, 10);
+
+  ASSERT_EQ(result.size(), 3);
+  EXPECT_EQ(result[0].value, 2);
+  EXPECT_EQ(result[0].length, 4);
+  EXPECT_EQ(result[1].value, 4);
+  EXPECT_EQ(result[1].length, 6);
+  EXPECT_EQ(result[2].value, 3);
+  EXPECT_EQ(result[2].length, 7);
 }


### PR DESCRIPTION
## 1：减少 `Prism::ExpandSearch` 的队列状态

### 修改内容

修改文件：

```text
src/rime/dict/prism.cc
```

原来的广度优先补全搜索会在每个队列节点中保存完整拼写字符串，并在扩展每个子分支时重新构造新的字符串。

本次修改后，队列节点只保存：

```cpp
size_t node_pos;
size_t key_length;
```

扩展子节点时，直接从当前 Darts Trie 节点继续遍历下一个字符，不再保留和复制完整 key。

### 收益

* 减少补全过程中的临时字符串构造和复制
* 缩小 BFS 队列节点体积
* 减少入队、出队时的数据搬运
* 降低补全分支较多时的内存访问开销
* 保持 BFS 顺序、返回结果顺序和 `limit` 行为不变

---

## 2：避免音节图构建过程中的临时后缀字符串

### 修改内容

修改文件：

```text
src/rime/dict/prism.h
src/rime/dict/prism.cc
src/rime/algo/syllabifier.cc
```

为以下接口增加“字符指针＋显式长度”重载：

```cpp
CommonPrefixSearch(const char* key,
                   size_t key_length,
                   vector<Match>* result);

ExpandSearch(const char* key,
             size_t key_length,
             vector<Match>* result,
             size_t limit);
```

原来 `Syllabifier::BuildSyllableGraph()` 每访问一个可达音节图位置，都会先创建一个新的后缀字符串：

```cpp
auto current_input = input.substr(begin_pos);
prism.CommonPrefixSearch(current_input, &matches);
```

现在直接传入原始输入字符串中的对应位置和剩余长度：

```cpp
prism.CommonPrefixSearch(input.c_str() + begin_pos,
                         input.length() - begin_pos,
                         &matches);
```

补全路径中的 `ExpandSearch()` 也采用相同方式，避免创建临时后缀字符串。

纠错开启时，`ToleranceSearch()` 仍然使用原来的 `current_input` 字符串，因此纠错行为保持不变；只有实际需要纠错时才创建该子串。

### 收益

* 避免音节图构建过程中反复创建后缀字符串
* 减少字符复制、临时字符串析构和潜在堆内存分配
* 降低输入存在较多可达音节位置时的内存分配压力
* 对长输入、九键、模糊音及拼写分支较多的方案更有意义
* 保留原有 `std::string` 接口，兼容现有调用
* 不改变 Prism 文件格式、查询结果和部署产物

该修改并未改变 Trie 遍历算法本身，而是减少了每次进入 Prism 查询前的字符串准备开销。

在九键下，200万行词库，未开启简拼运算，按下9，原来是850,按修改重新编译后测试降低到650
<img width="2878" height="730" alt="image" src="https://github.com/user-attachments/assets/231efa6d-a92f-45dd-a266-15fa7101bb06" />
