### PR TITLE
feat(engine): add component creation timing stats

### DIFF
--- a/src/rime/engine.cc
+++ b/src/rime/engine.cc
@@ -5,6 +5,7 @@
 // 2011-04-24 GONG Chen <chen.sst@gmail.com>
 //
 #include <cctype>
+#include <chrono>
 #include <rime/common.h>
 #include <rime/composition.h>
 #include <rime/context.h>
@@ -313,7 +314,20 @@ inline void CreateComponentsFromList(Engine* engine,
                    << ticket.klass << "'";
         continue;
       }
+      const auto create_start = std::chrono::steady_clock::now();
       auto component = c->Create(ticket);
+      const auto create_cost_us =
+          std::chrono::duration_cast<std::chrono::microseconds>(
+              std::chrono::steady_clock::now() - create_start)
+              .count();
+      const auto create_cost_ms = create_cost_us / 1000.0;
+      LOG(INFO) << "[ComponentTiming] type=" << component_type
+                << " prescription='" << prescription->str() << "'"
+                << " class='" << ticket.klass << "'"
+                << " namespace='" << ticket.name_space << "'"
+                << " cost_us=" << create_cost_us
+                << " cost_ms=" << create_cost_ms
+                << " success=" << (component != nullptr);
       if (!component) {
         LOG(ERROR) << "error creating " << component_type << " from ticket: '"
                    << ticket.klass << "'";


### PR DESCRIPTION
Log the time each engine component (processor, segmentor, translator, filter) takes to initialize. Many schemas now bundle Lua plugins, which significantly slows down component creation. These timing logs make it easy to identify which components are the performance bottleneck.

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
