### PR TITLE
feat(api): add RimeCandidatePreview for inline preedit

### DIFF
--- a/src/rime/composition.cc
+++ b/src/rime/composition.cc
@@ -179,4 +179,53 @@ string Composition::GetTextBefore(size_t pos) const {
   return string();
 }
 
+Composition::CandidatePreview Composition::GetCandidatePreview(
+    const string& full_input) const {
+  CandidatePreview preview;
+  // input_ is truncated to the caret; full_input recovers chars past it.
+  const string& source = !full_input.empty() ? full_input : input_;
+
+  if (empty()) {
+    preview.selected_text = source;
+    return preview;
+  }
+
+  // rime appends an empty segment at the caret; use the last non-empty one.
+  size_t active = size() - 1;
+  while (active > 0 && at(active).start >= at(active).end) {
+    --active;
+  }
+
+  string before;
+  for (size_t i = 0; i < active; i++) {
+    const Segment& seg = at(i);
+    if (auto cand = seg.GetSelectedCandidate()) {
+      before += cand->text();
+    } else {
+      before += input_.substr(seg.start, seg.end - seg.start);
+    }
+  }
+  preview.text_before_selection = before;
+
+  const Segment& current_seg = at(active);
+  size_t candidate_end_pos = current_seg.end;
+  string segment_text;
+  if (auto candidate = current_seg.GetSelectedCandidate()) {
+    if (candidate && !candidate->text().empty()) {
+      segment_text = candidate->text();
+      candidate_end_pos = candidate->end();
+    }
+  }
+  if (segment_text.empty()) {
+    segment_text =
+        input_.substr(current_seg.start, current_seg.end - current_seg.start);
+  }
+  preview.selected_text = segment_text;
+
+  if (source.length() > candidate_end_pos) {
+    preview.text_after_selection = source.substr(candidate_end_pos);
+  }
+  return preview;
+}
+
 }  // namespace rime

--- a/src/rime/composition.h
+++ b/src/rime/composition.h
@@ -32,6 +32,15 @@ class Composition : public Segmentation {
   RIME_DLL string GetDebugText() const;
   // Returns text of the last segment before the given position.
   string GetTextBefore(size_t pos) const;
+
+  struct CandidatePreview {
+    string text_before_selection;
+    string selected_text;
+    string text_after_selection;
+  };
+
+  CandidatePreview GetCandidatePreview(
+      const string& full_input = string()) const;
 };
 
 }  // namespace rime

--- a/src/rime/context.cc
+++ b/src/rime/context.cc
@@ -324,4 +324,10 @@ void Context::ClearTransientOptions() {
   }
 }
 
+Composition::CandidatePreview Context::GetCandidatePreview() const {
+  // pass the un-truncated input_ so the preview can include chars past the
+  // caret
+  return composition_.GetCandidatePreview(input_);
+}
+
 }  // namespace rime

--- a/src/rime/context.h
+++ b/src/rime/context.h
@@ -36,6 +36,8 @@ class RIME_DLL Context {
   bool HasMenu() const;
   an<Candidate> GetSelectedCandidate() const;
 
+  Composition::CandidatePreview GetCandidatePreview() const;
+
   bool PushInput(char ch);
   bool PushInput(const string& str);
   bool PopInput(size_t len = 1);

--- a/src/rime_api.h
+++ b/src/rime_api.h
@@ -165,6 +165,16 @@ typedef struct RIME_FLAVORED(rime_context_t) {
 /*!
  *  Should be initialized by calling RIME_STRUCT_INIT(Type, var);
  */
+typedef struct rime_candidate_preview_t {
+  int data_size;
+  char* text_before_selection;
+  char* selected_text;
+  char* text_after_selection;
+} RimeCandidatePreview;
+
+/*!
+ *  Should be initialized by calling RIME_STRUCT_INIT(Type, var);
+ */
 typedef struct RIME_FLAVORED(rime_status_t) {
   int data_size;
   // v0.9
@@ -505,6 +515,12 @@ typedef struct RIME_FLAVORED(rime_api_t) {
                                               size_t index);
 
   Bool (*change_page)(RimeSessionId session_id, Bool backward);
+
+  //! get the preview of committing the highlighted candidate
+  Bool (*get_candidate_preview)(RimeSessionId session_id,
+                                RimeCandidatePreview* preview);
+  //! free a RimeCandidatePreview filled by get_candidate_preview
+  Bool (*free_candidate_preview)(RimeCandidatePreview* preview);
 } RIME_FLAVORED(RimeApi);
 
 //! API entry

--- a/src/rime_api_impl.h
+++ b/src/rime_api_impl.h
@@ -1027,6 +1027,51 @@ static Bool RimeChangePage(RimeSessionId session_id, Bool backward) {
   return Bool(ctx->Highlight(index));
 }
 
+static char* dup_string(const string& s) {
+  if (s.empty())
+    return nullptr;
+  char* p = new char[s.length() + 1];
+  std::strcpy(p, s.c_str());
+  return p;
+}
+
+static Bool fill_candidate_preview(const Composition::CandidatePreview& src,
+                                   RimeCandidatePreview* dst) {
+  if (src.selected_text.empty()) {
+    return False;
+  }
+  dst->text_before_selection = dup_string(src.text_before_selection);
+  dst->selected_text = dup_string(src.selected_text);
+  dst->text_after_selection = dup_string(src.text_after_selection);
+  return True;
+}
+
+static Bool RimeGetCandidatePreview(RimeSessionId session_id,
+                                    RimeCandidatePreview* preview) {
+  if (!preview || preview->data_size <= 0)
+    return False;
+  RIME_STRUCT_CLEAR(*preview);
+
+  an<Session> session(Service::instance().GetSession(session_id));
+  if (!session)
+    return False;
+  Context* ctx = session->context();
+  if (!ctx)
+    return False;
+
+  return fill_candidate_preview(ctx->GetCandidatePreview(), preview);
+}
+
+static Bool RimeFreeCandidatePreview(RimeCandidatePreview* preview) {
+  if (!preview)
+    return False;
+  delete[] preview->text_before_selection;
+  delete[] preview->selected_text;
+  delete[] preview->text_after_selection;
+  RIME_STRUCT_CLEAR(*preview);
+  return True;
+}
+
 static Bool RimeHighlightCandidate(RimeSessionId session_id, size_t index) {
   return (Bool)do_with_candidate(session_id, index, &Context::Highlight);
 }
@@ -1232,6 +1277,8 @@ RIME_API RIME_FLAVORED(RimeApi) * RIME_FLAVORED(rime_get_api)() {
     s_api.highlight_candidate_on_current_page =
         &RimeHighlightCandidateOnCurrentPage;
     s_api.change_page = &RimeChangePage;
+    s_api.get_candidate_preview = &RimeGetCandidatePreview;
+    s_api.free_candidate_preview = &RimeFreeCandidatePreview;
   }
   return &s_api;
 }


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #1163

#### Feature
The alignment between the raw preedit input and the candidate text is only known accurately inside librime; a frontend cannot reliably reconstruct it from the outside. That reconstruction is the root cause of a recurring class of crashes — [rime/squirrel#1041](https://github.com/rime/squirrel/issues/1041) / [rime/squirrel#1045](https://github.com/rime/squirrel/issues/1045) / [rime/squirrel#1047](https://github.com/rime/squirrel/issues/1047) / [rime/squirrel#1081](https://github.com/rime/squirrel/issues/1081) — where the preedit offsets (e.g. pinyin) and the Han-character commit_text_preview don't line up.

This exposes a new CandidatePreview API that returns the text a candidate would commit, already split at the selection boundary into three parts:

```C++
typedef struct {
  int data_size;
  char* text_before_selection;
  char* selected_text;
  char* text_after_selection;
  Bool has_remaining_input;
} RimeCandidatePreview;

Bool (*get_candidate_preview)(RimeSessionId, size_t index, RimeCandidatePreview*);
Bool (*get_candidate_preview_on_current_page)(RimeSessionId, size_t index, RimeCandidatePreview*);
Bool (*free_candidate_preview)(RimeCandidatePreview*);
```

#### Unit test
- [ ] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
[The Old Approach](https://github.com/rime/squirrel/blob/1dde02217f112d912772a5b03e217e0dd4895e14/sources/SquirrelInputController.swift#L477)
After:

```Swift
if inlineCandidate {
  var preview = RimeCandidatePreview.rimeStructInit()
  _ = rimeAPI.get_candidate_preview(session, &preview)
  let before = preview.text_before_selection.map { String(cString: $0) } ?? ""
  let selected = preview.selected_text.map { String(cString: $0) } ?? ""
  let after = preview.text_after_selection.map { String(cString: $0) } ?? ""
  let hasRemaining = preview.text_after_selection != nil
  _ = rimeAPI.free_candidate_preview(&preview)

  let display = (inlinePreedit || !hasRemaining) ? before + selected + after : before + selected
  let selLocation = before.utf16.count
  show(preedit: display,
       selRange: NSRange(location: selLocation, length: selected.utf16.count),
       caretPos: selLocation + selected.utf16.count)
}
```

已在本地自行编译并将使用新API的鼠须管作为日常输入法使用过一段时间，测试过不同方案（魔然/雾凇/默认），上述issue均不再复现，也没有发现其他问题。