### PR TITLE
fix(user_db): clamp denormal dee to restore Pack/Unpack round-trip

### DIFF
--- a/src/rime/dict/user_db.cc
+++ b/src/rime/dict/user_db.cc
@@ -43,20 +43,14 @@ bool UserDbValue::Unpack(const string& value) {
       continue;
     string k(k_eq_v.substr(0, eq));
     string v(k_eq_v.substr(eq + 1));
-    // Use C-style strto* parsers: they accept denormal floats without
-    // throwing and give us a precise "no conversion performed" signal via
-    // the end-pointer. std::stod throws std::out_of_range on denormals,
-    // which used to make Unpack() reject the whole record on round-trip.
     try {
       if (k == "c") {
-        char* end = nullptr;
-        errno = 0;
-        long parsed = std::strtol(v.c_str(), &end, 10);
-        if (end == v.c_str() || errno == ERANGE) {
-          throw std::invalid_argument("bad commits");
-        }
-        commits = static_cast<int>(parsed);
+        commits = std::stoi(v);
       } else if (k == "d") {
+        // Use strtod instead of std::stod: denormal floats (which arise
+        // naturally from long-term decay) are a valid input, not an
+        // exceptional condition. strtod returns 0 on underflow without
+        // throwing, preserving the round-trip for aged-out entries.
         char* end = nullptr;
         errno = 0;
         double parsed = std::strtod(v.c_str(), &end);
@@ -69,13 +63,7 @@ bool UserDbValue::Unpack(const string& value) {
           parsed = 0.0;
         dee = (std::min)(10000.0, parsed);
       } else if (k == "t") {
-        char* end = nullptr;
-        errno = 0;
-        unsigned long parsed = std::strtoul(v.c_str(), &end, 10);
-        if (end == v.c_str() || errno == ERANGE) {
-          throw std::invalid_argument("bad tick");
-        }
-        tick = static_cast<TickCount>(parsed);
+        tick = std::stoul(v);
       }
     } catch (...) {
       LOG(ERROR) << "failed in parsing key-value from userdb entry '" << k_eq_v

--- a/src/rime/dict/user_db.cc
+++ b/src/rime/dict/user_db.cc
@@ -5,7 +5,10 @@
 // 2011-11-02 GONG Chen <chen.sst@gmail.com>
 //
 #include <algorithm>
+#include <cerrno>
+#include <cmath>
 #include <cstdlib>
+#include <limits>
 #include <sstream>
 #include <boost/algorithm/string.hpp>
 #include <rime/service.h>
@@ -21,7 +24,13 @@ UserDbValue::UserDbValue(const string& value) {
 
 string UserDbValue::Pack() const {
   std::ostringstream packed;
-  packed << "c=" << commits << " d=" << dee << " t=" << tick;
+  // Clamp denormal (and negative) dee to 0 before serialization.
+  // Denormals serialize to strings like "9.88131e-324" that std::stod cannot
+  // parse back, breaking the Pack/Unpack round-trip on long-lived entries
+  // whose decay weight has fallen below the normal-double floor.
+  constexpr double kMinNormal = std::numeric_limits<double>::min();
+  double safe_dee = (dee < kMinNormal) ? 0.0 : dee;
+  packed << "c=" << commits << " d=" << safe_dee << " t=" << tick;
   return packed.str();
 }
 
@@ -34,13 +43,39 @@ bool UserDbValue::Unpack(const string& value) {
       continue;
     string k(k_eq_v.substr(0, eq));
     string v(k_eq_v.substr(eq + 1));
+    // Use C-style strto* parsers: they accept denormal floats without
+    // throwing and give us a precise "no conversion performed" signal via
+    // the end-pointer. std::stod throws std::out_of_range on denormals,
+    // which used to make Unpack() reject the whole record on round-trip.
     try {
       if (k == "c") {
-        commits = std::stoi(v);
+        char* end = nullptr;
+        errno = 0;
+        long parsed = std::strtol(v.c_str(), &end, 10);
+        if (end == v.c_str() || errno == ERANGE) {
+          throw std::invalid_argument("bad commits");
+        }
+        commits = static_cast<int>(parsed);
       } else if (k == "d") {
-        dee = (std::min)(10000.0, std::stod(v));
+        char* end = nullptr;
+        errno = 0;
+        double parsed = std::strtod(v.c_str(), &end);
+        if (end == v.c_str()) {
+          throw std::invalid_argument("bad dee");
+        }
+        // strtod returns 0 on underflow and HUGE_VAL on overflow; either
+        // way, clamp to [0, 10000] which is the valid dee range.
+        if (parsed < 0.0 || std::isnan(parsed))
+          parsed = 0.0;
+        dee = (std::min)(10000.0, parsed);
       } else if (k == "t") {
-        tick = std::stoul(v);
+        char* end = nullptr;
+        errno = 0;
+        unsigned long parsed = std::strtoul(v.c_str(), &end, 10);
+        if (end == v.c_str() || errno == ERANGE) {
+          throw std::invalid_argument("bad tick");
+        }
+        tick = static_cast<TickCount>(parsed);
       }
     } catch (...) {
       LOG(ERROR) << "failed in parsing key-value from userdb entry '" << k_eq_v

--- a/src/rime/dict/user_db.cc
+++ b/src/rime/dict/user_db.cc
@@ -8,7 +8,6 @@
 #include <cerrno>
 #include <cmath>
 #include <cstdlib>
-#include <limits>
 #include <sstream>
 #include <boost/algorithm/string.hpp>
 #include <rime/service.h>
@@ -24,12 +23,13 @@ UserDbValue::UserDbValue(const string& value) {
 
 string UserDbValue::Pack() const {
   std::ostringstream packed;
-  // Clamp denormal (and negative) dee to 0 before serialization.
-  // Denormals serialize to strings like "9.88131e-324" that std::stod cannot
-  // parse back, breaking the Pack/Unpack round-trip on long-lived entries
-  // whose decay weight has fallen below the normal-double floor.
-  constexpr double kMinNormal = std::numeric_limits<double>::min();
-  double safe_dee = (dee < kMinNormal) ? 0.0 : dee;
+  // Clamp aged-out (and denormal/negative) dee to 0 before serialization.
+  // Entries at or below kUserDbDiscardThreshold are discarded on load, so
+  // serializing them with their tiny weights would store a state that
+  // disagrees with their effective semantics. Denormals in particular
+  // serialize to strings like "9.88131e-324" that cannot be parsed back,
+  // breaking the Pack/Unpack round-trip.
+  double safe_dee = (dee <= kUserDbDiscardThreshold) ? 0.0 : dee;
   packed << "c=" << commits << " d=" << safe_dee << " t=" << tick;
   return packed.str();
 }

--- a/src/rime/dict/user_db.h
+++ b/src/rime/dict/user_db.h
@@ -16,6 +16,14 @@ namespace rime {
 
 using TickCount = uint64_t;
 
+/// Entries whose decay weight `dee` has fallen to this value or below are
+/// considered aged out: they are discarded when loading the user dictionary
+/// (see UserDictionary::CreateDictEntry), and clamped to zero before being
+/// serialized by UserDbValue::Pack() so that the stored state matches the
+/// effective semantics.
+/// The value corresponds to log2(1/T)*200*ln(2) ticks in the decay formula.
+constexpr double kUserDbDiscardThreshold = 1e-200;
+
 /// Properties of a user db entry value.
 struct UserDbValue {
   int commits = 0;

--- a/src/rime/dict/user_dictionary.cc
+++ b/src/rime/dict/user_dictionary.cc
@@ -529,9 +529,6 @@ bool UserDictionary::TranslateCodeToString(const Code& code, string* result) {
   return true;
 }
 
-// Corresponds to log2(1/T)*200*ln(2) ticks.
-constexpr double kDiscardThreshold = 1e-200;
-
 an<DictEntry> UserDictionary::CreateDictEntry(const string& key,
                                               const string& value,
                                               TickCount present_tick,
@@ -551,7 +548,7 @@ an<DictEntry> UserDictionary::CreateDictEntry(const string& key,
     v.dee = algo::formula_d(0, (double)present_tick, v.dee, (double)v.tick);
   // tick==0: table/stabledb phrases (custom_phrase.txt etc.) never entered
   // userdb decay. Discard only aged user-history entries.
-  if (v.tick != 0 && v.dee <= kDiscardThreshold)
+  if (v.tick != 0 && v.dee <= kUserDbDiscardThreshold)
     return e;
   // create!
   e = New<DictEntry>();

--- a/test/user_db_test.cc
+++ b/test/user_db_test.cc
@@ -5,6 +5,8 @@
 // 2011-07-03 GONG Chen <chen.sst@gmail.com>
 //
 #include <gtest/gtest.h>
+#include <cmath>
+#include <limits>
 #include <rime/algo/syllabifier.h>
 #include <rime/dict/text_db.h>
 #include <rime/dict/user_db.h>
@@ -88,4 +90,86 @@ TEST(RimeUserDbTest, Query) {
     EXPECT_FALSE(accessor->GetNextRecord(&key, &value));
   }
   db.Close();
+}
+
+TEST(RimeUserDbValueTest, PackUnpackRoundtripNormal) {
+  UserDbValue original;
+  original.commits = 42;
+  original.dee = 1.23456;
+  original.tick = 1000;
+
+  string packed = original.Pack();
+  EXPECT_EQ("c=42 d=1.23456 t=1000", packed);
+
+  UserDbValue restored(packed);
+  EXPECT_EQ(42, restored.commits);
+  EXPECT_DOUBLE_EQ(1.23456, restored.dee);
+  EXPECT_EQ(1000u, restored.tick);
+}
+
+TEST(RimeUserDbValueTest, PackUnpackRoundtripZero) {
+  UserDbValue original;
+  original.commits = 0;
+  original.dee = 0.0;
+  original.tick = 0;
+
+  string packed = original.Pack();
+  UserDbValue restored(packed);
+  EXPECT_EQ(0, restored.commits);
+  EXPECT_DOUBLE_EQ(0.0, restored.dee);
+  EXPECT_EQ(0u, restored.tick);
+}
+
+TEST(RimeUserDbValueTest, PackUnpackRoundtripSmallNormal) {
+  // A small but normal (non-denormal) positive value, just above min().
+  UserDbValue original;
+  original.commits = 7;
+  original.dee = 3e-300;
+  original.tick = 999;
+
+  string packed = original.Pack();
+  UserDbValue restored(packed);
+  EXPECT_EQ(7, restored.commits);
+  EXPECT_DOUBLE_EQ(3e-300, restored.dee);
+  EXPECT_EQ(999u, restored.tick);
+}
+
+TEST(RimeUserDbValueTest, UnpackSurvivesDenormal) {
+  // Simulate an entry written by a buggy older version that serialized a
+  // denormal float. Unpack MUST NOT fail; it should treat the denormal as
+  // effectively zero (below the representable normal range).
+  const string denormal_entry = "c=16 d=9.88131e-324 t=1449225";
+  UserDbValue v(denormal_entry);
+  EXPECT_EQ(16, v.commits);
+  EXPECT_EQ(1449225u, v.tick);
+  // dee should not throw or leave the field uninitialized; it must be
+  // representable as a normal non-negative double (0 is acceptable).
+  EXPECT_GE(v.dee, 0.0);
+  EXPECT_FALSE(std::isnan(v.dee));
+}
+
+TEST(RimeUserDbValueTest, PackThenUnpackDenormalIsClamped) {
+  // Setting dee to a denormal in memory and Pack()ing it must produce a
+  // string that Unpack() can parse back without error — the round-trip must
+  // not lose the record.
+  UserDbValue original;
+  original.commits = 5;
+  original.dee = std::numeric_limits<double>::denorm_min();  // ~4.94e-324
+  original.tick = 12345;
+
+  string packed = original.Pack();
+  UserDbValue restored;
+  ASSERT_TRUE(restored.Unpack(packed))
+      << "Unpack failed on packed string: " << packed;
+  EXPECT_EQ(5, restored.commits);
+  EXPECT_EQ(12345u, restored.tick);
+  EXPECT_GE(restored.dee, 0.0);
+  EXPECT_FALSE(std::isnan(restored.dee));
+}
+
+TEST(RimeUserDbValueTest, UnpackRejectsGarbage) {
+  // Fields that are not numbers at all should still be rejected (the
+  // Unpack() contract is not "accept anything").
+  UserDbValue v;
+  EXPECT_FALSE(v.Unpack("c=abc d=xyz t=qqq"));
 }

--- a/test/user_db_test.cc
+++ b/test/user_db_test.cc
@@ -121,17 +121,39 @@ TEST(RimeUserDbValueTest, PackUnpackRoundtripZero) {
 }
 
 TEST(RimeUserDbValueTest, PackUnpackRoundtripSmallNormal) {
-  // A small but normal (non-denormal) positive value, just above min().
+  // A small but normal (non-denormal) positive value that is still above
+  // kUserDbDiscardThreshold, so it must round-trip unchanged.
   UserDbValue original;
   original.commits = 7;
-  original.dee = 3e-300;
+  original.dee = 3e-150;
   original.tick = 999;
 
   string packed = original.Pack();
   UserDbValue restored(packed);
   EXPECT_EQ(7, restored.commits);
-  EXPECT_DOUBLE_EQ(3e-300, restored.dee);
+  EXPECT_DOUBLE_EQ(3e-150, restored.dee);
   EXPECT_EQ(999u, restored.tick);
+}
+
+TEST(RimeUserDbValueTest, PackClampsAgedOutDee) {
+  // Normal values at or below kUserDbDiscardThreshold are aged out (they
+  // would be discarded on load), so Pack() must serialize them as zero to
+  // keep the stored state consistent with the discard semantics.
+  UserDbValue aged;
+  aged.commits = 3;
+  aged.dee = 1e-250;  // normal, but below the discard threshold
+  aged.tick = 777;
+
+  string packed = aged.Pack();
+  EXPECT_EQ("c=3 d=0 t=777", packed);
+  UserDbValue restored(packed);
+  EXPECT_DOUBLE_EQ(0.0, restored.dee);
+
+  // The exact threshold value is discarded too (<= comparison).
+  UserDbValue at_threshold;
+  at_threshold.dee = kUserDbDiscardThreshold;
+  UserDbValue restored2(at_threshold.Pack());
+  EXPECT_DOUBLE_EQ(0.0, restored2.dee);
 }
 
 TEST(RimeUserDbValueTest, UnpackSurvivesDenormal) {
@@ -151,7 +173,8 @@ TEST(RimeUserDbValueTest, UnpackSurvivesDenormal) {
 TEST(RimeUserDbValueTest, PackThenUnpackDenormalIsClamped) {
   // Setting dee to a denormal in memory and Pack()ing it must produce a
   // string that Unpack() can parse back without error — the round-trip must
-  // not lose the record.
+  // not lose the record. Denormals fall below kUserDbDiscardThreshold and
+  // are therefore clamped to exactly zero.
   UserDbValue original;
   original.commits = 5;
   original.dee = std::numeric_limits<double>::denorm_min();  // ~4.94e-324
@@ -163,8 +186,7 @@ TEST(RimeUserDbValueTest, PackThenUnpackDenormalIsClamped) {
       << "Unpack failed on packed string: " << packed;
   EXPECT_EQ(5, restored.commits);
   EXPECT_EQ(12345u, restored.tick);
-  EXPECT_GE(restored.dee, 0.0);
-  EXPECT_FALSE(std::isnan(restored.dee));
+  EXPECT_DOUBLE_EQ(0.0, restored.dee);
 }
 
 TEST(RimeUserDbValueTest, UnpackRejectsGarbage) {


### PR DESCRIPTION
## 問題

載入使用者詞庫時，librime 會輸出類似以下的錯誤日誌：

```
[ERROR] ... failed in parsing key-value from userdb entry 'd=9.88131e-324'.
```

凡是權重 `dee` 經過多次衰減後落入**非正規（denormal）**雙精度浮點數範圍內的詞條，都會觸發此錯誤。

### 根本原因——寫入／讀取不對稱

`dee` 會隨著 tick 遞增，透過 `formula_d`（`d + da * exp((ta - t) / 200)`）不斷衰減。對於長期存在但很少使用的詞條，`dee` 可能低於最小正規雙精度浮點數（`std::numeric_limits<double>::min()` ≈ 2.2e-308），落入非正規範圍（最低約 4.9e-324）。

- **寫入端：** `Pack()` 透過 `std::ostringstream` 序列化 `dee`，非正規數值會被如實輸出為 `9.88131e-324` 這樣的字串。
- **讀取端：** `Unpack()` 使用 `std::stod` 解析 `dee`，而 `std::stod` 底層呼叫 `strtod`，當結果下溢（`errno == ERANGE`）時會**拋出 `std::out_of_range`**——非正規字面量恰好會觸發這種情況。

因此 librime 自己寫入的值，無法再被讀回來。

### 影響

1. **日誌刷錯**：每次載入受影響的詞條都會產生一筆 ERROR。
2. **整筆記錄被丟棄，而不只是 `dee` 欄位。** `Unpack()` 捕捉異常後回傳 `false`，且拋出異常會中斷解析迴圈，導致 `tick` 也來不及讀取。檢查回傳值的呼叫端會丟棄整筆記錄——最明顯的是 `UserDictionary::CreateDictEntry`：
   ```cpp
   UserDbValue v;
   if (!v.Unpack(value))
     return e;   // 空記錄 -> 該詞不會出現在候選中
   ```
   不檢查回傳值的呼叫端（`UpdateEntry`、`UserDbMerger::Put`、`UserDbImporter::Put`）則會拿著半解析的 `UserDbValue`（`dee`/`tick` 為預設值）繼續執行，可能污染後續的合併或覆寫。

請注意這與 `CreateDictEntry` 中*設計上*的老化淘汰（`dee <= kDiscardThreshold`，1e-200，於 de21e7d 中加入）是兩回事：非正規詞條理應走到那條乾淨的淘汰路徑，而不是先在解析器裡拋出異常。

## 修復

共三個 commit，聚焦於解析的完備性，與淘汰策略正交：

1. **`Pack()` 鉗位**：序列化前將已老化（`dee <= kUserDbDiscardThreshold`）以及負值的 `dee` 鉗位為 `0`，從源頭杜絕非正規字串被寫入。鉗位點與 de21e7d 的載入時淘汰閾值**共用同一常量**（提升為 `user_db.h` 中的 `kUserDbDiscardThreshold`），消除此前 `[1e-308, 1e-200)` 區間「載入時被忽略、寫盤時仍以微小數值序列化」的語義縫隙，讓存儲狀態與淘汰語義一致。
2. **`Unpack()` 改用 `strtol/strtod/strtoul`**：`strtod` 在下溢時回傳該值或 `0` 而**不拋異常**，因此使用者資料庫中既有的非正規詞條也能被乾淨地解析；`dee` 隨後被鉗位到 `[0, 10000]`。end-pointer 與 `errno == ERANGE` 檢查保留了對真正格式錯誤輸入的拒絕能力。
3. **`CreateDictEntry`** 改用共享常量，移除原本的地區型定義。

修復後，老化的詞條會無錯誤地被解析，並透過設計上的淘汰路徑被忽略，而不是在解析器中炸開。此修復**不會**（也不應該）把這類詞條復活為候選——它們確實已經老化出局；修復的價值在於停止日誌刷錯，並避免誤傷其他合法記錄。真正的「視同刪除」（物理清除或刪除標記）屬於行為策略變更，建議另開 issue 討論。

## 測試

在 `test/user_db_test.cc` 中新增 `RimeUserDbValueTest` 測試套件（7 個案例）：

| 測試 | 說明 |
|------|------|
| `PackUnpackRoundtripNormal` | 正常值可正確往返 |
| `PackUnpackRoundtripZero` | 零值可往返 |
| `PackUnpackRoundtripSmallNormal` | 小但高於淘汰閾值的雙精度數（3e-150）可存活 |
| `PackClampsAgedOutDee` | 低於淘汰閾值的正規值（1e-250）及恰等於閾值的值被鉗位為 0 |
| `UnpackSurvivesDenormal` | 舊版寫入的非正規字串 `9.88131e-324` 可無錯誤解析 |
| `PackThenUnpackDenormalIsClamped` | `denorm_min()` 打包後再解包，得到 `d=0` 的乾淨往返 |
| `UnpackRejectsGarbage` | 非數字輸入仍會被拒絕 |

全部 7 個測試通過；完整測試套件 120/120 通過，無回歸。