### PR TITLE
Perf/key processing

### DIFF
--- a/src/rime/algo/syllabifier.cc
+++ b/src/rime/algo/syllabifier.cc
@@ -34,9 +34,29 @@ int Syllabifier::BuildSyllableGraph(const string& input,
   if (input.empty())
     return 0;
 
+  using CachedSpellingList = vector<pair<SyllableId, SpellingProperties>>;
+  hash_map<SyllableId, CachedSpellingList> spelling_cache;
+  auto get_cached_spellings =
+      [&](SyllableId spelling_id) -> const CachedSpellingList& {
+    auto it = spelling_cache.find(spelling_id);
+    if (it != spelling_cache.end())
+      return it->second;
+    auto& result = spelling_cache[spelling_id];
+    SpellingAccessor accessor(prism.QuerySpelling(spelling_id));
+    while (!accessor.exhausted()) {
+      result.emplace_back(accessor.syllable_id(), accessor.properties());
+      accessor.Next();
+    }
+    return result;
+  };
+
   size_t farthest = 0;
   VertexQueue queue;
   queue.push(Vertex{0, kNormalSpelling});  // start
+
+  // Reusable vector for prism matches; kept outside the loop to preserve
+  // capacity across iterations and avoid per-vertex reallocation.
+  vector<Prism::Match> matches;
 
   while (!queue.empty()) {
     Vertex vertex(queue.top());
@@ -64,7 +84,7 @@ int Syllabifier::BuildSyllableGraph(const string& input,
                << ", begin_pos: " << begin_pos;
 
     // see where we can go by advancing a syllable
-    vector<Prism::Match> matches;
+    matches.clear();
     set<SyllableId> exact_match_syllables;
     std::string_view current_input(input.data() + begin_pos,
                                    input.length() - begin_pos);
@@ -106,10 +126,11 @@ int Syllabifier::BuildSyllableGraph(const string& input,
         // when spelling algebra is enabled,
         // a spelling evaluates to a set of syllables;
         // otherwise, it resembles exactly the syllable itself.
-        SpellingAccessor accessor(prism.QuerySpelling(m.value));
-        while (!accessor.exhausted()) {
-          SyllableId syllable_id = accessor.syllable_id();
-          EdgeProperties props(accessor.properties());
+        // Use cached spelling list to avoid repeated QuerySpelling iteration
+        // when the same spelling_id appears from multiple vertices.
+        for (const auto& [syllable_id, raw_props] :
+             get_cached_spellings(m.value)) {
+          EdgeProperties props(raw_props);
           if (strict_spelling_ && matches_input &&
               props.type != kNormalSpelling) {
             // disqualify fuzzy spelling or abbreviation as single word
@@ -134,7 +155,6 @@ int Syllabifier::BuildSyllableGraph(const string& input,
               end_vertex_type = props.type;
             }
           }
-          accessor.Next();
         }
         if (spellings.empty()) {
           DLOG(INFO) << "not spelled.";
@@ -221,10 +241,9 @@ int Syllabifier::BuildSyllableGraph(const string& input,
         // when spelling algebra is enabled,
         // a spelling evaluates to a set of syllables;
         // otherwise, it resembles exactly the syllable itself.
-        SpellingAccessor accessor(prism.QuerySpelling(m.value));
-        while (!accessor.exhausted()) {
-          SyllableId syllable_id = accessor.syllable_id();
-          SpellingProperties props = accessor.properties();
+        for (const auto& [syllable_id, raw_props] :
+             get_cached_spellings(m.value)) {
+          SpellingProperties props = raw_props;
           if (props.type < kAbbreviation) {
             props.type = kCompletion;
             props.credibility += kCompletionPenalty;
@@ -233,7 +252,6 @@ int Syllabifier::BuildSyllableGraph(const string& input,
             // spelling-to-syllable map
             spellings.insert({syllable_id, props});
           }
-          accessor.Next();
         }
       }
       if (spellings.empty()) {

--- a/src/rime/composition.cc
+++ b/src/rime/composition.cc
@@ -25,6 +25,7 @@ Preedit Composition::GetPreedit(const string& full_input,
                                 size_t caret_pos,
                                 const string& caret) const {
   Preedit preedit;
+  preedit.text.reserve(full_input.length() * 3 + 32);
   preedit.caret_pos = string::npos;
   size_t start = 0;
   size_t end = 0;
@@ -41,7 +42,7 @@ Preedit Composition::GetPreedit(const string& full_input,
       } else {  // raw input
         end = at(i).end;
         if (!at(i).HasTag("phony")) {
-          preedit.text += input_.substr(start, end - start);
+          preedit.text.append(input_.data() + start, end - start);
         }
       }
     } else {  // highlighted
@@ -49,22 +50,24 @@ Preedit Composition::GetPreedit(const string& full_input,
       preedit.sel_end = string::npos;
       if (cand && !cand->preedit().empty()) {
         end = cand->end();
-        auto caret_placeholder = cand->preedit().find('\t');
+        const string preedit_str = cand->preedit();
+        auto caret_placeholder = preedit_str.find('\t');
         if (caret_placeholder != string::npos) {
-          preedit.text += cand->preedit().substr(0, caret_placeholder);
+          preedit.text.append(preedit_str.data(), caret_placeholder);
           // the part after caret is considered prompt string,
           // show it only when the caret is at the end of input.
           if (caret_pos == end && end == full_input.length()) {
             preedit.sel_end = preedit.sel_start + caret_placeholder;
             preedit.caret_pos = preedit.sel_end;
-            preedit.text += cand->preedit().substr(caret_placeholder + 1);
+            preedit.text.append(preedit_str.data() + caret_placeholder + 1,
+                                preedit_str.length() - caret_placeholder - 1);
           }
         } else {
-          preedit.text += cand->preedit();
+          preedit.text += preedit_str;
         }
       } else {
         end = at(i).end;
-        preedit.text += input_.substr(start, end - start);
+        preedit.text.append(input_.data() + start, end - start);
       }
       if (preedit.sel_end == string::npos) {
         preedit.sel_end = preedit.text.length();
@@ -72,14 +75,14 @@ Preedit Composition::GetPreedit(const string& full_input,
     }
   }
   if (end < input_.length()) {
-    preedit.text += input_.substr(end);
+    preedit.text.append(input_.data() + end, input_.length() - end);
     end = input_.length();
   }
   if (preedit.caret_pos == string::npos) {
     preedit.caret_pos = preedit.text.length();
   }
   if (end < full_input.length()) {
-    preedit.text += full_input.substr(end);
+    preedit.text.append(full_input.data() + end, full_input.length() - end);
   }
   // insert soft cursor and prompt string.
   auto prompt = caret + GetPrompt();
@@ -101,6 +104,7 @@ string Composition::GetPrompt() const {
 
 string Composition::GetCommitText() const {
   string result;
+  result.reserve(input_.length() * 3 + 16);
   size_t end = 0;
   for (const Segment& seg : *this) {
     if (auto cand = seg.GetSelectedCandidate()) {
@@ -109,18 +113,19 @@ string Composition::GetCommitText() const {
     } else {
       end = seg.end;
       if (!seg.HasTag("phony")) {
-        result += input_.substr(seg.start, seg.end - seg.start);
+        result.append(input_.data() + seg.start, seg.end - seg.start);
       }
     }
   }
   if (input_.length() > end) {
-    result += input_.substr(end);
+    result.append(input_.data() + end, input_.length() - end);
   }
   return result;
 }
 
 string Composition::GetScriptText(bool keep_selection) const {
   string result;
+  result.reserve(input_.length() * 3 + 16);
   size_t start = 0;
   size_t end = 0;
   for (const Segment& seg : *this) {
@@ -130,13 +135,14 @@ string Composition::GetScriptText(bool keep_selection) const {
     if (keep_selection && cand && !cand->text().empty() &&
         seg.status >= Segment::kSelected)
       result += cand->text();
-    else if (cand && !cand->preedit().empty())
-      result += boost::erase_first_copy(cand->preedit(), "\t");
-    else if (!seg.HasTag("phony"))
-      result += input_.substr(start, end - start);
+    else if (cand && !cand->preedit().empty()) {
+      const string preedit_str = cand->preedit();
+      result += boost::erase_first_copy(preedit_str, "\t");
+    } else if (!seg.HasTag("phony"))
+      result.append(input_.data() + start, end - start);
   }
   if (input_.length() > end) {
-    result += input_.substr(end);
+    result.append(input_.data() + end, input_.length() - end);
   }
   return result;
 }

--- a/src/rime/dict/prism.cc
+++ b/src/rime/dict/prism.cc
@@ -273,11 +273,22 @@ bool Prism::GetValue(const string& key, int* value) const {
 // Given a key, search all the keys in the tree that share
 // a common prefix with that key.
 void Prism::CommonPrefixSearch(std::string_view key, vector<Match>* result) {
-  if (!result || key.empty())
+  if (!result) {
     return;
-  result->resize(key.length());
-  size_t num_results = trie_->commonPrefixSearch(key.data(), &result->front(),
-                                                 key.length(), key.length());
+  }
+  if (key.empty()) {
+    result->clear();
+    return;
+  }
+  size_t len = key.length();
+  // Reserve capacity to avoid repeated reallocation when the caller reuses
+  // the same vector across multiple calls (e.g., inside BuildSyllableGraph).
+  if (result->capacity() < len) {
+    result->reserve(len);
+  }
+  result->resize(len);
+  size_t num_results =
+      trie_->commonPrefixSearch(key.data(), &result->front(), len, len);
   result->resize(num_results);
 }
 

--- a/test/prism_test.cc
+++ b/test/prism_test.cc
@@ -121,3 +121,31 @@ TEST_F(RimePrismTest, ExpandSearchWithLength) {
   EXPECT_EQ(result[2].value, 3);
   EXPECT_EQ(result[2].length, 7);
 }
+
+TEST_F(RimePrismTest, RepeatedCommonPrefixSearch) {
+  // Exercises the capacity-reuse path in CommonPrefixSearch.
+  // Reuses the same result vector across multiple calls of varying lengths.
+  vector<Prism::Match> result;
+
+  // First call: longer input
+  prism_->CommonPrefixSearch("goodbye", &result);
+  ASSERT_EQ(result.size(), 2);
+  EXPECT_EQ(result[0].value, 2);  // good
+  EXPECT_EQ(result[1].value, 3);  // goodbye
+
+  // Second call: shorter input (same vector, no reallocation expected)
+  result.clear();
+  prism_->CommonPrefixSearch("good", &result);
+  ASSERT_EQ(result.size(), 1);
+  EXPECT_EQ(result[0].value, 2);  // good
+
+  // Third call: longer input again (should reuse existing capacity)
+  prism_->CommonPrefixSearch("goodbye", &result);
+  ASSERT_EQ(result.size(), 2);
+  EXPECT_EQ(result[0].value, 2);  // good
+  EXPECT_EQ(result[1].value, 3);  // goodbye
+
+  // Empty key: should clear the result vector
+  prism_->CommonPrefixSearch("", &result);
+  EXPECT_TRUE(result.empty());
+}

--- a/test/syllabifier_test.cc
+++ b/test/syllabifier_test.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <utility>
 #include <gtest/gtest.h>
+#include <rime/algo/algebra.h>
 #include <rime/dict/prism.h>
 #include <rime/algo/syllabifier.h>
 
@@ -38,7 +39,10 @@ class RimeSyllabifierTest : public ::testing::Test {
     prism_->Build(keyset);
   }
 
-  virtual void TearDown() {}
+  virtual void TearDown() {
+    std::error_code ec;
+    std::filesystem::remove("syllabifier_test.bin", ec);
+  }
 
  protected:
   rime::map<rime::string, rime::SyllableId> syllable_id_;
@@ -210,4 +214,117 @@ TEST_F(RimeSyllabifierTest, TrimBothLeadingAndTrailingDelimiters) {
   ASSERT_FALSE(sp.end() == sp.find(syllable_id_["a"]));
   EXPECT_EQ(rime::kNormalSpelling, sp[0].type);
   EXPECT_EQ(0.0, sp[0].credibility);
+}
+
+// Tests that the spelling cache is used correctly when the same spelling_id
+// is encountered from multiple BFS vertices (ambiguous parsing).
+// Builds a local syllabary that includes "n" as a standalone syllable to
+// exercise the deeper ambiguous path: a + n + a + na.
+// "a" spelling_id is queried at vertices 0 (miss) and 2,4 (hit).
+// "n" spelling_id is queried at vertices 1 (miss) and 3 (hit).
+TEST_F(RimeSyllabifierTest, AmbiguousCacheHit) {
+  rime::vector<rime::string> syllables;
+  syllables.push_back("a");
+  syllables.push_back("an");
+  syllables.push_back("n");
+  syllables.push_back("na");
+  std::sort(syllables.begin(), syllables.end());
+
+  rime::map<rime::string, rime::SyllableId> sid;
+  for (size_t i = 0; i < syllables.size(); ++i) {
+    sid[syllables[i]] = i;
+  }
+
+  rime::path file_path("syllabifier_cache_test.bin");
+  auto test_prism = rime::New<rime::Prism>(file_path);
+  test_prism->Remove();
+  rime::set<rime::string> keyset;
+  std::copy(syllables.begin(), syllables.end(),
+            std::inserter(keyset, keyset.begin()));
+  EXPECT_TRUE(test_prism->Build(keyset));
+
+  rime::Syllabifier s;
+  rime::SyllableGraph g;
+  const rime::string input("anana");
+  int result = s.BuildSyllableGraph(input, *test_prism, &g);
+  EXPECT_EQ(input.length(), result);
+  EXPECT_EQ(input.length(), g.interpreted_length);
+  EXPECT_EQ(input.length() + 1, g.vertices.size());
+
+  // Verify key vertices and edges for the a-n-a-na path
+  EXPECT_FALSE(g.edges.end() == g.edges.find(0));
+  EXPECT_FALSE(g.edges.end() == g.edges.find(1));
+  EXPECT_FALSE(g.edges.end() == g.edges.find(2));
+  EXPECT_FALSE(g.vertices.end() == g.vertices.find(1));
+  EXPECT_FALSE(g.vertices.end() == g.vertices.find(3));
+
+  // a@0→1
+  auto& e0 = g.edges[0];
+  EXPECT_FALSE(e0.end() == e0.find(1));
+  EXPECT_FALSE(e0[1].end() == e0[1].find(sid["a"]));
+  // n@1→2
+  auto& e1 = g.edges[1];
+  EXPECT_FALSE(e1.end() == e1.find(2));
+  EXPECT_FALSE(e1[2].end() == e1[2].find(sid["n"]));
+  // a@2→3
+  auto& e2 = g.edges[2];
+  EXPECT_FALSE(e2.end() == e2.find(3));
+  EXPECT_FALSE(e2[3].end() == e2[3].find(sid["a"]));
+  // na@3→5
+  auto& e3 = g.edges[3];
+  EXPECT_FALSE(e3.end() == e3.find(5));
+  EXPECT_FALSE(e3[5].end() == e3[5].find(sid["na"]));
+
+  test_prism->Remove();
+}
+
+// Test with spelling algebra (Script) to exercise the full cached
+// QuerySpelling path with a non-null spelling_map.
+TEST_F(RimeSyllabifierTest, SpellingAlgebraCache) {
+  rime::set<rime::string> keyset;
+  keyset.insert("zhi");
+  keyset.insert("li");
+  keyset.insert("shi");
+
+  rime::Script script;
+  {
+    rime::Spelling s("zhi");
+    s.properties.type = rime::kNormalSpelling;
+    script["zhi"].push_back(s);
+  }
+  {
+    rime::Spelling s("zhi");
+    s.properties.type = rime::kAbbreviation;
+    script["zh"].push_back(s);
+  }
+  {
+    rime::Spelling s("li");
+    s.properties.type = rime::kNormalSpelling;
+    script["li"].push_back(s);
+  }
+  {
+    rime::Spelling s("shi");
+    s.properties.type = rime::kNormalSpelling;
+    script["shi"].push_back(s);
+  }
+
+  rime::path file_path("syllabifier_algebra_test.bin");
+  auto test_prism = rime::New<rime::Prism>(file_path);
+  test_prism->Remove();
+  EXPECT_TRUE(test_prism->Build(keyset, &script));
+  EXPECT_TRUE(test_prism->Save());
+  EXPECT_TRUE(test_prism->Load());
+
+  rime::Syllabifier s;
+  rime::SyllableGraph g;
+  const rime::string input("zhili");
+  int result = s.BuildSyllableGraph(input, *test_prism, &g);
+  EXPECT_EQ(input.length(), result);
+  EXPECT_EQ(input.length(), g.interpreted_length);
+  EXPECT_FALSE(g.vertices.end() == g.vertices.find(3));
+  EXPECT_FALSE(g.vertices.end() == g.vertices.find(5));
+  EXPECT_FALSE(g.edges.end() == g.edges.find(3));
+  EXPECT_FALSE(g.edges[3].end() == g.edges[3].find(5));
+
+  test_prism->Remove();
 }


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info

#### Summary
Reduce redundant QuerySpelling iterations and string allocation overhead in syllable graph building and composition text assembly.
#### Changes
##### Syllabifier: cache repeated QuerySpelling iterations
BuildSyllableGraph uses BFS; the same spelling_id can be resolved from multiple vertices. Previously each occurrence re-iterated the full SpellingAccessor. Added a hash_map cache so each spelling_id is iterated at most once. Also moved the per-vertex matches vector outside the BFS loop to reuse capacity across iterations, and switched to string_view for the per-vertex substring to avoid substr copies.
##### Composition: eliminate substr copies in text building
GetPreedit / GetCommitText / GetScriptText used string::substr (heap alloc per segment) and += (repeated reallocation). Replaced with append(data() + offset, count) and added reserve() with an estimated upper bound.
Prism: CommonPrefixSearch vector capacity reuse
Added reserve() before resize() so that callers reusing the same vector<Match> across multiple calls (like BuildSyllableGraph) avoid repeated reallocation.
#### Tests added
- AmbiguousCacheHit — validates cache correctness in an ambiguous parse (4-syllable syllabary, overlapping paths)
- SpellingAlgebraCache — validates cache with spelling algebra (Script) and a non-null spelling_map
- RepeatedCommonPrefixSearch — exercises vector capacity reuse across calls of varying lengths
