### PR TITLE
feat(prism,syllabifier): canonicalize input

### DIFF
--- a/src/rime/algo/calculus.cc
+++ b/src/rime/algo/calculus.cc
@@ -70,27 +70,38 @@ Calculation* Transliteration::Parse(const vector<string>& args) {
 bool Transliteration::Apply(Spelling* spelling) {
   if (!spelling || spelling->str.empty())
     return false;
+
+  const char* const start = spelling->str.c_str();
+  const char* const end = start + spelling->str.size();
+
+  string result;
   bool modified = false;
-  const char* p = spelling->str.c_str();
-  const int buffer_len = 256;
-  char buffer[buffer_len] = "";
-  char* q = buffer;
-  uint32_t c;
-  while ((c = utf8::unchecked::next(p))) {
-    if (q - buffer > buffer_len - 7) {  // insufficient space
-      modified = false;
-      break;
+
+  const char* p = start;
+  while (p < end) {
+    const char* here = p;
+    uint32_t c = utf8::unchecked::next(p);
+
+    auto it = char_map_.find(c);
+    if (it != char_map_.end()) {
+      if (!modified) {
+        // allocate space and copy unmodified prefix up to this point
+        modified = true;
+        result.reserve(spelling->str.size());
+        result.assign(start, here - start);
+      }
+      c = it->second;  // replace character
     }
-    if (char_map_.find(c) != char_map_.end()) {
-      c = char_map_[c];
-      modified = true;
+
+    if (modified) {
+      utf8::unchecked::append(c, std::back_inserter(result));
     }
-    q = utf8::unchecked::append(c, q);
   }
+
   if (modified) {
-    *q = '\0';
-    spelling->str.assign(buffer);
+    spelling->str = std::move(result);
   }
+
   return modified;
 }
 

--- a/src/rime/algo/calculus.cc
+++ b/src/rime/algo/calculus.cc
@@ -22,6 +22,7 @@ Calculus::Calculus() {
   Register("derive", &Derivation::Parse);
   Register("fuzz", &Fuzzing::Parse);
   Register("abbrev", &Abbreviation::Parse);
+  Register("reorder", &Reorder::Parse);
 }
 
 void Calculus::Register(const string& token, Calculation::Factory* factory) {
@@ -252,6 +253,120 @@ bool Correction::Apply(Spelling* spelling) {
     spelling->properties.credibility += kCorrectionPenalty;
   }
   return result;
+}
+
+// Reorder
+
+Calculation* Reorder::Parse(const vector<string>& args) {
+  if (args.size() < 2)
+    return nullptr;
+  const string& order = args[1];
+  if (order.empty())
+    return nullptr;
+  bool dedup = args.size() > 2 && args[2] == "dedup";
+  the<Reorder> x(new Reorder);
+  utf8::unchecked::utf8to32(order.begin(), order.end(),
+                            std::back_inserter(x->order_));
+  x->dedup_ = dedup;
+  return x.release();
+}
+
+bool Reorder::Apply(Spelling* spelling) {
+  if (!spelling || spelling->str.empty())
+    return false;
+
+  const char* const start = spelling->str.c_str();
+  const char* const end = start + spelling->str.length();
+
+  string result;
+  bool modified = false;
+
+  vector<int> key_count(order_.size(), 0);
+  const char* group_start = nullptr;
+  size_t last_key_index = 0;
+  bool needs_reorder = false;
+
+  // flush the reordered characters from the key group
+  auto flush_group = [&](auto& output) {
+    for (size_t k = 0; k < order_.size(); ++k) {
+      if (key_count[k]) {
+        const uint32_t key = order_.at(k);
+        const size_t n = dedup_ ? 1 : key_count[k];
+        for (size_t i = 0; i < n; ++i) {
+          utf8::unchecked::append(key, output);
+        }
+      }
+    }
+  };
+
+  // clear the key count of the current group
+  auto clear_group = [&]() {
+    std::fill(key_count.begin(), key_count.end(), 0);
+    group_start = nullptr;
+  };
+
+  auto settle_group = [&](const char* group_end) {
+    if (!group_start)
+      return;
+
+    if (needs_reorder) {
+      if (!modified) {
+        modified = true;
+        // allocate space and copy unmodified prefix before the group
+        result.reserve(spelling->str.size());
+        result.assign(start, group_start - start);
+      }
+      auto output = std::back_inserter(result);
+      flush_group(output);
+    } else if (modified) {
+      // copy the unmodified group to the result
+      result.append(group_start, group_end - group_start);
+    }
+    clear_group();
+  };
+
+  const char* p = start;
+  while (p < end) {
+    const char* const here = p;
+    uint32_t c = utf8::unchecked::next(p);
+
+    size_t key_index = order_.find(c);
+    if (key_index != std::u32string::npos) {
+      // belongs to the key group to be reordered
+      if (!group_start) {
+        group_start = here;
+        needs_reorder = false;
+      } else if (key_index < last_key_index) {
+        // the key is not in monotonically increasing order
+        needs_reorder = true;
+      }
+      last_key_index = key_index;
+
+      ++key_count[key_index];
+      if (dedup_ && key_count[key_index] > 1) {
+        needs_reorder = true;
+      }
+      continue;
+    }
+
+    // found a delimiting character; settle the previous key group
+    settle_group(here);
+
+    // append the current delimiting character
+    if (modified) {
+      auto output = std::back_inserter(result);
+      utf8::unchecked::append(c, output);
+    }
+  }  // end of string traversal
+
+  // settle the key group at the end of string
+  settle_group(end);
+
+  if (modified) {
+    spelling->str = std::move(result);
+  }
+
+  return modified;
 }
 
 }  // namespace rime

--- a/src/rime/algo/calculus.h
+++ b/src/rime/algo/calculus.h
@@ -96,6 +96,17 @@ class Correction : public Derivation {
   bool Apply(Spelling* spelling) override;
 };
 
+// reorder/zyx/dedup  ("xzxy" -> "zyx")
+class Reorder : public Calculation {
+ public:
+  static Factory Parse;
+  bool Apply(Spelling* spelling) override;
+
+ protected:
+  std::u32string order_;
+  bool dedup_;
+};
+
 }  // namespace rime
 
 #endif  // RIME_CALCULUS_H_

--- a/src/rime/algo/syllabifier.cc
+++ b/src/rime/algo/syllabifier.cc
@@ -68,7 +68,24 @@ int Syllabifier::BuildSyllableGraph(const string& input,
     set<SyllableId> exact_match_syllables;
     std::string_view current_input(input.data() + begin_pos,
                                    input.length() - begin_pos);
-    prism.CommonPrefixSearch(current_input, &matches);
+    if (canonicalizer_) {
+      const size_t limit =
+          (std::min)(current_input.length(), prism.max_key_length());
+      string syllable;
+      syllable.reserve(limit);
+      for (size_t len = 1; len <= limit; ++len) {
+        // TODO: 須重構 Calculus 爲寫入時複製以避免複製子串.
+        syllable.assign(current_input.data(), len);
+        canonicalizer_->Apply(&syllable);
+        // 重排打破了前綴單調性, 故不能用前綴下行搜索, 改爲每次步進精確查詢.
+        int value = -1;
+        if (prism.GetValue(syllable, &value)) {
+          matches.emplace_back(Prism::Match{value, len});
+        }
+      }
+    } else {
+      prism.CommonPrefixSearch(current_input, &matches);
+    }
     if (corrector_) {
       for (auto& m : matches) {
         exact_match_syllables.insert(m.value);

--- a/src/rime/algo/syllabifier.h
+++ b/src/rime/algo/syllabifier.h
@@ -15,8 +15,9 @@
 
 namespace rime {
 
-class Prism;
 class Corrector;
+class Prism;
+class Projection;
 
 using SyllableId = int32_t;
 
@@ -49,10 +50,12 @@ class Syllabifier {
   Syllabifier() = default;
   explicit Syllabifier(const string& delimiters,
                        bool enable_completion = false,
-                       bool strict_spelling = false)
+                       bool strict_spelling = false,
+                       Projection* canonicalizer = nullptr)
       : delimiters_(delimiters),
         enable_completion_(enable_completion),
-        strict_spelling_(strict_spelling) {}
+        strict_spelling_(strict_spelling),
+        canonicalizer_(canonicalizer) {}
 
   RIME_DLL int BuildSyllableGraph(const string& input,
                                   Prism& prism,
@@ -66,6 +69,7 @@ class Syllabifier {
   string delimiters_;
   bool enable_completion_ = false;
   bool strict_spelling_ = false;
+  Projection* canonicalizer_ = nullptr;
   Corrector* corrector_ = nullptr;
 };
 

--- a/src/rime/dict/prism.cc
+++ b/src/rime/dict/prism.cc
@@ -29,8 +29,8 @@ const int32_t kSpellingTypeMask = ~kTypeIsCorrectionMask;
 
 }  // namespace
 
-const char kPrismFormat[] = "Rime::Prism/4.0";
-const double kPrismFormatVersion = 4.0;
+const char kPrismFormat[] = "Rime::Prism/5.0";
+const double kPrismFormatVersion = 5.0;
 
 const char kPrismFormatPrefix[] = "Rime::Prism/";
 const size_t kPrismFormatPrefixLen = sizeof(kPrismFormatPrefix) - 1;
@@ -149,14 +149,17 @@ bool Prism::Build(const Syllabary& syllabary,
   vector<const char*> keys(num_spellings);
   size_t key_id = 0;
   size_t map_size = 0;
+  size_t max_key_length = 0;
   if (script) {
     for (auto it = script->begin(); it != script->end(); ++it, ++key_id) {
       keys[key_id] = it->first.c_str();
+      max_key_length = (std::max)(max_key_length, it->first.length());
       map_size += it->second.size();
     }
   } else {
     for (auto it = syllabary.begin(); it != syllabary.end(); ++it, ++key_id) {
       keys[key_id] = it->c_str();
+      max_key_length = (std::max)(max_key_length, it->length());
     }
   }
   if (0 != trie_->build(num_spellings, &keys[0])) {
@@ -185,6 +188,7 @@ bool Prism::Build(const Syllabary& syllabary,
   metadata->schema_file_checksum = schema_file_checksum;
   metadata->num_syllables = num_syllables;
   metadata->num_spellings = num_spellings;
+  metadata->max_key_length = max_key_length;
   metadata_ = metadata;
   // alphabet
   {
@@ -330,6 +334,10 @@ SpellingAccessor Prism::QuerySpelling(SyllableId spelling_id) {
 
 size_t Prism::array_size() const {
   return trie_->size();
+}
+
+size_t Prism::max_key_length() const {
+  return metadata_ ? metadata_->max_key_length : 0;
 }
 
 uint32_t Prism::dict_file_checksum() const {

--- a/src/rime/dict/prism.cc
+++ b/src/rime/dict/prism.cc
@@ -256,13 +256,13 @@ bool Prism::Build(const Syllabary& syllabary,
   return true;
 }
 
-bool Prism::HasKey(const string& key) {
-  int value = trie_->exactMatchSearch<int>(key.c_str());
+bool Prism::HasKey(std::string_view key) {
+  int value = trie_->exactMatchSearch<int>(key.data(), key.length());
   return value != -1;
 }
 
-bool Prism::GetValue(const string& key, int* value) const {
-  int result = trie_->exactMatchSearch<int>(key.c_str());
+bool Prism::GetValue(std::string_view key, int* value) const {
+  int result = trie_->exactMatchSearch<int>(key.data(), key.length());
   if (result == -1) {
     return false;
   }

--- a/src/rime/dict/prism.h
+++ b/src/rime/dict/prism.h
@@ -78,8 +78,8 @@ class Prism : public MappedFile {
                       uint32_t dict_file_checksum = 0,
                       uint32_t schema_file_checksum = 0);
 
-  RIME_DLL bool HasKey(const string& key);
-  RIME_DLL bool GetValue(const string& key, int* value) const;
+  RIME_DLL bool HasKey(std::string_view key);
+  RIME_DLL bool GetValue(std::string_view key, int* value) const;
   RIME_DLL void CommonPrefixSearch(std::string_view key, vector<Match>* result);
   RIME_DLL void ExpandSearch(std::string_view key,
                              vector<Match>* result,

--- a/src/rime/dict/prism.h
+++ b/src/rime/dict/prism.h
@@ -45,6 +45,8 @@ struct Metadata {
   // v1.0
   OffsetPtr<SpellingMap> spelling_map;
   char alphabet[256];
+  // v5.0
+  uint32_t max_key_length;
 };
 
 }  // namespace prism
@@ -87,7 +89,7 @@ class Prism : public MappedFile {
   SpellingAccessor QuerySpelling(SyllableId spelling_id);
 
   RIME_DLL size_t array_size() const;
-
+  RIME_DLL size_t max_key_length() const;
   uint32_t dict_file_checksum() const;
   uint32_t schema_file_checksum() const;
   Darts::DoubleArray& trie() const { return *trie_; }

--- a/src/rime/gear/script_translator.cc
+++ b/src/rime/gear/script_translator.cc
@@ -86,7 +86,8 @@ class ScriptSyllabifier : public PhraseSyllabifier {
         start_(start),
         syllabifier_(translator->delimiters(),
                      translator->enable_completion(),
-                     translator->strict_spelling()) {
+                     translator->strict_spelling(),
+                     translator->canonicalizer()) {
     if (corrector) {
       syllabifier_.EnableCorrection(corrector);
     }
@@ -196,6 +197,12 @@ ScriptTranslator::ScriptTranslator(const Ticket& ticket)
     }
     config->GetInt(name_space_ + "/max_homophones", &max_homophones_);
     poet_.reset(new Poet(language(), config));
+    if (an<ConfigList> rules = config->GetList(name_space_ + "/canonicalize")) {
+      the<Projection> canonicalizer(new Projection());
+      if (canonicalizer->Load(rules)) {
+        canonicalizer_ = std::move(canonicalizer);
+      }
+    }
   }
   if (enable_correction_) {
     if (auto* corrector = Corrector::Require("corrector")) {

--- a/src/rime/gear/script_translator.h
+++ b/src/rime/gear/script_translator.h
@@ -52,6 +52,7 @@ class ScriptTranslator : public Translator,
   bool enable_word_completion() const { return enable_word_completion_; }
   int max_word_length() const { return max_word_length_; }
   int core_word_length() const;
+  Projection* canonicalizer() const { return canonicalizer_.get(); }
 
  protected:
   int max_homophones_ = 1;
@@ -61,6 +62,7 @@ class ScriptTranslator : public Translator,
   bool always_show_comments_ = false;
   bool enable_correction_ = false;
   bool enable_word_completion_ = false;
+  the<Projection> canonicalizer_;
   the<Corrector> corrector_;
   the<Poet> poet_;
   vector<an<Phrase>> queue_;

--- a/test/calculus_test.cc
+++ b/test/calculus_test.cc
@@ -2,34 +2,31 @@
 // Copyright RIME Developers
 // Distributed under the BSD License
 //
-// 2012-01-17 GONG Chen <chen.sst@gmail.com>
-//
 #include <cmath>
 #include <gtest/gtest.h>
 #include <rime/common.h>
 #include <rime/algo/calculus.h>
 
-static const char* kTransliteration =
-    "xlit abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-static const char* kTransformation = "xform/^([zcs])h(.*)$/$1$2/";
-static const char* kErasion = "erase/^[czs]h[aoe]ng?$/";
-static const char* kDerivation = "derive/^([zcs])h/$1/";
-static const char* kAbbreviation = "abbrev/^([zcs]h).*$/$1/";
+// Combo Pinyin 3.0 key order
+static const char* kComboPinyinKeyOrder = "SCZHLFGDBKTPIUÜANREO";
+
+using namespace rime;
 
 TEST(RimeCalculusTest, Transliteration) {
-  rime::Calculus calc;
-  rime::the<rime::Calculation> c(calc.Parse(kTransliteration));
+  Calculus calc;
+  the<Calculation> c(
+      calc.Parse("xlit abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
   ASSERT_TRUE(bool(c));
-  rime::Spelling s("abracadabra");
+  Spelling s("abracadabra");
   EXPECT_TRUE(c->Apply(&s));
   EXPECT_EQ("ABRACADABRA", s.str);
 }
 
 TEST(RimeCalculusTest, Transformation) {
-  rime::Calculus calc;
-  rime::the<rime::Calculation> c(calc.Parse(kTransformation));
+  Calculus calc;
+  the<Calculation> c(calc.Parse("xform/^([zcs])h(.*)$/$1$2/"));
   ASSERT_TRUE(bool(c));
-  rime::Spelling s("shang");
+  Spelling s("shang");
   EXPECT_TRUE(c->Apply(&s));
   EXPECT_EQ("sang", s.str);
   // non-matching case
@@ -38,12 +35,12 @@ TEST(RimeCalculusTest, Transformation) {
 }
 
 TEST(RimeCalculusTest, Erasion) {
-  rime::Calculus calc;
-  rime::the<rime::Calculation> c(calc.Parse(kErasion));
+  Calculus calc;
+  the<Calculation> c(calc.Parse("erase/^[czs]h[aoe]ng?$/"));
   ASSERT_TRUE(bool(c));
   EXPECT_FALSE(c->addition());
   EXPECT_TRUE(c->deletion());
-  rime::Spelling s("shang");
+  Spelling s("shang");
   EXPECT_TRUE(c->Apply(&s));
   EXPECT_EQ("", s.str);
   // non-matching case
@@ -52,12 +49,12 @@ TEST(RimeCalculusTest, Erasion) {
 }
 
 TEST(RimeCalculusTest, Derivation) {
-  rime::Calculus calc;
-  rime::the<rime::Calculation> c(calc.Parse(kDerivation));
+  Calculus calc;
+  the<Calculation> c(calc.Parse("derive/^([zcs])h/$1/"));
   ASSERT_TRUE(bool(c));
   EXPECT_TRUE(c->addition());
   EXPECT_FALSE(c->deletion());
-  rime::Spelling s("shang");
+  Spelling s("shang");
   EXPECT_TRUE(c->Apply(&s));
   EXPECT_EQ("sang", s.str);
   // non-matching case
@@ -66,14 +63,156 @@ TEST(RimeCalculusTest, Derivation) {
 }
 
 TEST(RimeCalculusTest, Abbreviation) {
-  rime::Calculus calc;
-  rime::the<rime::Calculation> c(calc.Parse(kAbbreviation));
+  Calculus calc;
+  the<Calculation> c(calc.Parse("abbrev/^([zcs]h).*$/$1/"));
   ASSERT_TRUE(bool(c));
   EXPECT_TRUE(c->addition());
   EXPECT_FALSE(c->deletion());
-  rime::Spelling s("shang");
+  Spelling s("shang");
   EXPECT_TRUE(c->Apply(&s));
   EXPECT_EQ("sh", s.str);
   EXPECT_EQ(rime::kAbbreviation, s.properties.type);
   EXPECT_DOUBLE_EQ(log(0.5), s.properties.credibility);
+}
+
+// 基礎雙鍵與多鍵並擊亂序重排 (Inversion & Interleaving)
+TEST(RimeCalculusTest, ReorderBasicInversion) {
+  Calculus calc;
+  std::string formula = std::string("reorder ") + kComboPinyinKeyOrder;
+  std::unique_ptr<Calculation> reorder(calc.Parse(formula));
+  ASSERT_NE(reorder, nullptr);
+
+  // 1. 聲母同手指倒錯：FZ (zh) -> ZF
+  Spelling s1("FZ");
+  EXPECT_TRUE(reorder->Apply(&s1));
+  EXPECT_EQ(s1.str, "ZF");
+
+  // 2. 音節內多鍵亂序：FZURO (zhong) -> ZFURO
+  Spelling s2("FZURO");
+  EXPECT_TRUE(reorder->Apply(&s2));
+  EXPECT_EQ(s2.str, "ZFURO");
+
+  // 3. 雙手並發極速交錯（右手先於左手）：UZRF (zhui) -> ZFUR
+  Spelling s3("UZRF");
+  EXPECT_TRUE(reorder->Apply(&s3));
+  EXPECT_EQ(s3.str, "ZFUR");
+}
+
+// 已經符合標準鍵序的字符串（無須修改，應返回 false）
+TEST(RimeCalculusTest, ReorderAlreadyOrdered) {
+  Calculus calc;
+  std::string formula = std::string("reorder ") + kComboPinyinKeyOrder;
+  std::unique_ptr<Calculation> reorder(calc.Parse(formula));
+  ASSERT_NE(reorder, nullptr);
+
+  // 標準和弦碼：不應修改，Apply 返回 false
+  Spelling s1("ZFURO");
+  EXPECT_FALSE(reorder->Apply(&s1));
+  EXPECT_EQ(s1.str, "ZFURO");
+
+  Spelling s2("ZF");
+  EXPECT_FALSE(reorder->Apply(&s2));
+  EXPECT_EQ(s2.str, "ZF");
+}
+
+// 包含音節分隔符 '\'' 的連擊字符串 (Delimited Key Groups)
+TEST(RimeCalculusTest, ReorderWithDelimiter) {
+  Calculus calc;
+  std::string formula = std::string("reorder ") + kComboPinyinKeyOrder;
+  std::unique_ptr<Calculation> reorder(calc.Parse(formula));
+  ASSERT_NE(reorder, nullptr);
+
+  // 1. 第一組亂序，第二組已有序：FZURO'UN -> ZFURO'UN
+  Spelling s1("FZURO'UN");
+  EXPECT_TRUE(reorder->Apply(&s1));
+  EXPECT_EQ(s1.str, "ZFURO'UN");
+
+  // 2. 兩組均亂序：FZ'NU -> ZF'UN
+  Spelling s2("FZ'NU");
+  EXPECT_TRUE(reorder->Apply(&s2));
+  EXPECT_EQ(s2.str, "ZF'UN");
+
+  // 3. 分隔符位於開頭與末尾的邊界情況
+  Spelling s3("'FZ");
+  EXPECT_TRUE(reorder->Apply(&s3));
+  EXPECT_EQ(s3.str, "'ZF");
+
+  Spelling s4("FZ'");
+  EXPECT_TRUE(reorder->Apply(&s4));
+  EXPECT_EQ(s4.str, "ZF'");
+}
+
+// 去重模式 (dedup) 驗證
+TEST(RimeCalculusTest, ReorderDeduplication) {
+  Calculus calc;
+  std::string formula_no_dedup = std::string("reorder ") + kComboPinyinKeyOrder;
+  std::string formula_dedup =
+      std::string("reorder ") + kComboPinyinKeyOrder + " dedup";
+
+  std::unique_ptr<Calculation> reorder_no_dedup(calc.Parse(formula_no_dedup));
+  std::unique_ptr<Calculation> reorder_dedup(calc.Parse(formula_dedup));
+
+  ASSERT_NE(reorder_no_dedup, nullptr);
+  ASSERT_NE(reorder_dedup, nullptr);
+
+  // 無 dedup 模式：重複按鍵保留（若是順序的則返回 false）
+  Spelling s1("ZZFFUU");
+  EXPECT_FALSE(reorder_no_dedup->Apply(&s1));
+  EXPECT_EQ(s1.str, "ZZFFUU");
+
+  // 有 dedup 模式：重複按鍵被壓縮去重，且返回 true（觸發了修改）
+  Spelling s2("ZZFFUU");
+  EXPECT_TRUE(reorder_dedup->Apply(&s2));
+  EXPECT_EQ(s2.str, "ZFU");
+
+  // 有 dedup 模式 + 亂序：FFZZUU -> ZFU
+  Spelling s3("FFZZUU");
+  EXPECT_TRUE(reorder_dedup->Apply(&s3));
+  EXPECT_EQ(s3.str, "ZFU");
+}
+
+// 非鍵序內字符（如標點、大寫字母）的隔離保護
+TEST(RimeCalculusTest, ReorderNonOrderCharacters) {
+  Calculus calc;
+  std::unique_ptr<Calculation> reorder(calc.Parse("reorder zyx"));
+  ASSERT_NE(reorder, nullptr);
+
+  // 1. 字符 'a' 不在 "zyx" 中，作為分隔符：xzy - a - xzy -> zyx - a - zyx
+  Spelling s1("xzyaxzy");
+  EXPECT_TRUE(reorder->Apply(&s1));
+  EXPECT_EQ(s1.str, "zyxazyx");
+
+  // 2. 大寫字母 A, B 不在 "zyx" 中，原樣保留：
+  // xzy - A - xzy - B -> zyx - A - zyx - B
+  Spelling s2("xzyAxzyB");
+  EXPECT_TRUE(reorder->Apply(&s2));
+  EXPECT_EQ(s2.str, "zyxAzyxB");
+}
+
+// 非鍵序內字符（如標點、大寫字母）的隔離保護，開啓去重模式
+TEST(RimeCalculusTest, ReorderNonOrderCharactersWithDedup) {
+  Calculus calc;
+  // 加上 dedup 參數
+  std::unique_ptr<Calculation> reorder(calc.Parse("reorder zyx dedup"));
+  ASSERT_NE(reorder, nullptr);
+
+  // 'a' 爲分隔符，xzxy 去重重排 -> zyx，xzy 重排 -> zyx
+  Spelling s1("xzxyaxzy");
+  EXPECT_TRUE(reorder->Apply(&s1));
+  EXPECT_EQ(s1.str, "zyxazyx");
+}
+
+// Calculus 工廠解析器 (Parse) 的參數校驗
+TEST(RimeCalculusTest, ReorderParseValidation) {
+  Calculus calc;
+
+  // 缺少參數 -> 返回 nullptr
+  EXPECT_EQ(calc.Parse("reorder"), nullptr);
+
+  // order 字符串爲空 -> 返回 nullptr
+  EXPECT_EQ(calc.Parse("reorder "), nullptr);
+
+  // 合法參數
+  EXPECT_NE(calc.Parse("reorder zyx"), nullptr);
+  EXPECT_NE(calc.Parse("reorder zyx dedup"), nullptr);
 }

--- a/test/prism_test.cc
+++ b/test/prism_test.cc
@@ -44,6 +44,10 @@ TEST_F(RimePrismTest, SaveAndLoad) {
   EXPECT_EQ(prism_->array_size(), test.array_size());
 }
 
+TEST_F(RimePrismTest, Metadata) {
+  EXPECT_EQ(prism_->max_key_length(), 9);  // "macrosoft"
+}
+
 TEST_F(RimePrismTest, HasKey) {
   EXPECT_TRUE(prism_->HasKey("google"));
   EXPECT_FALSE(prism_->HasKey("googlesoft"));

--- a/test/syllabifier_test.cc
+++ b/test/syllabifier_test.cc
@@ -5,15 +5,18 @@
 // 2011-07-05 GONG Chen <chen.sst@gmail.com>
 //
 #include <algorithm>
-#include <utility>
+#include <filesystem>
 #include <gtest/gtest.h>
 #include <rime/dict/prism.h>
+#include <rime/algo/algebra.h>
 #include <rime/algo/syllabifier.h>
+
+using namespace rime;
 
 class RimeSyllabifierTest : public ::testing::Test {
  public:
   virtual void SetUp() {
-    rime::vector<rime::string> syllables;
+    vector<string> syllables;
     syllables.push_back("a");      // 0 == id
     syllables.push_back("an");     // 1
     syllables.push_back("cha");    // 2
@@ -30,9 +33,9 @@ class RimeSyllabifierTest : public ::testing::Test {
       syllable_id_[syllables[i]] = i;
     }
 
-    rime::path file_path("syllabifier_test.bin");
-    prism_.reset(new rime::Prism(file_path));
-    rime::set<rime::string> keyset;
+    path file_path("syllabifier_test.bin");
+    prism_.reset(new Prism(file_path));
+    set<string> keyset;
     std::copy(syllables.begin(), syllables.end(),
               std::inserter(keyset, keyset.begin()));
     prism_->Build(keyset);
@@ -41,47 +44,47 @@ class RimeSyllabifierTest : public ::testing::Test {
   virtual void TearDown() {}
 
  protected:
-  rime::map<rime::string, rime::SyllableId> syllable_id_;
-  rime::the<rime::Prism> prism_;
+  map<string, SyllableId> syllable_id_;
+  the<Prism> prism_;
 };
 
 TEST_F(RimeSyllabifierTest, CaseAlpha) {
-  rime::Syllabifier s;
-  rime::SyllableGraph g;
-  const rime::string input("a");
+  Syllabifier s;
+  SyllableGraph g;
+  const string input("a");
   s.BuildSyllableGraph(input, *prism_, &g);
   EXPECT_EQ(input.length(), g.input_length);
   EXPECT_EQ(input.length(), g.interpreted_length);
   EXPECT_EQ(2, g.vertices.size());
   ASSERT_FALSE(g.vertices.end() == g.vertices.find(1));
-  EXPECT_EQ(rime::kNormalSpelling, g.vertices[1]);
-  rime::SpellingMap& sp(g.edges[0][1]);
+  EXPECT_EQ(kNormalSpelling, g.vertices[1]);
+  SpellingMap& sp(g.edges[0][1]);
   EXPECT_EQ(1, sp.size());
   ASSERT_FALSE(sp.end() == sp.find(syllable_id_["a"]));
-  EXPECT_EQ(rime::kNormalSpelling, sp[0].type);
+  EXPECT_EQ(kNormalSpelling, sp[0].type);
   EXPECT_EQ(0.0, sp[0].credibility);
 }
 
 TEST_F(RimeSyllabifierTest, CaseFailure) {
-  rime::Syllabifier s;
-  rime::SyllableGraph g;
-  const rime::string input("ang");
+  Syllabifier s;
+  SyllableGraph g;
+  const string input("ang");
   s.BuildSyllableGraph(input, *prism_, &g);
   EXPECT_EQ(input.length(), g.input_length);
   EXPECT_EQ(input.length() - 1, g.interpreted_length);
   EXPECT_EQ(2, g.vertices.size());
   ASSERT_TRUE(g.vertices.end() == g.vertices.find(1));
   ASSERT_FALSE(g.vertices.end() == g.vertices.find(2));
-  EXPECT_EQ(rime::kNormalSpelling, g.vertices[2]);
-  rime::SpellingMap& sp(g.edges[0][2]);
+  EXPECT_EQ(kNormalSpelling, g.vertices[2]);
+  SpellingMap& sp(g.edges[0][2]);
   EXPECT_EQ(1, sp.size());
   ASSERT_FALSE(sp.end() == sp.find(syllable_id_["an"]));
 }
 
 TEST_F(RimeSyllabifierTest, CaseChangan) {
-  rime::Syllabifier s;
-  rime::SyllableGraph g;
-  const rime::string input("changan");
+  Syllabifier s;
+  SyllableGraph g;
+  const string input("changan");
   s.BuildSyllableGraph(input, *prism_, &g);
   EXPECT_EQ(input.length(), g.input_length);
   EXPECT_EQ(input.length(), g.interpreted_length);
@@ -90,31 +93,31 @@ TEST_F(RimeSyllabifierTest, CaseChangan) {
   EXPECT_TRUE(g.vertices.end() == g.vertices.find(1));
   ASSERT_FALSE(g.vertices.end() == g.vertices.find(4));
   ASSERT_FALSE(g.vertices.end() == g.vertices.find(5));
-  EXPECT_EQ(rime::kNormalSpelling, g.vertices[4]);
-  EXPECT_EQ(rime::kNormalSpelling, g.vertices[5]);
+  EXPECT_EQ(kNormalSpelling, g.vertices[4]);
+  EXPECT_EQ(kNormalSpelling, g.vertices[5]);
   // chan, chang but not cha
-  rime::EndVertexMap& e0(g.edges[0]);
+  EndVertexMap& e0(g.edges[0]);
   EXPECT_EQ(2, e0.size());
   ASSERT_FALSE(e0.end() == e0.find(4));
   ASSERT_FALSE(e0.end() == e0.find(5));
   EXPECT_FALSE(e0[4].end() == e0[4].find(syllable_id_["chan"]));
   EXPECT_FALSE(e0[5].end() == e0[5].find(syllable_id_["chang"]));
   // gan$
-  rime::EndVertexMap& e4(g.edges[4]);
+  EndVertexMap& e4(g.edges[4]);
   EXPECT_EQ(1, e4.size());
   ASSERT_FALSE(e4.end() == e4.find(7));
   EXPECT_FALSE(e4[7].end() == e4[7].find(syllable_id_["gan"]));
   // an$
-  rime::EndVertexMap& e5(g.edges[5]);
+  EndVertexMap& e5(g.edges[5]);
   EXPECT_EQ(1, e5.size());
   ASSERT_FALSE(e5.end() == e5.find(7));
   EXPECT_FALSE(e5[7].end() == e5[7].find(syllable_id_["an"]));
 }
 
 TEST_F(RimeSyllabifierTest, CaseTuan) {
-  rime::Syllabifier s;
-  rime::SyllableGraph g;
-  const rime::string input("tuan");
+  Syllabifier s;
+  SyllableGraph g;
+  const string input("tuan");
   s.BuildSyllableGraph(input, *prism_, &g);
   EXPECT_EQ(input.length(), g.input_length);
   EXPECT_EQ(input.length(), g.interpreted_length);
@@ -122,25 +125,25 @@ TEST_F(RimeSyllabifierTest, CaseTuan) {
   // both tu'an and tuan
   ASSERT_FALSE(g.vertices.end() == g.vertices.find(2));
   ASSERT_FALSE(g.vertices.end() == g.vertices.find(4));
-  EXPECT_EQ(rime::kAmbiguousSpelling, g.vertices[2]);
-  EXPECT_EQ(rime::kNormalSpelling, g.vertices[4]);
-  rime::EndVertexMap& e0(g.edges[0]);
+  EXPECT_EQ(kAmbiguousSpelling, g.vertices[2]);
+  EXPECT_EQ(kNormalSpelling, g.vertices[4]);
+  EndVertexMap& e0(g.edges[0]);
   EXPECT_EQ(2, e0.size());
   ASSERT_FALSE(e0.end() == e0.find(2));
   ASSERT_FALSE(e0.end() == e0.find(4));
   EXPECT_FALSE(e0[2].end() == e0[2].find(syllable_id_["tu"]));
   EXPECT_FALSE(e0[4].end() == e0[4].find(syllable_id_["tuan"]));
   // an$
-  rime::EndVertexMap& e2(g.edges[2]);
+  EndVertexMap& e2(g.edges[2]);
   EXPECT_EQ(1, e2.size());
   ASSERT_FALSE(e2.end() == e2.find(4));
   EXPECT_FALSE(e2[4].end() == e2[4].find(syllable_id_["an"]));
 }
 
 TEST_F(RimeSyllabifierTest, CaseChainingAmbiguity) {
-  rime::Syllabifier s;
-  rime::SyllableGraph g;
-  const rime::string input("anana");
+  Syllabifier s;
+  SyllableGraph g;
+  const string input("anana");
   s.BuildSyllableGraph(input, *prism_, &g);
   EXPECT_EQ(input.length(), g.input_length);
   EXPECT_EQ(input.length(), g.interpreted_length);
@@ -148,9 +151,9 @@ TEST_F(RimeSyllabifierTest, CaseChainingAmbiguity) {
 }
 
 TEST_F(RimeSyllabifierTest, TransposedSyllableGraph) {
-  rime::Syllabifier s;
-  rime::SyllableGraph g;
-  const rime::string input("changan");
+  Syllabifier s;
+  SyllableGraph g;
+  const string input("changan");
   s.BuildSyllableGraph(input, *prism_, &g);
   ASSERT_FALSE(g.indices.end() == g.indices.find(0));
   EXPECT_EQ(2, g.indices[0].size());
@@ -162,52 +165,196 @@ TEST_F(RimeSyllabifierTest, TransposedSyllableGraph) {
 }
 
 TEST_F(RimeSyllabifierTest, TrimLeadingDelimiters) {
-  rime::Syllabifier s(" '");
-  rime::SyllableGraph g;
-  const rime::string input("''a");
+  Syllabifier s(" '");
+  SyllableGraph g;
+  const string input("''a");
   s.BuildSyllableGraph(input, *prism_, &g);
   EXPECT_EQ(input.length(), g.input_length);
   EXPECT_EQ(input.length(), g.interpreted_length);
   EXPECT_EQ(2, g.vertices.size());
   ASSERT_FALSE(g.vertices.end() == g.vertices.find(3));
-  EXPECT_EQ(rime::kNormalSpelling, g.vertices[1]);
-  rime::SpellingMap& sp(g.edges[0][3]);
+  EXPECT_EQ(kNormalSpelling, g.vertices[1]);
+  SpellingMap& sp(g.edges[0][3]);
   EXPECT_EQ(1, sp.size());
   ASSERT_FALSE(sp.end() == sp.find(syllable_id_["a"]));
-  EXPECT_EQ(rime::kNormalSpelling, sp[0].type);
+  EXPECT_EQ(kNormalSpelling, sp[0].type);
   EXPECT_EQ(0.0, sp[0].credibility);
 }
 
 TEST_F(RimeSyllabifierTest, TrimTrailingDelimiters) {
-  rime::Syllabifier s(" '");
-  rime::SyllableGraph g;
-  const rime::string input("a''");
+  Syllabifier s(" '");
+  SyllableGraph g;
+  const string input("a''");
   s.BuildSyllableGraph(input, *prism_, &g);
   EXPECT_EQ(input.length(), g.input_length);
   EXPECT_EQ(input.length(), g.interpreted_length);
   EXPECT_EQ(2, g.vertices.size());
   ASSERT_FALSE(g.vertices.end() == g.vertices.find(3));
-  EXPECT_EQ(rime::kNormalSpelling, g.vertices[1]);
-  rime::SpellingMap& sp(g.edges[0][3]);
+  EXPECT_EQ(kNormalSpelling, g.vertices[1]);
+  SpellingMap& sp(g.edges[0][3]);
   EXPECT_EQ(1, sp.size());
   ASSERT_FALSE(sp.end() == sp.find(syllable_id_["a"]));
-  EXPECT_EQ(rime::kNormalSpelling, sp[0].type);
+  EXPECT_EQ(kNormalSpelling, sp[0].type);
   EXPECT_EQ(0.0, sp[0].credibility);
 }
 
 TEST_F(RimeSyllabifierTest, TrimBothLeadingAndTrailingDelimiters) {
-  rime::Syllabifier s(" '");
-  rime::SyllableGraph g;
-  const rime::string input("''a''");
+  Syllabifier s(" '");
+  SyllableGraph g;
+  const string input("''a''");
   s.BuildSyllableGraph(input, *prism_, &g);
   EXPECT_EQ(input.length(), g.input_length);
   EXPECT_EQ(input.length(), g.interpreted_length);
   EXPECT_EQ(2, g.vertices.size());
   ASSERT_FALSE(g.vertices.end() == g.vertices.find(5));
-  EXPECT_EQ(rime::kNormalSpelling, g.vertices[1]);
-  rime::SpellingMap& sp(g.edges[0][5]);
+  EXPECT_EQ(kNormalSpelling, g.vertices[1]);
+  SpellingMap& sp(g.edges[0][5]);
   EXPECT_EQ(1, sp.size());
   ASSERT_FALSE(sp.end() == sp.find(syllable_id_["a"]));
-  EXPECT_EQ(rime::kNormalSpelling, sp[0].type);
+  EXPECT_EQ(kNormalSpelling, sp[0].type);
   EXPECT_EQ(0.0, sp[0].credibility);
+}
+
+class CanonicalizeSyllabifierTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    test_prism_path_ =
+        std::filesystem::temp_directory_path() / "test_canonicalize.prism.bin";
+
+    // 宮保拼音並擊碼
+    Syllabary syllabary = {
+        "ZF",     // zhi
+        "ZFUR",   // zhui
+        "ZFURO",  // zhong
+        "SA",     // sa
+        "HE",     // he
+        "GE",     // ge
+        "HGE"     // re
+    };
+
+    Prism prism(test_prism_path_);
+    ASSERT_TRUE(prism.Build(syllabary));
+    ASSERT_TRUE(prism.Save());
+
+    loaded_prism_ = std::make_unique<Prism>(test_prism_path_);
+    ASSERT_TRUE(loaded_prism_->Load());
+
+    auto rules = New<ConfigList>();
+    // 宮保拼音 3.0 標準鍵序
+    rules->Append(New<ConfigValue>("reorder SCZHLFGDBKTPIUÜANREO"));
+    canonicalizer_ = std::make_unique<Projection>();
+    ASSERT_TRUE(canonicalizer_->Load(rules));
+  }
+
+  void TearDown() override {
+    loaded_prism_.reset();
+    if (std::filesystem::exists(test_prism_path_)) {
+      std::filesystem::remove(test_prism_path_);
+    }
+  }
+
+  std::filesystem::path test_prism_path_;
+  std::unique_ptr<Prism> loaded_prism_;
+  std::unique_ptr<Projection> canonicalizer_;
+};
+
+// 測試 1: 基礎聲母同手倒錯 (FZ -> ZF) 與多鍵倒錯 (FZURO -> ZFURO)
+TEST_F(CanonicalizeSyllabifierTest, BasicInversion) {
+  Syllabifier syllabifier("'", false, false, canonicalizer_.get());
+  SyllableGraph graph;
+
+  // 輸入亂序碼 FZURO (意圖打 zhong)，標準碼為 ZFURO
+  int farthest =
+      syllabifier.BuildSyllableGraph("FZURO", *loaded_prism_, &graph);
+
+  EXPECT_EQ(5, farthest);
+  EXPECT_EQ(5, graph.interpreted_length);
+
+  // 驗證圖上是否存在從起點 0 到終點 5 的邊
+  ASSERT_NE(graph.edges.find(0), graph.edges.end());
+  auto& end_vertices = graph.edges[0];
+  ASSERT_NE(end_vertices.find(5), end_vertices.end());
+
+  // 取得該邊匹配到的音節 ID，確認對應 Prism 內的 "ZFURO"
+  int expected_syll_id = -1;
+  ASSERT_TRUE(loaded_prism_->GetValue("ZFURO", &expected_syll_id));
+  EXPECT_NE(end_vertices[5].find(expected_syll_id), end_vertices[5].end());
+}
+
+// 測試 2: 雙手交錯落鍵 (UZRF -> ZFUR)
+TEST_F(CanonicalizeSyllabifierTest, CrossHandInterleaving) {
+  Syllabifier syllabifier("'", false, false, canonicalizer_.get());
+  SyllableGraph graph;
+
+  // 右手 U/R 與左手 Z/F 交錯落鍵: U-Z-R-F
+  int farthest = syllabifier.BuildSyllableGraph("UZRF", *loaded_prism_, &graph);
+
+  EXPECT_EQ(4, farthest);
+  int expected_syll_id = -1;
+  ASSERT_TRUE(loaded_prism_->GetValue("ZFUR", &expected_syll_id));
+
+  ASSERT_NE(graph.edges[0].find(4), graph.edges[0].end());
+  EXPECT_NE(graph.edges[0][4].find(expected_syll_id), graph.edges[0][4].end());
+}
+
+// 測試 3: 連續多音節串流切分 (FZURO'SA 與無分隔符 FZUROSA)
+TEST_F(CanonicalizeSyllabifierTest, MultiSyllableStreaming) {
+  Syllabifier syllabifier("'", false, false, canonicalizer_.get());
+
+  int id_zfuro = -1;
+  int id_sa = -1;
+  ASSERT_TRUE(loaded_prism_->GetValue("ZFURO", &id_zfuro));
+  ASSERT_TRUE(loaded_prism_->GetValue("SA", &id_sa));
+
+  // 情況 A: 帶隔音符號 FZURO'SA
+  {
+    SyllableGraph graph;
+    int farthest =
+        syllabifier.BuildSyllableGraph("FZURO'SA", *loaded_prism_, &graph);
+    EXPECT_EQ(8, farthest);
+
+    // 第一音節: 匹配長度 5 + 吞入 1 位分隔符 '\'' -> 終點爲 6，即邊 [0, 6)
+    ASSERT_NE(graph.edges[0].find(6), graph.edges[0].end());
+    EXPECT_NE(graph.edges[0][6].find(id_zfuro), graph.edges[0][6].end());
+
+    // 第二音節: 承接頂點 6，終點爲 8，即邊 [6, 8)
+    ASSERT_NE(graph.edges.find(6), graph.edges.end());
+    ASSERT_NE(graph.edges[6].find(8), graph.edges[6].end());
+    EXPECT_NE(graph.edges[6][8].find(id_sa), graph.edges[6][8].end());
+  }
+
+  // 情況 B: 無隔音符號連續連打 FZUROSA
+  {
+    SyllableGraph graph;
+    int farthest =
+        syllabifier.BuildSyllableGraph("FZUROSA", *loaded_prism_, &graph);
+    EXPECT_EQ(7, farthest);
+
+    // 第一音節邊: [0, 5)
+    ASSERT_NE(graph.edges[0].find(5), graph.edges[0].end());
+    EXPECT_NE(graph.edges[0][5].find(id_zfuro), graph.edges[0][5].end());
+
+    // 第二音節邊: [5, 7)
+    ASSERT_NE(graph.edges.find(5), graph.edges.end());
+    ASSERT_NE(graph.edges[5].find(7), graph.edges[5].end());
+    EXPECT_NE(graph.edges[5][7].find(id_sa), graph.edges[5][7].end());
+  }
+}
+
+// 測試 4: 回退保證 (當 canonicalizer 爲 nullptr 時恢復原生前綴匹配)
+TEST_F(CanonicalizeSyllabifierTest, NullCanonicalizerFallback) {
+  // 不傳入 canonicalizer_，此時應走原生 CommonPrefixSearch
+  Syllabifier syllabifier("'", false, false, nullptr);
+  SyllableGraph graph;
+
+  // 1. 輸入標準順序 ZFURO -> 必須成功
+  int farthest_ordered =
+      syllabifier.BuildSyllableGraph("ZFURO", *loaded_prism_, &graph);
+  EXPECT_EQ(5, farthest_ordered);
+
+  // 2. 輸入亂序 FZURO -> 未開重排時必須無法切分（或者長度無法推進到 5）
+  SyllableGraph graph_disordered;
+  int farthest_disordered = syllabifier.BuildSyllableGraph(
+      "FZURO", *loaded_prism_, &graph_disordered);
+  EXPECT_NE(5, farthest_disordered);
 }


### PR DESCRIPTION
#### 背景與動機 (Motivation)

在並擊（Chording）或琶音（Arpeggio）輸入方案中，手指微觀落鍵時差（如強指領先、右手拇指搶先觸底）常導致輸入緩衝區內的編碼順序與標準音節碼不一致。

過去若依賴 `speller/algebra` 的 `derive` 規則在編譯期窮舉錯序，會遇到以下瓶頸：

1. **規則與空間爆炸**：多鍵並擊與雙手交錯排列組合過多（4～5 鍵音節全排列達數十至上百種），難以全面覆蓋且顯著膨脹詞典與音節圖。
2. **缺乏動態適應性**：無法宣告式地統一依鍵序重排。

本 PR 在 `Syllabifier` 切分查詢時引入 `canonicalize` 規則投影，動態將切分出的子串片段按規範鍵序重排後再查詢 Prism。

---

#### 機制與配置 (Configuration)

在方案中配置 `translator/canonicalize`（配合 `reorder` 算子）：

```yaml
speller:
  algebra:
    - xform ch CL
    - xform zh ZF
    - xform an AN
    - xform uan UAN
    - xform ong URO
    - xform ou RO

translator:
  canonicalize:
    - reorder SCZHLFGDBKTPIUÜANREO

```

拼寫運算生成之標準 Prism 映射：

* 詞典編碼：`chan` $\to$ 並擊碼：`CLAN`
* 詞典編碼：`chuan` $\to$ 並擊碼：`CLUAN`
* 詞典編碼：`zhou` $\to$ 並擊碼：`ZFRO`
* 詞典編碼：`zhong` $\to$ 並擊碼：`ZFURO`

---

#### 運作示例 (Example: 宮保拼音)

使用者快速連續落鍵（無自動插入隔音符號）：
`input: FZORUCNAL`

切分算法依碼長步進截取子串，經由 `canonicalizer` 規範化後查詢 Prism，自動在 `SyllableGraph` 上展開多路徑切分：

1. **路徑 A**：
* 截取 `FZORU` $\xrightarrow{\text{reorder}}$ `ZFURO`（命中 `zhong`，長度 5）
* 截取 `CNAL` $\xrightarrow{\text{reorder}}$ `CLAN`（命中 `chan`，長度 4）
* 形成路徑：`[zhong chan]`


2. **路徑 B**：
* 截取 `FZOR` $\xrightarrow{\text{reorder}}$ `ZFRO`（命中 `zhou`，長度 4）
* 截取 `UCNAL` $\xrightarrow{\text{reorder}}$ `CLUAN`（命中 `chuan`，長度 5）
* 形成路徑：`[zhou chuan]`

其餘無效切分（如 `F ZURO CAN L` 等）因無法成詞或權重劣後而被圖剪枝，最終由語言模型裁決最優候選。

---

#### 效能與向下相容性 (Performance & Compatibility)

1. **無前綴單調性下的步進精準匹配**：
重排打破了前綴樹下行的單調性，故在啓用 `canonicalizer_` 時改採「長度步進截取 + `prism.GetValue()`」精準匹配；步進上限由 `std::min(input.length(), prism.max_key_length())` 嚴格約束，避免無界空轉。
2. **零開銷向下相容**：
未配置 `canonicalize` 的傳統拼音/形碼方案，`canonicalizer_` 為 `nullptr`，流程嚴格保持原有的 `prism.CommonPrefixSearch()`，效能與行爲零迴退。