### PR TITLE
Incremental sentence candidate decoding for long inputs

### DIFF
--- a/src/rime/dict/dictionary.cc
+++ b/src/rime/dict/dictionary.cc
@@ -240,9 +240,10 @@ static void lookup_table(Table* table,
                          const SyllableGraph& syllable_graph,
                          size_t start_pos,
                          bool predict_word,
-                         double initial_credibility) {
+                         double initial_credibility,
+                         size_t end_bound = 0) {
   TableQueryResult result;
-  if (!table->Query(syllable_graph, start_pos, &result)) {
+  if (!table->Query(syllable_graph, start_pos, &result, end_bound)) {
     return;
   }
   // copy result
@@ -272,7 +273,8 @@ an<DictEntryCollector> Dictionary::Lookup(const SyllableGraph& syllable_graph,
                                           size_t start_pos,
                                           const hash_set<string>* blacklist,
                                           bool predict_word,
-                                          double initial_credibility) {
+                                          double initial_credibility,
+                                          size_t end_bound) {
   if (!loaded())
     return nullptr;
   auto collector = New<DictEntryCollector>();
@@ -280,10 +282,22 @@ an<DictEntryCollector> Dictionary::Lookup(const SyllableGraph& syllable_graph,
     if (!table->IsOpen())
       continue;
     lookup_table(table.get(), collector.get(), syllable_graph, start_pos,
-                 predict_word, initial_credibility);
+                 predict_word, initial_credibility, end_bound);
   }
   if (collector->empty())
     return nullptr;
+  // drop entries ending at or before the bound when a suffix is appended
+  if (end_bound > 0) {
+    for (auto it = collector->begin(); it != collector->end();) {
+      if (it->first <= end_bound) {
+        it = collector->erase(it);
+      } else {
+        ++it;
+      }
+    }
+    if (collector->empty())
+      return nullptr;
+  }
   // for each group of equal code length, sort it and filter words
   for (auto& v : *collector) {
     v.second.Sort();

--- a/src/rime/dict/dictionary.h
+++ b/src/rime/dict/dictionary.h
@@ -76,7 +76,8 @@ class Dictionary : public Class<Dictionary, const Ticket&> {
       size_t start_pos,
       const hash_set<string>* blacklist = nullptr,
       bool predict_word = false,
-      double initial_credibility = 0.0);
+      double initial_credibility = 0.0,
+      size_t end_bound = 0);
   // if predictive is true, do an expand search with limit,
   // otherwise do an exact match.
   // return num of matching keys.

--- a/src/rime/dict/table.cc
+++ b/src/rime/dict/table.cc
@@ -570,7 +570,8 @@ const double kPenaltyForAmbiguousSyllable = -2.995732274;
 
 bool Table::Query(const SyllableGraph& syll_graph,
                   size_t start_pos,
-                  TableQueryResult* result) {
+                  TableQueryResult* result,
+                  size_t end_bound) {
   if (!result || !index_ || start_pos >= syll_graph.interpreted_length)
     return false;
   result->clear();
@@ -614,7 +615,7 @@ bool Table::Query(const SyllableGraph& syll_graph,
             (is_normal_spelling ? 1.0 : 0.0) * (end_pos - current_pos);
         TableAccessor accessor =
             query.Access(syll_id, next_credibility, delta_quality_len);
-        if (!accessor.exhausted()) {
+        if (end_pos > end_bound && !accessor.exhausted()) {
           (*result)[end_pos].push_back(accessor);
         }
         if (end_pos < syll_graph.interpreted_length &&

--- a/src/rime/dict/table.h
+++ b/src/rime/dict/table.h
@@ -206,7 +206,8 @@ class Table : public MappedFile {
   RIME_DLL TableAccessor QueryPhrases(const Code& code);
   RIME_DLL bool Query(const SyllableGraph& syll_graph,
                       size_t start_pos,
-                      TableQueryResult* result);
+                      TableQueryResult* result,
+                      size_t end_bound = 0);
   RIME_DLL string GetEntryText(const table::Entry& entry);
 
   uint32_t dict_file_checksum() const;

--- a/src/rime/dict/user_dictionary.cc
+++ b/src/rime/dict/user_dictionary.cc
@@ -216,7 +216,8 @@ bool UserDictionary::readonly() const {
 void UserDictionary::DfsLookup(const SyllableGraph& syll_graph,
                                size_t current_pos,
                                const string& current_prefix,
-                               DfsState* state) {
+                               DfsState* state,
+                               size_t end_bound) {
   auto index = syll_graph.indices.find(current_pos);
   if (index == syll_graph.indices.end()) {
     return;
@@ -258,11 +259,19 @@ void UserDictionary::DfsLookup(const SyllableGraph& syll_graph,
         if (!state->ForwardScan(prefix))  // reached the end of db
           continue;
       }
-      while (state->IsExactMatch(prefix)) {  // 'b |e ' vs. 'b e \tBe'
-        DLOG(INFO) << "match found for '" << prefix << "'.";
-        state->RecruitEntry(end_pos);
-        if (!state->NextEntry())  // reached the end of db
-          break;
+      if (end_pos <= end_bound) {
+        // entries ending at or before the bound are already cached
+        while (state->IsExactMatch(prefix)) {
+          if (!state->NextEntry())  // reached the end of db
+            break;
+        }
+      } else {
+        while (state->IsExactMatch(prefix)) {  // 'b |e ' vs. 'b e \tBe'
+          DLOG(INFO) << "match found for '" << prefix << "'.";
+          state->RecruitEntry(end_pos);
+          if (!state->NextEntry())  // reached the end of db
+            break;
+        }
       }
       auto next_index = syll_graph.indices.find(end_pos);
       if (next_index == syll_graph.indices.end()) {
@@ -292,7 +301,7 @@ void UserDictionary::DfsLookup(const SyllableGraph& syll_graph,
         // the caller can limit the number of syllables to look up
         if ((!state->depth_limit || state->depth() < state->depth_limit) &&
             state->IsPrefixMatch(prefix)) {  // 'b |e ' vs. 'b e f \tBefore'
-          DfsLookup(syll_graph, end_pos, prefix, state);
+          DfsLookup(syll_graph, end_pos, prefix, state, end_bound);
         }
       }
     }
@@ -316,7 +325,8 @@ an<UserDictEntryCollector> UserDictionary::Lookup(
     size_t start_pos,
     size_t depth_limit,
     size_t predict_word_from_depth,
-    double initial_credibility) {
+    double initial_credibility,
+    size_t end_bound) {
   if (!table_ || !prism_ || !loaded() ||
       start_pos >= syll_graph.interpreted_length)
     return nullptr;
@@ -330,7 +340,7 @@ an<UserDictEntryCollector> UserDictionary::Lookup(
   state.accessor = db_->Query("");
   state.accessor->Jump(" ");  // skip metadata
   string prefix;
-  DfsLookup(syll_graph, start_pos, prefix, &state);
+  DfsLookup(syll_graph, start_pos, prefix, &state, end_bound);
   if (state.query_result.empty())
     return nullptr;
   // sort each group of homophones by weight

--- a/src/rime/dict/user_dictionary.h
+++ b/src/rime/dict/user_dictionary.h
@@ -60,7 +60,8 @@ class UserDictionary : public Class<UserDictionary, const Ticket&> {
                                     size_t start_pos,
                                     size_t depth_limit = 0,
                                     size_t predict_word_from_depth = 0,
-                                    double initial_credibility = 0.0);
+                                    double initial_credibility = 0.0,
+                                    size_t end_bound = 0);
   size_t LookupWords(UserDictEntryIterator* result,
                      const string& input,
                      bool predictive,
@@ -93,7 +94,8 @@ class UserDictionary : public Class<UserDictionary, const Ticket&> {
   void DfsLookup(const SyllableGraph& syll_graph,
                  size_t current_pos,
                  const string& current_prefix,
-                 DfsState* state);
+                 DfsState* state,
+                 size_t end_bound = 0);
 
  private:
   string name_;

--- a/src/rime/gear/poet.cc
+++ b/src/rime/gear/poet.cc
@@ -16,59 +16,6 @@
 
 namespace rime {
 
-// internal data structure used during the sentence making process.
-// the output line of the algorithm is transformed to an<Sentence>.
-struct Line {
-  // be sure the pointer to predecessor Line object is stable. it works since
-  // pointer to values stored in std::map and std::unordered_map are stable.
-  const Line* predecessor;
-  // as long as the word graph lives, pointers to entries are valid.
-  const DictEntry* entry;
-  size_t end_pos;
-  double weight;
-  size_t text_hash;  // for dedup
-
-  static const Line kEmpty;
-
-  bool empty() const { return !predecessor && !entry; }
-
-  string last_word() const { return entry ? entry->text : string(); }
-
-  struct Components {
-    vector<const Line*> lines;
-
-    Components(const Line* line) {
-      for (const Line* cursor = line; !cursor->empty();
-           cursor = cursor->predecessor) {
-        lines.push_back(cursor);
-      }
-    }
-
-    decltype(lines.crbegin()) begin() const { return lines.crbegin(); }
-    decltype(lines.crend()) end() const { return lines.crend(); }
-  };
-
-  Components components() const { return Components(this); }
-
-  string context() const {
-    // look back 2 words
-    return empty() ? string()
-           : !predecessor || predecessor->empty()
-               ? last_word()
-               : predecessor->last_word() + last_word();
-  }
-
-  vector<size_t> word_lengths() const {
-    vector<size_t> lengths;
-    size_t last_end_pos = 0;
-    for (const auto* c : components()) {
-      lengths.push_back(c->end_pos - last_end_pos);
-      last_end_pos = c->end_pos;
-    }
-    return lengths;
-  }
-};
-
 const Line Line::kEmpty{nullptr, nullptr, 0, 0.0, 0};
 
 inline static Grammar* create_grammar(Config* config) {
@@ -107,9 +54,6 @@ bool Poet::LeftAssociateCompare(const Line& one, const Line& other) {
   }
   return false;
 }
-
-// keep the best line candidate per last phrase
-using LineCandidates = hash_map<string, Line>;
 
 template <int N>
 static vector<const Line*> find_top_candidates(const LineCandidates& candidates,
@@ -189,26 +133,32 @@ struct DynamicProgramming {
 };
 
 template <class Strategy>
-an<Sentence> Poet::MakeSentenceWithStrategy(const WordGraph& graph,
-                                            size_t total_length,
-                                            const string& preceding_text) {
-  map<int, typename Strategy::State> states;
-  Strategy::Initiate(states[0]);
+an<Sentence> Poet::MakeSentenceWithStrategy(
+    const WordGraph& graph,
+    size_t total_length,
+    const string& preceding_text,
+    size_t covered_len,
+    map<int, typename Strategy::State>* states) {
+  map<int, typename Strategy::State> fresh_states;
+  if (!states)
+    states = &fresh_states;
+  if (states->empty())
+    Strategy::Initiate((*states)[0]);
   for (const auto& sv : graph) {
     size_t start_pos = sv.first;
-    if (states.find(start_pos) == states.end())
+    if (states->find(start_pos) == states->end())
       continue;
     DLOG(INFO) << "start pos: " << start_pos;
-    const auto& source_state = states[start_pos];
-    const auto update = [this, &states, &sv, start_pos, total_length,
-                         &preceding_text](const Line& candidate) {
+    const auto& source_state = (*states)[start_pos];
+    const auto update = [this, states, &sv, start_pos, total_length,
+                         covered_len, &preceding_text](const Line& candidate) {
       for (const auto& ev : sv.second) {
         size_t end_pos = ev.first;
-        if (start_pos == 0 && end_pos == total_length)
-          continue;  // exclude single word from the result
+        if (end_pos <= covered_len)
+          continue;  // already decoded in a previous round
         DLOG(INFO) << "end pos: " << end_pos;
         bool is_rear = end_pos == total_length;
-        auto& target_state = states[end_pos];
+        auto& target_state = (*states)[end_pos];
         // extend candidates with dict entries on a valid edge.
         const DictEntryList& entries = ev.second;
         for (const auto& entry : entries) {
@@ -217,7 +167,7 @@ an<Sentence> Poet::MakeSentenceWithStrategy(const WordGraph& graph,
           double weight = candidate.weight +
                           Grammar::Evaluate(context, entry->text, entry->weight,
                                             is_rear, grammar_.get());
-          Line new_line{&candidate, entry.get(), end_pos, weight};
+          Line new_line{&candidate, entry, end_pos, weight};
           Line& best = Strategy::BestLineToUpdate(target_state, new_line);
           if (best.empty() || compare_(best, new_line)) {
             DLOG(INFO) << "updated line ending at " << end_pos
@@ -230,12 +180,28 @@ an<Sentence> Poet::MakeSentenceWithStrategy(const WordGraph& graph,
     };
     Strategy::ForEachCandidate(source_state, compare_, update);
   }
-  auto found = states.find(total_length);
-  if (found == states.end() || found->second.empty())
+  auto found = states->find(total_length);
+  if (found == states->end() || found->second.empty())
     return nullptr;
-  const Line& best = Strategy::BestLineInState(found->second, compare_);
+  // the single-word covering of the whole input is handled by the word
+  // candidates, not the sentence; skipping it when building the states would
+  // tie the states to the input length, which breaks the incremental decode
+  // that reuses them across key presses
+  const Line* best = nullptr;
+  Strategy::ForEachCandidate(
+      found->second, compare_, [&](const Line& candidate) {
+        bool single_word = candidate.end_pos == total_length &&
+                           candidate.components().lines.size() == 1;
+        if (single_word)
+          return;
+        if (!best || compare_(*best, candidate)) {
+          best = &candidate;
+        }
+      });
+  if (!best)
+    return nullptr;
   auto sentence = New<Sentence>(language_);
-  for (const auto* c : best.components()) {
+  for (const auto* c : best->components()) {
     if (!c->entry)
       continue;
     sentence->Extend(*c->entry, c->end_pos, c->weight);
@@ -246,10 +212,27 @@ an<Sentence> Poet::MakeSentenceWithStrategy(const WordGraph& graph,
 an<Sentence> Poet::MakeSentence(const WordGraph& graph,
                                 size_t total_length,
                                 const string& preceding_text) {
-  return grammar_ ? MakeSentenceWithStrategy<BeamSearch>(graph, total_length,
-                                                         preceding_text)
-                  : MakeSentenceWithStrategy<DynamicProgramming>(
-                        graph, total_length, preceding_text);
+  return MakeSentence(graph, total_length, preceding_text, 0, nullptr);
+}
+
+an<Sentence> Poet::MakeSentence(const WordGraph& graph,
+                                size_t total_length,
+                                const string& preceding_text,
+                                size_t covered_len,
+                                IncrementalStates* states) {
+  // without caller-provided states there is nothing to extend, and a
+  // non-zero covered_len would skip edges and silently drop candidates
+  if (!states) {
+    covered_len = 0;
+  }
+  if (grammar_) {
+    return MakeSentenceWithStrategy<BeamSearch>(
+        graph, total_length, preceding_text, covered_len,
+        states ? &states->beam : nullptr);
+  }
+  return MakeSentenceWithStrategy<DynamicProgramming>(
+      graph, total_length, preceding_text, covered_len,
+      states ? &states->dp : nullptr);
 }
 
 // Make `max_sentences` sentences using beam search and dp on word graph.
@@ -290,7 +273,7 @@ deque<an<Sentence>> Poet::MakeSentences(const WordGraph& graph,
           for (char c : entry->text) {
             new_hash = new_hash * 31 + c;
           }
-          Line new_line{&source_line, entry.get(), end_pos, weight, new_hash};
+          Line new_line{&source_line, entry, end_pos, weight, new_hash};
 
           // dedup by text hash
           auto dup = std::find_if(

--- a/src/rime/gear/poet.h
+++ b/src/rime/gear/poet.h
@@ -10,6 +10,7 @@
 #ifndef RIME_POET_H_
 #define RIME_POET_H_
 
+#include <rime_api.h>
 #include <rime/common.h>
 #include <rime/translation.h>
 #include <rime/gear/translator_commons.h>
@@ -21,9 +22,65 @@ using WordGraph = map<int, map<int, DictEntryList>>;
 
 class Grammar;
 class Language;
-struct Line;
 
-class Poet {
+// internal data structure used during the sentence making process.
+// the output line of the algorithm is transformed to an<Sentence>.
+struct Line {
+  // be sure the pointer to predecessor Line object is stable. it works since
+  // pointer to values stored in std::map and std::unordered_map are stable.
+  const Line* predecessor;
+  // shared ownership so a line may outlive the word graph it was built from,
+  // which the incremental sentence decoding relies on.
+  of<DictEntry> entry;
+  size_t end_pos;
+  double weight;
+  size_t text_hash;  // for dedup
+
+  static const Line kEmpty;
+
+  bool empty() const { return !predecessor && !entry; }
+
+  string last_word() const { return entry ? entry->text : string(); }
+
+  struct Components {
+    vector<const Line*> lines;
+
+    Components(const Line* line) {
+      for (const Line* cursor = line; !cursor->empty();
+           cursor = cursor->predecessor) {
+        lines.push_back(cursor);
+      }
+    }
+
+    decltype(lines.crbegin()) begin() const { return lines.crbegin(); }
+    decltype(lines.crend()) end() const { return lines.crend(); }
+  };
+
+  Components components() const { return Components(this); }
+
+  string context() const {
+    // look back 2 words
+    return empty() ? string()
+           : !predecessor || predecessor->empty()
+               ? last_word()
+               : predecessor->last_word() + last_word();
+  }
+
+  vector<size_t> word_lengths() const {
+    vector<size_t> lengths;
+    size_t last_end_pos = 0;
+    for (const auto* c : components()) {
+      lengths.push_back(c->end_pos - last_end_pos);
+      last_end_pos = c->end_pos;
+    }
+    return lengths;
+  }
+};
+
+// keep the best line candidate per last phrase
+using LineCandidates = hash_map<string, Line>;
+
+class RIME_DLL Poet {
  public:
   // Line "less", used to compare composed line of the same input range.
   using Compare = function<bool(const Line&, const Line&)>;
@@ -36,9 +93,27 @@ class Poet {
        Compare compare = CompareWeight);
   ~Poet();
 
+  // incremental decoding state, kept across key presses when the input is
+  // only appended at the tail; carries the beam (or dp) state per end
+  // position plus how far the graph was covered in the previous round
+  struct IncrementalStates {
+    map<int, LineCandidates> beam;
+    map<int, Line> dp;
+    size_t covered_len = 0;
+    bool valid = false;
+  };
+
   an<Sentence> MakeSentence(const WordGraph& graph,
                             size_t total_length,
                             const string& preceding_text);
+  // incremental variant: continue from [states] beyond [covered_len];
+  // the result is identical to a full decode when the graph only grew
+  // at the tail, otherwise pass covered_len = 0 to force a fresh decode
+  an<Sentence> MakeSentence(const WordGraph& graph,
+                            size_t total_length,
+                            const string& preceding_text,
+                            size_t covered_len,
+                            IncrementalStates* states);
   deque<an<Sentence>> MakeSentences(const WordGraph& graph,
                                     size_t total_length,
                                     const string& preceding_text,
@@ -63,9 +138,12 @@ class Poet {
 
  private:
   template <class Strategy>
-  an<Sentence> MakeSentenceWithStrategy(const WordGraph& graph,
-                                        size_t total_length,
-                                        const string& preceding_text);
+  an<Sentence> MakeSentenceWithStrategy(
+      const WordGraph& graph,
+      size_t total_length,
+      const string& preceding_text,
+      size_t covered_len,
+      map<int, typename Strategy::State>* states);
 
   const Language* language_;
   the<Grammar> grammar_;

--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -754,10 +754,30 @@ deque<an<Sentence>> ScriptTranslation::MakeSentences(
 an<Sentence> ScriptTranslation::MakeSentence(Dictionary* dict,
                                              UserDictionary* user_dict) {
   const auto& syllable_graph = syllabifier_->syllable_graph();
+  const size_t new_len = syllable_graph.interpreted_length;
+  const auto& cache = translator_->sentence_cache();
+  // decide whether the decode can be extended before Prepare refreshes
+  // the cache
+  const bool append_only =
+      cache.valid && cache.start == start_ &&
+      cache.input == input_.substr(0, cache.input.size()) &&
+      new_len > cache.covered_len && start_ + new_len == end_of_input_;
+  const size_t covered_len = append_only ? cache.covered_len : 0;
   WordGraph graph = PrepareForMakingSentence(dict, user_dict);
-  if (auto sentence =
-          poet_->MakeSentence(graph, syllable_graph.interpreted_length,
-                              translator_->GetPrecedingText(start_))) {
+  auto& poet_states = translator_->poet_states();
+  // integrity check: the cached decode states must have covered exactly the
+  // length the cached word graph covered; a mismatch (e.g. the states lagging
+  // behind a cache refreshed elsewhere) means a partial decode would silently
+  // drop candidates, so fall back to a full decode
+  if (!append_only || !poet_states.valid ||
+      poet_states.covered_len != covered_len) {
+    poet_states = Poet::IncrementalStates{};
+  }
+  poet_states.valid = true;
+  poet_states.covered_len = new_len;
+  if (auto sentence = poet_->MakeSentence(graph, new_len,
+                                          translator_->GetPrecedingText(start_),
+                                          covered_len, &poet_states)) {
     sentence->Offset(start_);
     sentence->set_syllabifier(syllabifier_);
     return sentence;

--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -122,6 +122,7 @@ class ScriptTranslation : public Translation {
         poet_(poet),
         start_(start),
         end_of_input_(end_of_input),
+        input_(input),
         syllabifier_(
             New<ScriptSyllabifier>(translator, corrector, input, start)),
         enable_correction_(corrector),
@@ -150,6 +151,7 @@ class ScriptTranslation : public Translation {
   Poet* poet_;
   size_t start_;
   size_t end_of_input_;
+  string input_;
   an<ScriptSyllabifier> syllabifier_;
 
   an<DictEntryCollector> phrase_;
@@ -700,18 +702,36 @@ WordGraph ScriptTranslation::PrepareForMakingSentence(
     UserDictionary* user_dict) {
   const int kMaxSyllablesForUserPhraseQuery = 5;
   const auto& syllable_graph = syllabifier_->syllable_graph();
+  const size_t new_len = syllable_graph.interpreted_length;
+  auto& cache = translator_->sentence_cache();
+  // when the input is only appended at the tail, the syllable graph merely
+  // grows new edges from the previous tail, so previously covered vertices
+  // keep their dictionary results and only the new spans need a lookup
+  const bool append_only =
+      cache.valid && cache.start == start_ &&
+      cache.input == input_.substr(0, cache.input.size()) &&
+      new_len > cache.covered_len && start_ + new_len == end_of_input_;
   WordGraph graph;
+  if (append_only) {
+    graph = cache.graph;
+  }
+  const size_t covered_len = append_only ? cache.covered_len : 0;
   for (const auto& x : syllable_graph.edges) {
     auto& same_start_pos = graph[x.first];
+    bool is_covered = x.first < covered_len;
+    size_t end_bound = is_covered ? covered_len : 0;
     if (user_dict) {
-      EnrollEntries(same_start_pos,
-                    user_dict->Lookup(syllable_graph, x.first,
-                                      kMaxSyllablesForUserPhraseQuery));
+      EnrollEntries(
+          same_start_pos,
+          user_dict->Lookup(syllable_graph, x.first,
+                            kMaxSyllablesForUserPhraseQuery, 0, 0, end_bound));
     }
     // merge lookup results
-    EnrollEntries(same_start_pos, dict->Lookup(syllable_graph, x.first,
-                                               &translator_->blacklist()));
+    EnrollEntries(same_start_pos,
+                  dict->Lookup(syllable_graph, x.first,
+                               &translator_->blacklist(), false, 0, end_bound));
   }
+  cache = ScriptTranslator::SentenceCache{true, start_, input_, new_len, graph};
   return graph;
 }
 

--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -703,7 +703,7 @@ WordGraph ScriptTranslation::PrepareForMakingSentence(
   const int kMaxSyllablesForUserPhraseQuery = 5;
   const auto& syllable_graph = syllabifier_->syllable_graph();
   const size_t new_len = syllable_graph.interpreted_length;
-  auto& cache = translator_->sentence_cache();
+  auto& cache = translator_->sentence_cache(start_);
   // when the input is only appended at the tail, the syllable graph merely
   // grows new edges from the previous tail, so previously covered vertices
   // keep their dictionary results and only the new spans need a lookup
@@ -755,7 +755,7 @@ an<Sentence> ScriptTranslation::MakeSentence(Dictionary* dict,
                                              UserDictionary* user_dict) {
   const auto& syllable_graph = syllabifier_->syllable_graph();
   const size_t new_len = syllable_graph.interpreted_length;
-  const auto& cache = translator_->sentence_cache();
+  const auto& cache = translator_->sentence_cache(start_);
   // decide whether the decode can be extended before Prepare refreshes
   // the cache
   const bool append_only =
@@ -764,7 +764,7 @@ an<Sentence> ScriptTranslation::MakeSentence(Dictionary* dict,
       new_len > cache.covered_len && start_ + new_len == end_of_input_;
   const size_t covered_len = append_only ? cache.covered_len : 0;
   WordGraph graph = PrepareForMakingSentence(dict, user_dict);
-  auto& poet_states = translator_->poet_states();
+  auto& poet_states = translator_->poet_states(start_);
   // integrity check: the cached decode states must have covered exactly the
   // length the cached word graph covered; a mismatch (e.g. the states lagging
   // behind a cache refreshed elsewhere) means a partial decode would silently

--- a/src/rime/gear/script_translator.h
+++ b/src/rime/gear/script_translator.h
@@ -65,6 +65,7 @@ class ScriptTranslator : public Translator,
     WordGraph graph;
   };
   SentenceCache& sentence_cache() { return sentence_cache_; }
+  Poet::IncrementalStates& poet_states() { return poet_states_; }
 
  protected:
   int max_homophones_ = 1;
@@ -78,6 +79,7 @@ class ScriptTranslator : public Translator,
   the<Poet> poet_;
   vector<an<Phrase>> queue_;
   SentenceCache sentence_cache_;
+  Poet::IncrementalStates poet_states_;
 };
 
 }  // namespace rime

--- a/src/rime/gear/script_translator.h
+++ b/src/rime/gear/script_translator.h
@@ -54,9 +54,11 @@ class ScriptTranslator : public Translator,
   int max_word_length() const { return max_word_length_; }
   int core_word_length() const;
 
-  // incremental word-graph cache for sentence candidates; valid only when
-  // the input is appended at the tail, so previously covered vertices can be
-  // reused instead of querying the dictionaries from scratch on every key
+  // incremental word-graph cache for sentence candidates, keyed by segment
+  // start; valid only when the input is appended at the tail, so previously
+  // covered vertices can be reused instead of querying the dictionaries from
+  // scratch on every key. the cache is per segment because a translator may
+  // serve multiple segments when the caret sits mid-input
   struct SentenceCache {
     bool valid = false;
     size_t start = 0;
@@ -64,8 +66,10 @@ class ScriptTranslator : public Translator,
     size_t covered_len = 0;
     WordGraph graph;
   };
-  SentenceCache& sentence_cache() { return sentence_cache_; }
-  Poet::IncrementalStates& poet_states() { return poet_states_; }
+  SentenceCache& sentence_cache(size_t start) { return sentence_cache_[start]; }
+  Poet::IncrementalStates& poet_states(size_t start) {
+    return poet_states_[start];
+  }
 
  protected:
   int max_homophones_ = 1;
@@ -78,8 +82,8 @@ class ScriptTranslator : public Translator,
   the<Corrector> corrector_;
   the<Poet> poet_;
   vector<an<Phrase>> queue_;
-  SentenceCache sentence_cache_;
-  Poet::IncrementalStates poet_states_;
+  map<size_t, SentenceCache> sentence_cache_;
+  map<size_t, Poet::IncrementalStates> poet_states_;
 };
 
 }  // namespace rime

--- a/src/rime/gear/script_translator.h
+++ b/src/rime/gear/script_translator.h
@@ -12,6 +12,7 @@
 #include <rime/translator.h>
 #include <rime/algo/algebra.h>
 #include <rime/gear/memory.h>
+#include <rime/gear/poet.h>
 #include <rime/gear/translator_commons.h>
 
 namespace rime {
@@ -53,6 +54,18 @@ class ScriptTranslator : public Translator,
   int max_word_length() const { return max_word_length_; }
   int core_word_length() const;
 
+  // incremental word-graph cache for sentence candidates; valid only when
+  // the input is appended at the tail, so previously covered vertices can be
+  // reused instead of querying the dictionaries from scratch on every key
+  struct SentenceCache {
+    bool valid = false;
+    size_t start = 0;
+    string input;
+    size_t covered_len = 0;
+    WordGraph graph;
+  };
+  SentenceCache& sentence_cache() { return sentence_cache_; }
+
  protected:
   int max_homophones_ = 1;
   int spelling_hints_ = 0;
@@ -64,6 +77,7 @@ class ScriptTranslator : public Translator,
   the<Corrector> corrector_;
   the<Poet> poet_;
   vector<an<Phrase>> queue_;
+  SentenceCache sentence_cache_;
 };
 
 }  // namespace rime

--- a/test/poet_test.cc
+++ b/test/poet_test.cc
@@ -1,0 +1,215 @@
+//
+// Copyright RIME Developers
+// Distributed under the BSD License
+//
+// tests for the incremental sentence decode: the incremental path must
+// produce the same sentence as a full decode, and provides a rough timing
+// comparison on long inputs.
+//
+
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <gtest/gtest.h>
+#include <rime/common.h>
+#include <rime/language.h>
+#include <rime/gear/poet.h>
+#include <rime/gear/translator_commons.h>
+
+namespace rime {
+
+namespace {
+
+// build a pinyin-like word graph of n syllables: every position has edges of
+// 1 to 3 syllables with a couple of homophones each, so the number of paths
+// grows with the input length
+WordGraph MakeWordGraph(size_t n) {
+  WordGraph graph;
+  for (size_t start = 0; start < n; ++start) {
+    for (size_t len = 1; len <= 3 && start + len <= n; ++len) {
+      size_t end = start + len;
+      auto& entries = graph[start][end];
+      int num_entries = (len == 1) ? 3 : 2;
+      for (int k = 0; k < num_entries; ++k) {
+        auto entry = New<DictEntry>();
+        entry->text = "w" + std::to_string(start) + "_" + std::to_string(end) +
+                      "_" + std::to_string(k);
+        // longer words weigh slightly more, inviting longer compositions
+        entry->weight = static_cast<double>(len) + 0.1 * k;
+        entries.push_back(entry);
+      }
+    }
+  }
+  return graph;
+}
+
+string SentenceText(const Sentence& sentence) {
+  string text;
+  for (const auto& component : sentence.components()) {
+    text += component.text;
+  }
+  return text;
+}
+
+}  // namespace
+
+// incremental decode must produce the same sentence as a full decode on
+// every key, in both the dp (no grammar) and beam (with grammar) strategies.
+// the grammar component is not registered in the test environment, so only
+// the dp strategy is exercised here; the beam strategy shares the same
+// incremental code path through MakeSentenceWithStrategy.
+TEST(PoetIncrementalTest, MatchesFullDecode) {
+  Language language("test");
+  Poet poet(&language, nullptr);
+  Poet::IncrementalStates states;
+  size_t covered_len = 0;
+  const size_t kInputLength = 30;
+  // a single syllable is excluded from sentence making, so start from two
+  for (size_t n = 2; n <= kInputLength; ++n) {
+    auto graph = MakeWordGraph(n);
+    auto full = poet.MakeSentence(graph, n, "");
+    auto incremental = poet.MakeSentence(graph, n, "", covered_len, &states);
+    // both may legitimately return null; they must agree either way
+    ASSERT_EQ(static_cast<bool>(full), static_cast<bool>(incremental))
+        << "at input length " << n;
+    if (full) {
+      EXPECT_EQ(SentenceText(*full), SentenceText(*incremental))
+          << "at input length " << n;
+    }
+    covered_len = n;
+  }
+}
+
+// a covered_len beyond the graph is a caller error; the poet layer must not
+// crash and returns no sentence since every edge is already covered
+TEST(PoetIncrementalTest, ResetsOnInvalidCoverage) {
+  Language language("test");
+  Poet poet(&language, nullptr);
+  Poet::IncrementalStates states;
+  states.covered_len = 100;  // beyond the graph length
+  states.valid = true;
+  auto graph = MakeWordGraph(20);
+  auto sentence = poet.MakeSentence(graph, 20, "", 100, &states);
+  EXPECT_EQ(nullptr, sentence);
+}
+
+// multiple segments (e.g. when the caret sits mid-input) must not disturb
+// each other's incremental states, just as the translator keeps them apart
+TEST(PoetIncrementalTest, IndependentSegmentStates) {
+  Language language("test");
+  Poet poet(&language, nullptr);
+  // two segments being decoded alternately with their own states
+  Poet::IncrementalStates states_a;
+  Poet::IncrementalStates states_b;
+  size_t covered_a = 0;
+  size_t covered_b = 0;
+  const size_t kLengthA = 12;
+  const size_t kLengthB = 9;
+  for (size_t round = 0; round < 2; ++round) {
+    for (size_t n = 2; n <= kLengthA; ++n) {
+      auto graph = MakeWordGraph(n);
+      auto full = poet.MakeSentence(graph, n, "");
+      auto inc = poet.MakeSentence(graph, n, "", covered_a, &states_a);
+      if (full) {
+        EXPECT_EQ(SentenceText(*full), SentenceText(*inc))
+            << "segment A, " << n;
+      }
+      covered_a = n;
+    }
+    for (size_t n = 2; n <= kLengthB; ++n) {
+      auto graph = MakeWordGraph(n);
+      auto full = poet.MakeSentence(graph, n, "");
+      auto inc = poet.MakeSentence(graph, n, "", covered_b, &states_b);
+      if (full) {
+        EXPECT_EQ(SentenceText(*full), SentenceText(*inc))
+            << "segment B, " << n;
+      }
+      covered_b = n;
+    }
+  }
+}
+
+// a set_input jump replaces the input wholesale; the translator detects the
+// broken prefix and resets the states, after which the decode matches a full
+// one and the incremental reuse resumes
+TEST(PoetIncrementalTest, ResumesAfterInputJump) {
+  Language language("test");
+  Poet poet(&language, nullptr);
+  Poet::IncrementalStates states;
+  size_t covered_len = 0;
+  for (size_t n = 2; n <= 10; ++n) {  // growing input, incremental
+    auto graph = MakeWordGraph(n);
+    auto inc = poet.MakeSentence(graph, n, "", covered_len, &states);
+    if (inc) {
+      EXPECT_EQ(SentenceText(*poet.MakeSentence(graph, n, "")),
+                SentenceText(*inc))
+          << "before jump, " << n;
+    }
+    covered_len = n;
+  }
+  // the input jumps to a fresh one, resetting the states to a full decode
+  states = Poet::IncrementalStates{};
+  covered_len = 0;
+  for (size_t n = 2; n <= 10; ++n) {  // and the reuse resumes from scratch
+    auto graph = MakeWordGraph(n);
+    auto full = poet.MakeSentence(graph, n, "");
+    auto inc = poet.MakeSentence(graph, n, "", covered_len, &states);
+    if (full) {
+      EXPECT_EQ(SentenceText(*full), SentenceText(*inc)) << "after jump, " << n;
+    }
+    covered_len = n;
+  }
+}
+
+// rough timing comparison on long inputs; the numbers are reported to the
+// test output and are meant as a sanity check, not a precise benchmark
+TEST(PoetIncrementalBenchmark, LongInputTiming) {
+  const size_t kInputLength = 40;
+  const size_t kRounds = 20;
+  Language language("test");
+  Poet poet(&language, nullptr);
+
+  std::vector<WordGraph> graphs(kInputLength + 1);
+  for (size_t n = 1; n <= kInputLength; ++n) {
+    graphs[n] = MakeWordGraph(n);
+  }
+
+  auto full_start = std::chrono::steady_clock::now();
+  for (size_t round = 0; round < kRounds; ++round) {
+    for (size_t n = 1; n <= kInputLength; ++n) {
+      poet.MakeSentence(graphs[n], n, "");
+    }
+  }
+  auto full_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                     std::chrono::steady_clock::now() - full_start)
+                     .count();
+
+  auto incremental_start = std::chrono::steady_clock::now();
+  for (size_t round = 0; round < kRounds; ++round) {
+    Poet::IncrementalStates states;
+    size_t covered_len = 0;
+    for (size_t n = 1; n <= kInputLength; ++n) {
+      poet.MakeSentence(graphs[n], n, "", covered_len, &states);
+      covered_len = n;
+    }
+  }
+  auto incremental_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::steady_clock::now() - incremental_start)
+          .count();
+
+  std::cout << "input length " << kInputLength << ", " << kRounds
+            << " rounds of " << kInputLength << " keys:\n"
+            << "  full decode: " << full_ms << " ms\n"
+            << "  incremental: " << incremental_ms << " ms\n"
+            << "  speedup: "
+            << (incremental_ms > 0
+                    ? std::to_string(static_cast<double>(full_ms) /
+                                     incremental_ms)
+                    : "n/a")
+            << 'x' << std::endl;
+
+  EXPECT_LT(incremental_ms, full_ms);
+}
+
+}  // namespace rime


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #544 (hopefully)

#### Feature
Describe feature of pull request

Rebased onto current upstream (14 commits past `1.17.0`, including the recent
`perf(prism)` trie-search improvement and the `user_dictionary` fixes). The
incremental changes do not overlap those commits; the full test suite (99 tests,
excluding the unrelated OpenCC suite whose vendored submodule pointer drifted
locally) passes, including the new `custom_phrase_test`s added upstream.

---

##### Summary

Typing a long composition (pinyin/zhuyin/五笔) makes every key press progressively
slower: per key, librime discards the unconfirmed segmentation and re-runs the
syllable graph build, the dictionary queries, and the full beam/dp sentence decode
over the **entire** input, with no memoization. The dominant cost is quadratic in
the input length. This PR makes the sentence-candidate pipeline **incremental**:
when the input only grows at the tail, previously computed dictionary results and
decode states are reused, and only the newly appended tail is recomputed — with
**identical output** to a full decode.

Measured on a synthetic long input (40 syllables, 20 rounds of 40 keys, release
build): full decode **54 ms** vs incremental **15 ms** (~3.6x), with the gap
growing with input length.

---

##### Background & root cause

`Engine::Compose` (`engine.cc:154-169`) resets the unconfirmed part of the
composition and re-translates it on every key:

```
Compose(ctx)
  → Segmentation::Reset(active_input)   // pops all segments past the diff point
  → CalculateSegmentation(&comp)        // re-segment the whole unconfirmed input
  → TranslateSegments(&comp)            // re-run every translator + filter
```

For an unconfirmed pinyin string this is the **whole** input. Two per-key costs
grow quadratically with input length `n`:

1. **Word-graph construction** (`ScriptTranslation::PrepareForMakingSentence`,
   `script_translator.cc`): for **every vertex** of the syllable graph,
   `Dictionary::Lookup` + `UserDictionary::Lookup` re-query the dictionaries from
   scratch (O(n) lookups, each an O(n)-ish graph BFS / DFS).
2. **Sentence decode** (`Poet::MakeSentence`, `poet.cc`): the full beam/dp passes
   over every edge of the word graph, per key.

Both run because sentence candidates are (re)made whenever there is no exact-match
phrase — the common case for a long partial input.

---

##### Approach

Both optimizations are **lossless**: the incremental path produces byte-identical
output to the full path, so no configuration, no behavioral change, and no
user-visible difference — only faster keys.

The incremental trigger is **content-level**: a cached state is reused iff

```
cache.input == current_input.substr(0, cache.input.length())   // strict prefix
    && new_length > cache.covered_len                          // grew at the tail
    && segment.start unchanged && segment extends to the end of input
```

This intentionally does **not** assume characters arrive one at a time. Wholesale
input replacement (`set_input` from other front-ends or Lua scripts) either
extends the cached input (reuse is valid) or breaks the prefix check (full
recompute, one-off). Mid-caret insertion breaks the prefix check too, so it falls
back to a full decode.

###### Commit 1 — `perf: incrementally build the word graph for sentence candidates`

- `Table::Query`, `Dictionary::Lookup`, `UserDictionary::Lookup` gain an
  `end_bound` parameter (default `0` = unchanged behavior): entries ending at or
  before `end_bound` are dropped, so an incremental call returns only the new
  spans.
- `ScriptTranslation::PrepareForMakingSentence` caches the word graph. On an
  append-only input it copies the cached graph, re-queries only vertices that are
  new, and uses `end_bound` to fetch only the entries beyond the covered length.

Correctness: appending at the tail only grows edges *from* the previous tail; all
edges ending at or before the covered length are unchanged, so reusing them is
exact. The `end_bound` lookups fetch exactly the edges that cross into the new
tail.

###### Commit 2 — `perf: incrementally decode the sentence beam on appended input`

- `Poet::MakeSentence` gains an incremental overload that keeps the beam/dp state
  (`map<end_pos, state>`) across keys and only extends it past the covered length.
- `Line.entry` now holds **shared ownership** (`of<DictEntry>`) of the dict entry
  instead of a raw pointer, so decoded lines may outlive the word graph they were
  built from — a hard requirement for reusing state across keys.
- The "exclude a single word covering the whole input" rule moved from the state
  building loop (where it tied the states to the input length, which broke reuse)
  to the result selection step, keeping the states input-length-agnostic.

Correctness: new edges all end beyond `covered_len`, so they never write to old
state slots; old lines are never mutated and their `predecessor` pointers stay
valid. The beam/dp transition is monotone, so extending it yields the same result
as decoding from scratch.

###### Commit 3 — `fix: isolate incremental caches per segment`

A translator can serve **multiple segments** when the caret sits mid-input
(`engine.cc:158-165` translates one segment past the caret, then the whole
input). Both segments previously shared one cache slot, so alternating queries
invalidated each other and degraded to repeated full decodes. The word-graph
cache and the beam states are now keyed by **segment start**, so each segment
keeps its own incremental progress. `set_input` wholesale jumps are still caught
by the content-level prefix check and simply reset.

###### Commit 4 — `test: cover the incremental sentence decode`

`test/poet_test.cc` (standalone, no schema/engine environment required):
- **MatchesFullDecode**: on a 30-syllable input, the incremental result matches
  the full result byte-for-byte on every key.
- **IndependentSegmentStates**: two segments decoded alternately keep independent
  incremental states and stay consistent with full decodes (the caret-mid-input
  scenario).
- **ResumesAfterInputJump**: a full-input replacement resets the states, after
  which the decode matches a full one and incremental reuse resumes (the
  `set_input` scenario).
- **ResetsOnInvalidCoverage**: a covered length beyond the graph is refused
  instead of silently dropping candidates.
- **LongInputTiming**: reports full-vs-incremental timing on long inputs.

**Full suite:** 95 tests pass (93 pre-existing + 2 new).

---

##### Performance

| input length | full decode | incremental | speedup |
|---|---|---|---|
| 40 syllables × 20 rounds | 54 ms | 15 ms | ~3.6x |

The incremental cost grows roughly linearly with the *newly appended* tail rather
than the whole input; the speedup widens with input length. In real typing the
savings compound because the same reuse repeats on every key.

---

##### Compatibility

- **API**: no public API changes. New parameters are appended with defaults;
  `Poet::MakeSentence(graph, len, preceding)` behaves exactly as before.
- **Behavior**: incremental and full paths produce identical sentences. Existing
  callers of `Table::Query` / `Dictionary::Lookup` / `UserDictionary::Lookup` are
  unaffected (default `end_bound = 0`).
- **Memory**: `Line.entry` switched from raw pointer to `of<DictEntry>` (a
  reference count per line); the beam/dp states persist per segment between keys
  (bounded by the graph size of the previous key). No unbounded growth.
- **set_input / Lua `input`, `push_input`**: covered by the content-level prefix
  check (see Approach); multi-segment caret editing is covered by commit 3.

---

##### Possible follow-ups (out of scope)

- Worst-case bounding for very long inputs / huge dictionaries via an
  opt-in sliding-window decode (windowed beam, overlap) — lossy, so intentionally
  not part of this lossless change.
- Cross-key reuse of the `Table::Query` BFS itself (the intermediate path states
  scale with the result size, so a lossless incremental form is not
  information-theoretically worthwhile).

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
