### PR TITLE
ci: upgrade github action to fix node20 deprecation

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout last commit
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Install clang-format
         run: |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,6 +9,6 @@ jobs:
       fail-fast: false
     steps:
     - name: Checkout last commit
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
     - name: Build with plugins
       run: docker build -t librime .

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -25,7 +25,7 @@ jobs:
     
     steps:
       - name: Checkout last commit
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.repository }}
 

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -28,7 +28,7 @@ jobs:
       RIME_PLUGINS: ${{ inputs.rime_plugins }}
     steps:
       - name: Checkout last commit
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.repository }}
           submodules: recursive
@@ -52,7 +52,7 @@ jobs:
 
       - name: Cache dependencies
         id: cache-deps
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             bin
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload artifacts
         if: matrix.create-distributable
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifact-${{ runner.os }}-${{ matrix.build_variant || runner.arch }}
           path: |

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           path: artifact
           merge-multiple: true

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout last commit
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.repository }}
           submodules: recursive
@@ -70,7 +70,7 @@ jobs:
 
       - name: Cache dependencies
         id: cache-deps
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             bin
@@ -97,7 +97,7 @@ jobs:
           bin include lib share
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifact-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.arch }}
           path: |
@@ -136,7 +136,7 @@ jobs:
 
       - run: git config --global core.autocrlf input
       - name: Checkout last commit
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.repository }}
             
@@ -173,7 +173,7 @@ jobs:
           bin include lib share
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifact-${{ runner.os }}-mingw
           path: |


### PR DESCRIPTION

## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

Currently there are lots of warnings in the CI, and **it will stop to work with node20 removal at Sep 23rd, 2026.**

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

> Editor’s note (August 25, 2026): Updated the Node20 removal date to September 23rd, 2026.


PS: There still has warning with the https://github.com/ilammy/msvc-dev-cmd/issues/99, I working on it.

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
