### PR TITLE
fix: use portable Linux platform check for CMake < 3.25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,9 @@ if(MSVC)
   set(Boost_USE_STATIC_RUNTIME ON)
 endif()
 
-if(LINUX)
+# `LINUX` is only defined by CMake >= 3.25; use the portable check so
+# older CMake (e.g. Ubuntu 22.04) takes the regex-component branch.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   find_package(Boost 1.74.0 REQUIRED COMPONENTS regex)
 else()
   find_package(Boost 1.77.0)


### PR DESCRIPTION
## 问题

`CMakeLists.txt` 用 `if(LINUX)` 判断平台，但 `LINUX` 变量是 **CMake 3.25** 才引入的。在更老的 CMake（如 Ubuntu 22.04 自带的 3.22）上该判断恒为假，走入 `else()` 分支执行 `find_package(Boost 1.77.0)`（非 REQUIRED、纯头文件模式）：

- 在 Boost 1.74 的系统上查找失败但**不产生任何报错**；
- `Boost_LIBRARIES` 为空，`librime.so` 不会被链接 `libboost_regex`；
- 编译可以通过（头文件恰好在默认搜索路径），但链接 `rime_deployer` 等工具时报大量 `undefined reference to boost::re_detail_107400::*`，且 `.so` 运行时同样无法解析符号。

## 修复

改用所有 CMake 版本都支持的 `CMAKE_SYSTEM_NAME STREQUAL "Linux"`，使老 CMake 正确进入 `find_package(Boost 1.74.0 REQUIRED COMPONENTS regex)` 分支。

## 验证

Ubuntu 22.04.5（CMake 3.22.1 / Boost 1.74 / GCC 11.4）：

- 配置阶段正确输出 `Found Boost: ... found components: regex`；
- `librime.so` 的 DT_NEEDED 包含 `libboost_regex.so.1.74.0`，全部工具程序链接成功；
- 已实际部署运行（fcitx5-rime 加载、Rime 正常输入）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)