### PR TITLE
Clean up the CI warnings and refactor release workflow

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -15,11 +15,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [macos-15-intel, macos-15]
+        runs-on: [macos-26-intel, macos-26]
         include:
-          - runs-on: macos-15-intel
+          - runs-on: macos-26-intel
             create-distributable: false
-          - runs-on: macos-15
+          - runs-on: macos-26
             create-distributable: true
             build_variant: universal
     env:

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -32,24 +32,41 @@ jobs:
           path: artifact
           merge-multiple: true
 
+      - name: Checkout last commit
+        if: github.ref_type == 'tag'
+        uses: actions/checkout@v7
+
+      - name: Build changelog
+        if: github.ref_type == 'tag'
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v6
+        with:
+          commitMode: true
+          configurationJson: |
+            {
+              "template": "Change log from #{{FROM_TAG}} to #{{TO_TAG}}: #{{RELEASE_DIFF}}\n#{{UNCATEGORIZED}}",
+              "pr_template": "- [#{{MERGE_SHA}}] - #{{TITLE}}"
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create Nightly release
         if: ${{ github.repository == 'rime/librime' && github.ref == 'refs/heads/master' }}
-        uses: 'marvinpinto/action-automatic-releases@latest'
+        uses: softprops/action-gh-release@v3
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          automatic_release_tag: latest
+          name: "Nightly Build"
+          tag_name: latest
           prerelease: true
-          title: "Nightly Build"
           files: |
             artifact/*
 
       - name: Create Stable release
-        if: ${{ github.ref != 'refs/heads/master' }}
-        uses: 'marvinpinto/action-automatic-releases@latest'
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v3
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           draft: true
+          name: librime ${{ github.ref_name }}
           prerelease: ${{ contains(github.ref_name, '-') }}
-          title: librime ${{ github.ref_name }}
+          body: ${{ steps.build_changelog.outputs.changelog }}
           files: |
             artifact/*

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -48,7 +48,7 @@ jobs:
           
       - name: Configure MSVC
         if: ${{ matrix.compiler == 'msvc' }}
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: TheMrMilchmann/setup-msvc-dev@v4
         with:
           arch: ${{ matrix.cross_arch || matrix.arch }}
 


### PR DESCRIPTION
## Pull request

#### Issue tracker
Fixes will automatically close the related issue

Fixes #

#### Feature
Describe feature of pull request

**All warnings were cleared with this pull request.**

Currently, the https://github.com/marvinpinto/action-automatic-releases
is archived, and it uses node20 and obsoleted `set-output` command.[1]

1. https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Preview of nightly build: https://github.com/Bambooin/librime/releases

The changelog format is changed in this pull request, sample of the new format: https://github.com/osfans/trime/releases/tag/v3.3.12

#### Unit test
- [x] Done

#### Manual test
- [x] Done

#### Code Review
1. Unit and manual test pass
2. GitHub Action CI pass
3. At least one contributor reviews and votes
4. Can be merged clean without conflicts
5. PR will be merged by rebase upstream base

#### Additional Info
