### PR TITLE
feat(user_dictionary): Ignore userdb entries whose dee is very small

### DIFF
--- a/src/rime/dict/user_dictionary.cc
+++ b/src/rime/dict/user_dictionary.cc
@@ -529,6 +529,9 @@ bool UserDictionary::TranslateCodeToString(const Code& code, string* result) {
   return true;
 }
 
+// Corresponds to log2(1/T)*200*ln(2) ticks.
+constexpr double kDiscardThreshold = 1e-200;
+
 an<DictEntry> UserDictionary::CreateDictEntry(const string& key,
                                               const string& value,
                                               TickCount present_tick,
@@ -546,6 +549,8 @@ an<DictEntry> UserDictionary::CreateDictEntry(const string& key,
     return e;
   if (v.tick < present_tick)
     v.dee = algo::formula_d(0, (double)present_tick, v.dee, (double)v.tick);
+  if (v.dee <= kDiscardThreshold)  // very old entry
+    return e;
   // create!
   e = New<DictEntry>();
   e->text = key.substr(separator_pos + 1);


### PR DESCRIPTION
在查询 userdb 时，跳过 dee 非常小的值，相当于删除了长期不用的废词。

# 参数选择

设初始 dee 为 `d`，

- `formula_d` dee 的半衰期是 `200*log(2) ≈ 138`，
- 令丢弃阈值为 `T`，则相对地 tick 变化了 `log2(1/T)*138` 次，

| T 值 | Δtick | 我的个人词库中的占比 |
|------|------|-------------------|
| 1e-100 | 46051 | 27% |
| 1e-200 | 92103 | 3.08% |
| 1e-300 | 138155 | 1.57% |

1e-200 似乎是个比较合理的值：差不多 10 万次输入都没有打过的用户词，遗忘应该是比较安全的。