### PR TITLE
fix: support building against glog < 0.6

### DIFF
--- a/src/rime/setup.cc
+++ b/src/rime/setup.cc
@@ -9,6 +9,9 @@
 
 #ifdef RIME_ENABLE_LOGGING
 #include <glog/logging.h>
+#if __has_include(<glog/version.h>)
+#include <glog/version.h>
+#endif
 #else
 #include "no_logging.h"
 #endif  // RIME_ENABLE_LOGGING
@@ -102,11 +105,18 @@ RIME_DLL void SetupLogging(const char* app_name,
   // Do not allow other users to read/write log files created by current
   // process.
   FLAGS_logfile_mode = 0600;
+#if defined(GLOG_VERSION_MAJOR) && defined(GLOG_VERSION_MINOR) && \
+    (GLOG_VERSION_MAJOR > 0 || GLOG_VERSION_MINOR >= 6)
   if (google::IsGoogleLoggingInitialized()) {
     LOG(WARNING) << "Glog is already initialized.";
   } else {
     google::InitGoogleLogging(app_name);
   }
+#else
+  // glog < 0.6 (e.g. Ubuntu 22.04) lacks google::IsGoogleLoggingInitialized();
+  // re-initializing was harmless there before the guard was introduced.
+  google::InitGoogleLogging(app_name);
+#endif
 #endif  // RIME_ENABLE_LOGGING
 }
 


### PR DESCRIPTION
## 问题

`src/rime/setup.cc` 使用了 `google::IsGoogleLoggingInitialized()`，该 API 在 glog **0.6** 才引入。在 glog < 0.6 的系统上编译 master 会直接报错，例如 Ubuntu 22.04（包版本 `0.5.0+really0.4.0`，实际为 0.4）：

```
src/rime/setup.cc:105:15: error: 'IsGoogleLoggingInitialized' is not a member of 'google'
```

## 修复

用 `__has_include(<glog/version.h>)` + `GLOG_VERSION_MAJOR/MINOR` 检测：glog ≥ 0.6 时保留原有守卫逻辑；老版本则直接调用 `InitGoogleLogging`（该守卫引入之前 librime 一直如此，老 glog 上重复初始化无害）。

## 验证

Ubuntu 22.04.5（glog 0.4.0、GCC 11.4）以 `BUILD_MERGED_PLUGINS=ON` 编译通过；产物已通过 fcitx5-rime 实际加载运行（含 librime-lua，日志功能正常）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)