### PR TITLE
[Spelling Algebra] Reorder rule

### DIFF
--- a/src/rime/algo/calculus.cc
+++ b/src/rime/algo/calculus.cc
@@ -70,27 +70,38 @@ Calculation* Transliteration::Parse(const vector<string>& args) {
 bool Transliteration::Apply(Spelling* spelling) {
   if (!spelling || spelling->str.empty())
     return false;
+
+  const char* const start = spelling->str.c_str();
+  const char* const end = start + spelling->str.size();
+
+  string result;
   bool modified = false;
-  const char* p = spelling->str.c_str();
-  const int buffer_len = 256;
-  char buffer[buffer_len] = "";
-  char* q = buffer;
-  uint32_t c;
-  while ((c = utf8::unchecked::next(p))) {
-    if (q - buffer > buffer_len - 7) {  // insufficient space
-      modified = false;
-      break;
+
+  const char* p = start;
+  while (p < end) {
+    const char* here = p;
+    uint32_t c = utf8::unchecked::next(p);
+
+    auto it = char_map_.find(c);
+    if (it != char_map_.end()) {
+      if (!modified) {
+        // allocate space and copy unmodified prefix up to this point
+        modified = true;
+        result.reserve(spelling->str.size());
+        result.assign(start, here - start);
+      }
+      c = it->second;  // replace character
     }
-    if (char_map_.find(c) != char_map_.end()) {
-      c = char_map_[c];
-      modified = true;
+
+    if (modified) {
+      utf8::unchecked::append(c, std::back_inserter(result));
     }
-    q = utf8::unchecked::append(c, q);
   }
+
   if (modified) {
-    *q = '\0';
-    spelling->str.assign(buffer);
+    spelling->str = std::move(result);
   }
+
   return modified;
 }
 

--- a/src/rime/algo/calculus.cc
+++ b/src/rime/algo/calculus.cc
@@ -22,6 +22,7 @@ Calculus::Calculus() {
   Register("derive", &Derivation::Parse);
   Register("fuzz", &Fuzzing::Parse);
   Register("abbrev", &Abbreviation::Parse);
+  Register("reorder", &Reorder::Parse);
 }
 
 void Calculus::Register(const string& token, Calculation::Factory* factory) {
@@ -252,6 +253,120 @@ bool Correction::Apply(Spelling* spelling) {
     spelling->properties.credibility += kCorrectionPenalty;
   }
   return result;
+}
+
+// Reorder
+
+Calculation* Reorder::Parse(const vector<string>& args) {
+  if (args.size() < 2)
+    return nullptr;
+  const string& order = args[1];
+  if (order.empty())
+    return nullptr;
+  bool dedup = args.size() > 2 && args[2] == "dedup";
+  the<Reorder> x(new Reorder);
+  utf8::unchecked::utf8to32(order.begin(), order.end(),
+                            std::back_inserter(x->order_));
+  x->dedup_ = dedup;
+  return x.release();
+}
+
+bool Reorder::Apply(Spelling* spelling) {
+  if (!spelling || spelling->str.empty())
+    return false;
+
+  const char* const start = spelling->str.c_str();
+  const char* const end = start + spelling->str.length();
+
+  string result;
+  bool modified = false;
+
+  vector<int> key_count(order_.size(), 0);
+  const char* group_start = nullptr;
+  size_t last_key_index = 0;
+  bool needs_reorder = false;
+
+  // flush the reordered characters from the key group
+  auto flush_group = [&](auto& output) {
+    for (size_t k = 0; k < order_.size(); ++k) {
+      if (key_count[k]) {
+        const uint32_t key = order_.at(k);
+        const size_t n = dedup_ ? 1 : key_count[k];
+        for (size_t i = 0; i < n; ++i) {
+          utf8::unchecked::append(key, output);
+        }
+      }
+    }
+  };
+
+  // clear the key count of the current group
+  auto clear_group = [&]() {
+    std::fill(key_count.begin(), key_count.end(), 0);
+    group_start = nullptr;
+  };
+
+  auto settle_group = [&](const char* group_end) {
+    if (!group_start)
+      return;
+
+    if (needs_reorder) {
+      if (!modified) {
+        modified = true;
+        // allocate space and copy unmodified prefix before the group
+        result.reserve(spelling->str.size());
+        result.assign(start, group_start - start);
+      }
+      auto output = std::back_inserter(result);
+      flush_group(output);
+    } else if (modified) {
+      // copy the unmodified group to the result
+      result.append(group_start, group_end - group_start);
+    }
+    clear_group();
+  };
+
+  const char* p = start;
+  while (p < end) {
+    const char* const here = p;
+    uint32_t c = utf8::unchecked::next(p);
+
+    size_t key_index = order_.find(c);
+    if (key_index != std::u32string::npos) {
+      // belongs to the key group to be reordered
+      if (!group_start) {
+        group_start = here;
+        needs_reorder = false;
+      } else if (key_index < last_key_index) {
+        // the key is not in monotonically increasing order
+        needs_reorder = true;
+      }
+      last_key_index = key_index;
+
+      ++key_count[key_index];
+      if (dedup_ && key_count[key_index] > 1) {
+        needs_reorder = true;
+      }
+      continue;
+    }
+
+    // found a delimiting character; settle the previous key group
+    settle_group(here);
+
+    // append the current delimiting character
+    if (modified) {
+      auto output = std::back_inserter(result);
+      utf8::unchecked::append(c, output);
+    }
+  }  // end of string traversal
+
+  // settle the key group at the end of string
+  settle_group(end);
+
+  if (modified) {
+    spelling->str = std::move(result);
+  }
+
+  return modified;
 }
 
 }  // namespace rime

--- a/src/rime/algo/calculus.h
+++ b/src/rime/algo/calculus.h
@@ -96,6 +96,17 @@ class Correction : public Derivation {
   bool Apply(Spelling* spelling) override;
 };
 
+// reorder/zyx/dedup  ("xzxy" -> "zyx")
+class Reorder : public Calculation {
+ public:
+  static Factory Parse;
+  bool Apply(Spelling* spelling) override;
+
+ protected:
+  std::u32string order_;
+  bool dedup_;
+};
+
 }  // namespace rime
 
 #endif  // RIME_CALCULUS_H_

--- a/test/calculus_test.cc
+++ b/test/calculus_test.cc
@@ -2,34 +2,31 @@
 // Copyright RIME Developers
 // Distributed under the BSD License
 //
-// 2012-01-17 GONG Chen <chen.sst@gmail.com>
-//
 #include <cmath>
 #include <gtest/gtest.h>
 #include <rime/common.h>
 #include <rime/algo/calculus.h>
 
-static const char* kTransliteration =
-    "xlit abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-static const char* kTransformation = "xform/^([zcs])h(.*)$/$1$2/";
-static const char* kErasion = "erase/^[czs]h[aoe]ng?$/";
-static const char* kDerivation = "derive/^([zcs])h/$1/";
-static const char* kAbbreviation = "abbrev/^([zcs]h).*$/$1/";
+// Combo Pinyin 3.0 key order
+static const char* kComboPinyinKeyOrder = "SCZHLFGDBKTPIUÜANREO";
+
+using namespace rime;
 
 TEST(RimeCalculusTest, Transliteration) {
-  rime::Calculus calc;
-  rime::the<rime::Calculation> c(calc.Parse(kTransliteration));
+  Calculus calc;
+  the<Calculation> c(
+      calc.Parse("xlit abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
   ASSERT_TRUE(bool(c));
-  rime::Spelling s("abracadabra");
+  Spelling s("abracadabra");
   EXPECT_TRUE(c->Apply(&s));
   EXPECT_EQ("ABRACADABRA", s.str);
 }
 
 TEST(RimeCalculusTest, Transformation) {
-  rime::Calculus calc;
-  rime::the<rime::Calculation> c(calc.Parse(kTransformation));
+  Calculus calc;
+  the<Calculation> c(calc.Parse("xform/^([zcs])h(.*)$/$1$2/"));
   ASSERT_TRUE(bool(c));
-  rime::Spelling s("shang");
+  Spelling s("shang");
   EXPECT_TRUE(c->Apply(&s));
   EXPECT_EQ("sang", s.str);
   // non-matching case
@@ -38,12 +35,12 @@ TEST(RimeCalculusTest, Transformation) {
 }
 
 TEST(RimeCalculusTest, Erasion) {
-  rime::Calculus calc;
-  rime::the<rime::Calculation> c(calc.Parse(kErasion));
+  Calculus calc;
+  the<Calculation> c(calc.Parse("erase/^[czs]h[aoe]ng?$/"));
   ASSERT_TRUE(bool(c));
   EXPECT_FALSE(c->addition());
   EXPECT_TRUE(c->deletion());
-  rime::Spelling s("shang");
+  Spelling s("shang");
   EXPECT_TRUE(c->Apply(&s));
   EXPECT_EQ("", s.str);
   // non-matching case
@@ -52,12 +49,12 @@ TEST(RimeCalculusTest, Erasion) {
 }
 
 TEST(RimeCalculusTest, Derivation) {
-  rime::Calculus calc;
-  rime::the<rime::Calculation> c(calc.Parse(kDerivation));
+  Calculus calc;
+  the<Calculation> c(calc.Parse("derive/^([zcs])h/$1/"));
   ASSERT_TRUE(bool(c));
   EXPECT_TRUE(c->addition());
   EXPECT_FALSE(c->deletion());
-  rime::Spelling s("shang");
+  Spelling s("shang");
   EXPECT_TRUE(c->Apply(&s));
   EXPECT_EQ("sang", s.str);
   // non-matching case
@@ -66,14 +63,156 @@ TEST(RimeCalculusTest, Derivation) {
 }
 
 TEST(RimeCalculusTest, Abbreviation) {
-  rime::Calculus calc;
-  rime::the<rime::Calculation> c(calc.Parse(kAbbreviation));
+  Calculus calc;
+  the<Calculation> c(calc.Parse("abbrev/^([zcs]h).*$/$1/"));
   ASSERT_TRUE(bool(c));
   EXPECT_TRUE(c->addition());
   EXPECT_FALSE(c->deletion());
-  rime::Spelling s("shang");
+  Spelling s("shang");
   EXPECT_TRUE(c->Apply(&s));
   EXPECT_EQ("sh", s.str);
   EXPECT_EQ(rime::kAbbreviation, s.properties.type);
   EXPECT_DOUBLE_EQ(log(0.5), s.properties.credibility);
+}
+
+// 基礎雙鍵與多鍵並擊亂序重排 (Inversion & Interleaving)
+TEST(RimeCalculusTest, ReorderBasicInversion) {
+  Calculus calc;
+  std::string formula = std::string("reorder ") + kComboPinyinKeyOrder;
+  std::unique_ptr<Calculation> reorder(calc.Parse(formula));
+  ASSERT_NE(reorder, nullptr);
+
+  // 1. 聲母同手指倒錯：FZ (zh) -> ZF
+  Spelling s1("FZ");
+  EXPECT_TRUE(reorder->Apply(&s1));
+  EXPECT_EQ(s1.str, "ZF");
+
+  // 2. 音節內多鍵亂序：FZURO (zhong) -> ZFURO
+  Spelling s2("FZURO");
+  EXPECT_TRUE(reorder->Apply(&s2));
+  EXPECT_EQ(s2.str, "ZFURO");
+
+  // 3. 雙手並發極速交錯（右手先於左手）：UZRF (zhui) -> ZFUR
+  Spelling s3("UZRF");
+  EXPECT_TRUE(reorder->Apply(&s3));
+  EXPECT_EQ(s3.str, "ZFUR");
+}
+
+// 已經符合標準鍵序的字符串（無須修改，應返回 false）
+TEST(RimeCalculusTest, ReorderAlreadyOrdered) {
+  Calculus calc;
+  std::string formula = std::string("reorder ") + kComboPinyinKeyOrder;
+  std::unique_ptr<Calculation> reorder(calc.Parse(formula));
+  ASSERT_NE(reorder, nullptr);
+
+  // 標準和弦碼：不應修改，Apply 返回 false
+  Spelling s1("ZFURO");
+  EXPECT_FALSE(reorder->Apply(&s1));
+  EXPECT_EQ(s1.str, "ZFURO");
+
+  Spelling s2("ZF");
+  EXPECT_FALSE(reorder->Apply(&s2));
+  EXPECT_EQ(s2.str, "ZF");
+}
+
+// 包含音節分隔符 '\'' 的連擊字符串 (Delimited Key Groups)
+TEST(RimeCalculusTest, ReorderWithDelimiter) {
+  Calculus calc;
+  std::string formula = std::string("reorder ") + kComboPinyinKeyOrder;
+  std::unique_ptr<Calculation> reorder(calc.Parse(formula));
+  ASSERT_NE(reorder, nullptr);
+
+  // 1. 第一組亂序，第二組已有序：FZURO'UN -> ZFURO'UN
+  Spelling s1("FZURO'UN");
+  EXPECT_TRUE(reorder->Apply(&s1));
+  EXPECT_EQ(s1.str, "ZFURO'UN");
+
+  // 2. 兩組均亂序：FZ'NU -> ZF'UN
+  Spelling s2("FZ'NU");
+  EXPECT_TRUE(reorder->Apply(&s2));
+  EXPECT_EQ(s2.str, "ZF'UN");
+
+  // 3. 分隔符位於開頭與末尾的邊界情況
+  Spelling s3("'FZ");
+  EXPECT_TRUE(reorder->Apply(&s3));
+  EXPECT_EQ(s3.str, "'ZF");
+
+  Spelling s4("FZ'");
+  EXPECT_TRUE(reorder->Apply(&s4));
+  EXPECT_EQ(s4.str, "ZF'");
+}
+
+// 去重模式 (dedup) 驗證
+TEST(RimeCalculusTest, ReorderDeduplication) {
+  Calculus calc;
+  std::string formula_no_dedup = std::string("reorder ") + kComboPinyinKeyOrder;
+  std::string formula_dedup =
+      std::string("reorder ") + kComboPinyinKeyOrder + " dedup";
+
+  std::unique_ptr<Calculation> reorder_no_dedup(calc.Parse(formula_no_dedup));
+  std::unique_ptr<Calculation> reorder_dedup(calc.Parse(formula_dedup));
+
+  ASSERT_NE(reorder_no_dedup, nullptr);
+  ASSERT_NE(reorder_dedup, nullptr);
+
+  // 無 dedup 模式：重複按鍵保留（若是順序的則返回 false）
+  Spelling s1("ZZFFUU");
+  EXPECT_FALSE(reorder_no_dedup->Apply(&s1));
+  EXPECT_EQ(s1.str, "ZZFFUU");
+
+  // 有 dedup 模式：重複按鍵被壓縮去重，且返回 true（觸發了修改）
+  Spelling s2("ZZFFUU");
+  EXPECT_TRUE(reorder_dedup->Apply(&s2));
+  EXPECT_EQ(s2.str, "ZFU");
+
+  // 有 dedup 模式 + 亂序：FFZZUU -> ZFU
+  Spelling s3("FFZZUU");
+  EXPECT_TRUE(reorder_dedup->Apply(&s3));
+  EXPECT_EQ(s3.str, "ZFU");
+}
+
+// 非鍵序內字符（如標點、大寫字母）的隔離保護
+TEST(RimeCalculusTest, ReorderNonOrderCharacters) {
+  Calculus calc;
+  std::unique_ptr<Calculation> reorder(calc.Parse("reorder zyx"));
+  ASSERT_NE(reorder, nullptr);
+
+  // 1. 字符 'a' 不在 "zyx" 中，作為分隔符：xzy - a - xzy -> zyx - a - zyx
+  Spelling s1("xzyaxzy");
+  EXPECT_TRUE(reorder->Apply(&s1));
+  EXPECT_EQ(s1.str, "zyxazyx");
+
+  // 2. 大寫字母 A, B 不在 "zyx" 中，原樣保留：
+  // xzy - A - xzy - B -> zyx - A - zyx - B
+  Spelling s2("xzyAxzyB");
+  EXPECT_TRUE(reorder->Apply(&s2));
+  EXPECT_EQ(s2.str, "zyxAzyxB");
+}
+
+// 非鍵序內字符（如標點、大寫字母）的隔離保護，開啓去重模式
+TEST(RimeCalculusTest, ReorderNonOrderCharactersWithDedup) {
+  Calculus calc;
+  // 加上 dedup 參數
+  std::unique_ptr<Calculation> reorder(calc.Parse("reorder zyx dedup"));
+  ASSERT_NE(reorder, nullptr);
+
+  // 'a' 爲分隔符，xzxy 去重重排 -> zyx，xzy 重排 -> zyx
+  Spelling s1("xzxyaxzy");
+  EXPECT_TRUE(reorder->Apply(&s1));
+  EXPECT_EQ(s1.str, "zyxazyx");
+}
+
+// Calculus 工廠解析器 (Parse) 的參數校驗
+TEST(RimeCalculusTest, ReorderParseValidation) {
+  Calculus calc;
+
+  // 缺少參數 -> 返回 nullptr
+  EXPECT_EQ(calc.Parse("reorder"), nullptr);
+
+  // order 字符串爲空 -> 返回 nullptr
+  EXPECT_EQ(calc.Parse("reorder "), nullptr);
+
+  // 合法參數
+  EXPECT_NE(calc.Parse("reorder zyx"), nullptr);
+  EXPECT_NE(calc.Parse("reorder zyx dedup"), nullptr);
 }


### PR DESCRIPTION
將構成音節的一串鍵碼按照宮保拼音並擊鍵序重新排列：

    - reorder SCZHLFGDBKTPIUÜANREO

`FZOUR ->  ZFURO`
`ZROUF ->  ZFURO`