### PR TITLE
feat(switches): 支持仅首次生效的默认状态

### DIFF
--- a/src/rime/engine.cc
+++ b/src/rime/engine.cc
@@ -380,7 +380,8 @@ void ConcreteEngine::InitializeOptions() {
   Switches switches(config);
   switches.FindOption([this](Switches::SwitchOption option) {
     LOG(INFO) << "found switch option: " << option.option_name
-              << ", reset: " << option.reset_value;
+              << ", reset: " << option.reset_value
+              << ", default: " << option.default_value;
     if (option.reset_value >= 0) {
       if (option.type == Switches::kToggleOption) {
         context_->set_option(option.option_name, (option.reset_value != 0));
@@ -388,6 +389,16 @@ void ConcreteEngine::InitializeOptions() {
         context_->set_option(
             option.option_name,
             static_cast<int>(option.option_index) == option.reset_value);
+      }
+    } else if (option.default_value >= 0 &&
+               context_->options().find(option.option_name) ==
+                   context_->options().end()) {
+      if (option.type == Switches::kToggleOption) {
+        context_->set_option(option.option_name, (option.default_value != 0));
+      } else if (option.type == Switches::kRadioGroup) {
+        context_->set_option(
+            option.option_name,
+            static_cast<int>(option.option_index) == option.default_value);
       }
     }
     return Switches::kContinue;

--- a/src/rime/switches.cc
+++ b/src/rime/switches.cc
@@ -4,9 +4,9 @@
 
 namespace rime {
 
-inline static int reset_value(ConfigItemRef& item) {
-  auto reset = item["reset"];
-  return reset.IsValue() ? reset.ToInt() : -1;
+inline static int state_value(ConfigItemRef& item, const char* key) {
+  auto value = item[key];
+  return value.IsValue() ? value.ToInt() : -1;
 }
 
 Switches::SwitchOption Switches::FindOptionFromConfigItem(
@@ -18,8 +18,13 @@ Switches::SwitchOption Switches::FindOptionFromConfigItem(
   auto options = item["options"];
   if (name.IsValue()) {
     SwitchOption option{
-        the_switch,        kToggleOption, name.ToString(),
-        reset_value(item), switch_index,
+        the_switch,
+        kToggleOption,
+        name.ToString(),
+        state_value(item, "reset"),
+        switch_index,
+        0,
+        state_value(item, "default"),
     };
     if (callback(option) == kFound)
       return option;
@@ -27,8 +32,13 @@ Switches::SwitchOption Switches::FindOptionFromConfigItem(
     for (size_t option_index = 0; option_index < options.size();
          ++option_index) {
       SwitchOption option{
-          the_switch,        kRadioGroup,  options[option_index].ToString(),
-          reset_value(item), switch_index, option_index,
+          the_switch,
+          kRadioGroup,
+          options[option_index].ToString(),
+          state_value(item, "reset"),
+          switch_index,
+          option_index,
+          state_value(item, "default"),
       };
       if (callback(option) == kFound)
         return option;
@@ -83,6 +93,7 @@ Switches::SwitchOption Switches::Cycle(const SwitchOption& current) {
           current.reset_value,
           current.switch_index,
           next_option_index,
+          current.default_value,
       };
     }
   }
@@ -102,6 +113,7 @@ Switches::SwitchOption Switches::Reset(const SwitchOption& current) {
         current.reset_value,
         current.switch_index,
         default_state,
+        current.default_value,
     };
   }
   return {};
@@ -117,6 +129,7 @@ Switches::SwitchOption Switches::FindRadioGroupOption(
           0,  // unknown
           0,  // unknown
           j,
+          -1,  // unknown
       };
       if (callback(option) == kFound)
         return option;

--- a/src/rime/switches.h
+++ b/src/rime/switches.h
@@ -40,6 +40,8 @@ class Switches {
     size_t switch_index = 0;
     // the index of the option in the radio group.
     size_t option_index = 0;
+    // initial state value when the option is unset. -1 if unspecified.
+    int default_value = -1;
 
     bool found() const { return bool(the_switch); }
   };

--- a/test/switches_test.cc
+++ b/test/switches_test.cc
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+#include <rime/config.h>
+#include <rime/context.h>
+#include <rime/engine.h>
+#include <rime/schema.h>
+
+using namespace rime;
+
+TEST(SwitchDefaultTest, AppliesDefaultWhenOptionIsUnset) {
+  the<Engine> engine(Engine::Create());
+
+  auto config = new Config;
+  (*config)["switches"][0]["name"] = "default_on";
+  (*config)["switches"][0]["default"] = 1;
+  auto schema = new Schema;
+  schema->set_config(config);
+
+  engine->ApplySchema(schema);
+
+  EXPECT_TRUE(engine->context()->get_option("default_on"));
+}
+
+TEST(SwitchDefaultTest, PreservesExistingOption) {
+  the<Engine> engine(Engine::Create());
+  engine->context()->set_option("saved_off", false);
+
+  auto config = new Config;
+  (*config)["switches"][0]["name"] = "saved_off";
+  (*config)["switches"][0]["default"] = 1;
+  auto schema = new Schema;
+  schema->set_config(config);
+
+  engine->ApplySchema(schema);
+
+  EXPECT_FALSE(engine->context()->get_option("saved_off"));
+}
+
+TEST(SwitchDefaultTest, ResetTakesPrecedenceOverDefault) {
+  the<Engine> engine(Engine::Create());
+  engine->context()->set_option("reset_on", false);
+
+  auto config = new Config;
+  (*config)["switches"][0]["name"] = "reset_on";
+  (*config)["switches"][0]["default"] = 0;
+  (*config)["switches"][0]["reset"] = 1;
+  auto schema = new Schema;
+  schema->set_config(config);
+
+  engine->ApplySchema(schema);
+
+  EXPECT_TRUE(engine->context()->get_option("reset_on"));
+}


### PR DESCRIPTION
为 switches 配置解析新增 default 状态，并在选项尚未进入当前 Context 时应用；已恢复的开启或关闭状态都会保持不变。

保留 reset 每次初始化强制覆盖的原有优先级，并将新字段追加到 SwitchOption 末尾以兼容既有聚合初始化调用。

新增开关行为测试，覆盖首次默认值、已存在关闭状态以及 reset 优先级。

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

#### Unit test
- [ ] Done

#### Manual test
- [ ] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
